### PR TITLE
Flatten component layers in UI styles

### DIFF
--- a/packages/ui/src/styles/components/button.css
+++ b/packages/ui/src/styles/components/button.css
@@ -1,141 +1,139 @@
-@layer components {
-  .btn {
-    --_btn-bg: transparent;
-    --_btn-hover-bg: var(--_btn-bg);
-    --_btn-color: var(--color-text);
-    --_btn-hover-color: var(--_btn-color);
-    --_btn-border: transparent;
-    --_btn-hover-border: var(--_btn-border);
-    --_btn-radius: 0.5rem;
-    --_btn-padding-y: 0.5rem;
-    --_btn-padding-x: 1rem;
-    --_btn-gap: 0.25rem;
-    --_btn-width: auto;
-    --_btn-justify: center;
+.btn {
+  --_btn-bg: transparent;
+  --_btn-hover-bg: var(--_btn-bg);
+  --_btn-color: var(--color-text);
+  --_btn-hover-color: var(--_btn-color);
+  --_btn-border: transparent;
+  --_btn-hover-border: var(--_btn-border);
+  --_btn-radius: 0.5rem;
+  --_btn-padding-y: 0.5rem;
+  --_btn-padding-x: 1rem;
+  --_btn-gap: 0.25rem;
+  --_btn-width: auto;
+  --_btn-justify: center;
 
-    display: inline-flex;
-    align-items: center;
-    justify-content: var(--_btn-justify);
-    width: var(--_btn-width);
-    gap: var(--_btn-gap);
-    padding-block: var(--_btn-padding-y);
-    padding-inline: var(--_btn-padding-x);
-    border-radius: var(--_btn-radius);
-    border: 1px solid var(--_btn-border);
-    background-color: var(--_btn-bg);
-    color: var(--_btn-color);
-    font-size: 0.875rem;
-    font-weight: 500;
-    line-height: 1.25rem;
-    transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease,
-      box-shadow 150ms ease, transform 150ms ease;
-    cursor: pointer;
-  }
+  display: inline-flex;
+  align-items: center;
+  justify-content: var(--_btn-justify);
+  width: var(--_btn-width);
+  gap: var(--_btn-gap);
+  padding-block: var(--_btn-padding-y);
+  padding-inline: var(--_btn-padding-x);
+  border-radius: var(--_btn-radius);
+  border: 1px solid var(--_btn-border);
+  background-color: var(--_btn-bg);
+  color: var(--_btn-color);
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease,
+    box-shadow 150ms ease, transform 150ms ease;
+  cursor: pointer;
+}
 
-  .btn:hover {
-    background-color: var(--_btn-hover-bg);
-    color: var(--_btn-hover-color);
-    border-color: var(--_btn-hover-border);
-  }
+.btn:hover {
+  background-color: var(--_btn-hover-bg);
+  color: var(--_btn-hover-color);
+  border-color: var(--_btn-hover-border);
+}
 
-  .btn:focus-visible {
-    outline: none;
-    box-shadow: var(--_btn-focus-ring, 0 0 0 3px var(--btn-default-ring, transparent));
-  }
+.btn:focus-visible {
+  outline: none;
+  box-shadow: var(--_btn-focus-ring, 0 0 0 3px var(--btn-default-ring, transparent));
+}
 
-  .btn:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 
-  .btn-default {
-    --_btn-bg: var(--btn-default-bg);
-    --_btn-hover-bg: var(--btn-default-bg-hover);
-    --_btn-color: var(--btn-default-fg);
-    --_btn-focus-ring: 0 0 0 3px var(--btn-default-ring);
-  }
+.btn-default {
+  --_btn-bg: var(--btn-default-bg);
+  --_btn-hover-bg: var(--btn-default-bg-hover);
+  --_btn-color: var(--btn-default-fg);
+  --_btn-focus-ring: 0 0 0 3px var(--btn-default-ring);
+}
 
-  .btn-titlebar {
-    --_btn-bg: var(--btn-titlebar-bg);
-    --_btn-hover-bg: var(--btn-titlebar-bg-hover);
-    --_btn-color: var(--btn-titlebar-fg);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-    --_btn-radius: 0;
-    --_btn-justify: flex-end;
-    --_btn-width: 100%;
-  }
+.btn-titlebar {
+  --_btn-bg: var(--btn-titlebar-bg);
+  --_btn-hover-bg: var(--btn-titlebar-bg-hover);
+  --_btn-color: var(--btn-titlebar-fg);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+  --_btn-radius: 0;
+  --_btn-justify: flex-end;
+  --_btn-width: 100%;
+}
 
-  .btn-list {
-    --_btn-bg: var(--btn-list-bg);
-    --_btn-hover-bg: var(--btn-list-bg-hover);
-    --_btn-color: var(--btn-list-fg);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-    --_btn-radius: 0;
-    --_btn-justify: flex-start;
-    --_btn-width: 100%;
+.btn-list {
+  --_btn-bg: var(--btn-list-bg);
+  --_btn-hover-bg: var(--btn-list-bg-hover);
+  --_btn-color: var(--btn-list-fg);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+  --_btn-radius: 0;
+  --_btn-justify: flex-start;
+  --_btn-width: 100%;
 
-    white-space: pre-wrap;
-    text-align: left;
-    overflow-wrap: break-word;
-  }
+  white-space: pre-wrap;
+  text-align: left;
+  overflow-wrap: break-word;
+}
 
-  .btn-icon {
-    --_btn-bg: transparent;
-    --_btn-hover-bg: transparent;
-    --_btn-color: var(--btn-icon-color);
-    --_btn-hover-color: var(--btn-icon-hover-color);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-    --_btn-padding-y: 0.5rem;
-    --_btn-padding-x: 0.5rem;
-    --_btn-radius: 0.5rem;
+.btn-icon {
+  --_btn-bg: transparent;
+  --_btn-hover-bg: transparent;
+  --_btn-color: var(--btn-icon-color);
+  --_btn-hover-color: var(--btn-icon-hover-color);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+  --_btn-padding-y: 0.5rem;
+  --_btn-padding-x: 0.5rem;
+  --_btn-radius: 0.5rem;
 
-    aspect-ratio: 1 / 1;
-  }
+  aspect-ratio: 1 / 1;
+}
 
-  .btn-icon.selected {
-    color: var(--btn-icon-hover-color);
-  }
+.btn-icon.selected {
+  color: var(--btn-icon-hover-color);
+}
 
-  .btn-card {
-    --_btn-bg: var(--btn-card-bg);
-    --_btn-hover-bg: var(--btn-card-bg-hover);
-    --_btn-color: var(--btn-card-fg);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-  }
+.btn-card {
+  --_btn-bg: var(--btn-card-bg);
+  --_btn-hover-bg: var(--btn-card-bg-hover);
+  --_btn-color: var(--btn-card-fg);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+}
 
-  .btn-primary {
-    --_btn-bg: var(--color-brand);
-    --_btn-hover-bg: var(--color-brand-hover);
-    --_btn-color: var(--color-text-inverse);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-    --_btn-focus-ring: 0 0 0 3px var(--btn-default-ring);
-  }
+.btn-primary {
+  --_btn-bg: var(--color-brand);
+  --_btn-hover-bg: var(--color-brand-hover);
+  --_btn-color: var(--color-text-inverse);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+  --_btn-focus-ring: 0 0 0 3px var(--btn-default-ring);
+}
 
-  .btn-secondary {
-    --_btn-bg: transparent;
-    --_btn-hover-bg: var(--color-surface-hover);
-    --_btn-color: var(--color-text);
-    --_btn-border: var(--color-border);
-    --_btn-hover-border: var(--color-border-hover);
-  }
+.btn-secondary {
+  --_btn-bg: transparent;
+  --_btn-hover-bg: var(--color-surface-hover);
+  --_btn-color: var(--color-text);
+  --_btn-border: var(--color-border);
+  --_btn-hover-border: var(--color-border-hover);
+}
 
-  .btn-panel-tab {
-    --_btn-bg: var(--btn-panel-tab-bg);
-    --_btn-hover-bg: var(--btn-panel-tab-bg-hover);
-    --_btn-color: var(--btn-panel-tab-fg);
-    --_btn-border: transparent;
-    --_btn-hover-border: transparent;
-    --_btn-padding-y: 0.625rem;
-    --_btn-padding-x: 1.25rem;
-    --_btn-radius: 0.625rem;
-  }
+.btn-panel-tab {
+  --_btn-bg: var(--btn-panel-tab-bg);
+  --_btn-hover-bg: var(--btn-panel-tab-bg-hover);
+  --_btn-color: var(--btn-panel-tab-fg);
+  --_btn-border: transparent;
+  --_btn-hover-border: transparent;
+  --_btn-padding-y: 0.625rem;
+  --_btn-padding-x: 1.25rem;
+  --_btn-radius: 0.625rem;
+}
 
-  .btn-panel-tab.selected {
-    --_btn-bg: var(--btn-panel-tab-bg-selected);
-  }
+.btn-panel-tab.selected {
+  --_btn-bg: var(--btn-panel-tab-bg-selected);
 }

--- a/packages/ui/src/styles/components/filetree.css
+++ b/packages/ui/src/styles/components/filetree.css
@@ -1,125 +1,123 @@
-@layer components {
-  :root {
-    --tree-font: ui-sans-serif, -apple-system, Segoe UI, Roboto, Helvetica, Arial,
-      'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
-    --tree-icon-size: 16px;
-    --tree-toggle-size: 20px;
-    --tree-row-vpad: 6px;
-    --tree-row-hpad: 8px;
-    --tree-depth-unit: 16px;
-    --tree-muted: var(--color-text-soft);
-    --tree-row-hover-bg: color-mix(in srgb, var(--ds-main-hover) 65%, transparent);
-    --tree-row-selected-bg: color-mix(in srgb, var(--ds-accent) 18%, transparent);
-    --tree-row-selected-border: color-mix(in srgb, var(--ds-accent) 35%, transparent);
-    --tree-row-highlight-bg: color-mix(in srgb, var(--ds-accent) 12%, transparent);
-    --tree-row-dragging-bg: color-mix(in srgb, var(--ds-main-hover) 50%, transparent);
-  }
+:root {
+  --tree-font: ui-sans-serif, -apple-system, Segoe UI, Roboto, Helvetica, Arial,
+    'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
+  --tree-icon-size: 16px;
+  --tree-toggle-size: 20px;
+  --tree-row-vpad: 6px;
+  --tree-row-hpad: 8px;
+  --tree-depth-unit: 16px;
+  --tree-muted: var(--color-text-soft);
+  --tree-row-hover-bg: color-mix(in srgb, var(--ds-main-hover) 65%, transparent);
+  --tree-row-selected-bg: color-mix(in srgb, var(--ds-accent) 18%, transparent);
+  --tree-row-selected-border: color-mix(in srgb, var(--ds-accent) 35%, transparent);
+  --tree-row-highlight-bg: color-mix(in srgb, var(--ds-accent) 12%, transparent);
+  --tree-row-dragging-bg: color-mix(in srgb, var(--ds-main-hover) 50%, transparent);
+}
 
-  [data-theme='dark'] {
-    --tree-row-hover-bg: color-mix(in srgb, var(--ds-main-hover) 40%, transparent);
-    --tree-row-selected-bg: color-mix(in srgb, var(--ds-accent) 26%, transparent);
-    --tree-row-selected-border: color-mix(in srgb, var(--ds-accent) 40%, transparent);
-    --tree-row-highlight-bg: color-mix(in srgb, var(--ds-accent) 18%, transparent);
-    --tree-row-dragging-bg: color-mix(in srgb, var(--ds-main-hover) 30%, transparent);
-  }
+[data-theme='dark'] {
+  --tree-row-hover-bg: color-mix(in srgb, var(--ds-main-hover) 40%, transparent);
+  --tree-row-selected-bg: color-mix(in srgb, var(--ds-accent) 26%, transparent);
+  --tree-row-selected-border: color-mix(in srgb, var(--ds-accent) 40%, transparent);
+  --tree-row-highlight-bg: color-mix(in srgb, var(--ds-accent) 18%, transparent);
+  --tree-row-dragging-bg: color-mix(in srgb, var(--ds-main-hover) 30%, transparent);
+}
 
-  .tree {
-    margin: 0;
-    padding: 6px;
-    background-color: transparent;
-    font-family: var(--tree-font);
-  }
+.tree {
+  margin: 0;
+  padding: 6px;
+  background-color: transparent;
+  font-family: var(--tree-font);
+}
 
-  .tree-node {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+.tree-node {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 
-  .tree-node + .tree-node {
-    margin-top: 2px;
-  }
+.tree-node + .tree-node {
+  margin-top: 2px;
+}
 
-  .tree-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: var(--tree-row-vpad) var(--tree-row-hpad);
-    background-color: transparent;
-    user-select: none;
-    cursor: default;
-    border-radius: 0.5rem;
-    transition: background-color 120ms ease, color 120ms ease;
-  }
+.tree-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: var(--tree-row-vpad) var(--tree-row-hpad);
+  background-color: transparent;
+  user-select: none;
+  cursor: default;
+  border-radius: 0.5rem;
+  transition: background-color 120ms ease, color 120ms ease;
+}
 
-  .tree-row:hover {
-    background-color: var(--tree-row-hover-bg);
-    cursor: pointer;
-  }
+.tree-row:hover {
+  background-color: var(--tree-row-hover-bg);
+  cursor: pointer;
+}
 
-  .tree-row.is-selected {
-    background-color: var(--tree-row-selected-bg);
-    box-shadow: inset 0 0 0 1px var(--tree-row-selected-border);
-  }
+.tree-row.is-selected {
+  background-color: var(--tree-row-selected-bg);
+  box-shadow: inset 0 0 0 1px var(--tree-row-selected-border);
+}
 
-  .tree-row.is-highlighted {
-    background-color: var(--tree-row-highlight-bg);
-  }
+.tree-row.is-highlighted {
+  background-color: var(--tree-row-highlight-bg);
+}
 
-  .tree-row.is-dragging {
-    background-color: var(--tree-row-dragging-bg);
-    cursor: grabbing;
-  }
+.tree-row.is-dragging {
+  background-color: var(--tree-row-dragging-bg);
+  cursor: grabbing;
+}
 
-  .tree-row .toggle {
-    width: var(--tree-toggle-size);
-    height: var(--tree-toggle-size);
-    display: grid;
-    place-items: center;
-    border: none;
-    background: transparent;
-    padding: 0;
-    color: inherit;
-  }
+.tree-row .toggle {
+  width: var(--tree-toggle-size);
+  height: var(--tree-toggle-size);
+  display: grid;
+  place-items: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
 
-  .tree-row .indent {
-    min-width: calc(var(--depth, 0) * var(--tree-depth-unit) + var(--tree-row-hpad));
-  }
+.tree-row .indent {
+  min-width: calc(var(--depth, 0) * var(--tree-depth-unit) + var(--tree-row-hpad));
+}
 
-  .tree-row .spacer {
-    min-width: var(--tree-toggle-size);
-    min-height: var(--tree-toggle-size);
-    display: inline-block;
-  }
+.tree-row .spacer {
+  min-width: var(--tree-toggle-size);
+  min-height: var(--tree-toggle-size);
+  display: inline-block;
+}
 
-  .tree-row .icon {
-    width: var(--tree-icon-size);
-    height: var(--tree-icon-size);
-    flex: 0 0 auto;
-  }
+.tree-row .icon {
+  width: var(--tree-icon-size);
+  height: var(--tree-icon-size);
+  flex: 0 0 auto;
+}
 
-  .tree-row .name {
-    flex: 1 1 auto;
-    min-width: 0;
-    font-size: 0.875rem;
-    font-weight: 500;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: inherit;
-  }
+.tree-row .name {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: inherit;
+}
 
-  .tree-row .more {
-    border: none;
-    background: transparent;
-    padding: 0;
-    opacity: 0;
-    transition: opacity 140ms ease;
-    color: var(--tree-muted);
-  }
+.tree-row .more {
+  border: none;
+  background: transparent;
+  padding: 0;
+  opacity: 0;
+  transition: opacity 140ms ease;
+  color: var(--tree-muted);
+}
 
-  .tree-row:hover .more {
-    opacity: 1;
-  }
+.tree-row:hover .more {
+  opacity: 1;
 }

--- a/packages/ui/src/styles/components/input.css
+++ b/packages/ui/src/styles/components/input.css
@@ -1,116 +1,114 @@
-@layer components {
-  .input {
-    --_input-bg: var(--input-default-bg, var(--color-surface));
-    --_input-color: var(--color-text);
-    --_input-border: var(--input-border, transparent);
-    --_input-radius: 0.5rem;
-    --_input-padding-y: 0.5rem;
-    --_input-padding-x: 0.75rem;
+.input {
+  --_input-bg: var(--input-default-bg, var(--color-surface));
+  --_input-color: var(--color-text);
+  --_input-border: var(--input-border, transparent);
+  --_input-radius: 0.5rem;
+  --_input-padding-y: 0.5rem;
+  --_input-padding-x: 0.75rem;
 
-    display: block;
-    width: 100%;
-    padding-block: var(--_input-padding-y);
-    padding-inline: var(--_input-padding-x);
-    border-radius: var(--_input-radius);
-    border: 1px solid var(--_input-border);
-    background-color: var(--_input-bg);
-    color: var(--_input-color);
-    font-size: 0.875rem;
-    font-weight: 400;
-    line-height: 1.25rem;
-    transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
-    outline: none;
-    appearance: none;
-  }
+  display: block;
+  width: 100%;
+  padding-block: var(--_input-padding-y);
+  padding-inline: var(--_input-padding-x);
+  border-radius: var(--_input-radius);
+  border: 1px solid var(--_input-border);
+  background-color: var(--_input-bg);
+  color: var(--_input-color);
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  transition: background-color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+  outline: none;
+  appearance: none;
+}
 
-  .input::placeholder {
-    color: var(--input-placeholder, var(--color-text-placeholder));
-    opacity: 0.7;
-  }
+.input::placeholder {
+  color: var(--input-placeholder, var(--color-text-placeholder));
+  opacity: 0.7;
+}
 
-  .input:focus-visible {
-    border-color: var(--input-focus-border, rgba(0, 0, 0, 0.2));
-    box-shadow: 0 0 0 3px var(--input-focus-ring, rgba(0, 0, 0, 0.08));
-  }
+.input:focus-visible {
+  border-color: var(--input-focus-border, rgba(0, 0, 0, 0.2));
+  box-shadow: 0 0 0 3px var(--input-focus-ring, rgba(0, 0, 0, 0.08));
+}
 
-  .input:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
+.input:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
 
-  .input:is(:invalid) {
-    border-color: var(--input-invalid-border, #e5484d);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--input-invalid-border, #e5484d) 20%, transparent);
-  }
+.input:is(:invalid) {
+  border-color: var(--input-invalid-border, #e5484d);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--input-invalid-border, #e5484d) 20%, transparent);
+}
 
-  .input-default {
-    --_input-bg: var(--input-default-bg, var(--ds-input-bg));
-    --_input-border: var(--input-border, var(--ds-input-border));
-  }
+.input-default {
+  --_input-bg: var(--input-default-bg, var(--ds-input-bg));
+  --_input-border: var(--input-border, var(--ds-input-border));
+}
 
-  .input-titlebar {
-    --_input-bg: var(--input-titlebar-bg, var(--btn-titlebar-bg));
-    --_input-border: transparent;
-    --_input-radius: 0;
-  }
+.input-titlebar {
+  --_input-bg: var(--input-titlebar-bg, var(--btn-titlebar-bg));
+  --_input-border: transparent;
+  --_input-radius: 0;
+}
 
-  .input-titlebar:hover {
-    background-color: var(--input-titlebar-bg-hover, var(--btn-titlebar-bg-hover));
-  }
+.input-titlebar:hover {
+  background-color: var(--input-titlebar-bg-hover, var(--btn-titlebar-bg-hover));
+}
 
-  .input-list {
-    --_input-bg: var(--input-list-bg, var(--btn-list-bg));
-    --_input-border: transparent;
-    --_input-radius: 0;
-  }
+.input-list {
+  --_input-bg: var(--input-list-bg, var(--btn-list-bg));
+  --_input-border: transparent;
+  --_input-radius: 0;
+}
 
-  .input-list:hover {
-    background-color: var(--input-list-bg-hover, var(--btn-list-bg-hover));
-  }
+.input-list:hover {
+  background-color: var(--input-list-bg-hover, var(--btn-list-bg-hover));
+}
 
-  .input-sm {
-    --_input-padding-y: 0.375rem;
-    --_input-padding-x: 0.625rem;
-    font-size: 0.8125rem;
-    border-radius: 0.375rem;
-  }
+.input-sm {
+  --_input-padding-y: 0.375rem;
+  --_input-padding-x: 0.625rem;
+  font-size: 0.8125rem;
+  border-radius: 0.375rem;
+}
 
-  .input-lg {
-    --_input-padding-y: 0.625rem;
-    --_input-padding-x: 1rem;
-    font-size: 1rem;
-    border-radius: 0.5rem;
-  }
+.input-lg {
+  --_input-padding-y: 0.625rem;
+  --_input-padding-x: 1rem;
+  font-size: 1rem;
+  border-radius: 0.5rem;
+}
 
-  .input-wrap {
-    position: relative;
-    width: 100%;
-  }
+.input-wrap {
+  position: relative;
+  width: 100%;
+}
 
-  .input-icon-start,
-  .input-icon-end {
-    position: absolute;
-    inset-block: 0;
-    display: inline-flex;
-    align-items: center;
-    pointer-events: none;
-    padding-inline: 0.5rem;
-    color: var(--icon-subtle, var(--ds-icon-subtle));
-  }
+.input-icon-start,
+.input-icon-end {
+  position: absolute;
+  inset-block: 0;
+  display: inline-flex;
+  align-items: center;
+  pointer-events: none;
+  padding-inline: 0.5rem;
+  color: var(--icon-subtle, var(--ds-icon-subtle));
+}
 
-  .input-icon-start {
-    inset-inline-start: 0;
-  }
+.input-icon-start {
+  inset-inline-start: 0;
+}
 
-  .input-icon-end {
-    inset-inline-end: 0;
-  }
+.input-icon-end {
+  inset-inline-end: 0;
+}
 
-  .input.with-start-icon {
-    padding-inline-start: 2rem;
-  }
+.input.with-start-icon {
+  padding-inline-start: 2rem;
+}
 
-  .input.with-end-icon {
-    padding-inline-end: 2rem;
-  }
+.input.with-end-icon {
+  padding-inline-end: 2rem;
 }

--- a/packages/ui/src/styles/components/modal.css
+++ b/packages/ui/src/styles/components/modal.css
@@ -1,29 +1,27 @@
-@layer components {
-  .modal-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 999;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background: var(--ds-overlay);
-  }
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: var(--ds-overlay);
+}
 
-  .modal {
-    position: relative;
-    padding: 1.25rem;
-    border-radius: var(--radius-2xl, 1rem);
-    background-color: var(--color-modal-bg);
-    color: var(--color-text);
-    border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
-    box-shadow: 0 24px 64px color-mix(in srgb, var(--ds-overlay) 60%, transparent);
-  }
+.modal {
+  position: relative;
+  padding: 1.25rem;
+  border-radius: var(--radius-2xl, 1rem);
+  background-color: var(--color-modal-bg);
+  color: var(--color-text);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  box-shadow: 0 24px 64px color-mix(in srgb, var(--ds-overlay) 60%, transparent);
+}
 
-  .modal-close {
-    position: absolute;
-    inset-inline-end: 0.75rem;
-    inset-block-start: 0.75rem;
-    width: 1.25rem;
-    height: 1.25rem;
-  }
+.modal-close {
+  position: absolute;
+  inset-inline-end: 0.75rem;
+  inset-block-start: 0.75rem;
+  width: 1.25rem;
+  height: 1.25rem;
 }

--- a/packages/ui/src/styles/components/splitter.css
+++ b/packages/ui/src/styles/components/splitter.css
@@ -1,5 +1,3 @@
-@layer components {
-  .splitter:hover {
-    background-color: var(--ds-accent);
-  }
+.splitter:hover {
+  background-color: var(--ds-accent);
 }

--- a/packages/ui/src/styles/components/switch.css
+++ b/packages/ui/src/styles/components/switch.css
@@ -1,40 +1,38 @@
-@layer components {
-  .switch {
-    cursor: pointer;
-    border-radius: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
-  }
+.switch {
+  cursor: pointer;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
+}
 
-  .switch-language {
-    background-color: var(--switch-language-bg);
-    color: var(--switch-language-fg);
-    border: 1px solid transparent;
-  }
+.switch-language {
+  background-color: var(--switch-language-bg);
+  color: var(--switch-language-fg);
+  border: 1px solid transparent;
+}
 
-  .switch-language:focus {
-    outline: none;
-  }
+.switch-language:focus {
+  outline: none;
+}
 
-  .switch-language:hover {
-    background-color: var(--switch-language-bg-hover);
-    border-color: var(--switch-language-bg-hover);
-  }
+.switch-language:hover {
+  background-color: var(--switch-language-bg-hover);
+  border-color: var(--switch-language-bg-hover);
+}
 
-  .switch-language option {
-    color: var(--switch-language-fg);
-    background-color: var(--switch-language-bg);
-    cursor: pointer;
-  }
+.switch-language option {
+  color: var(--switch-language-fg);
+  background-color: var(--switch-language-bg);
+  cursor: pointer;
+}
 
-  .switch-language option:hover,
-  .switch-language option:focus {
-    background-color: var(--switch-language-bg-hover);
-    color: var(--switch-language-fg);
-  }
+.switch-language option:hover,
+.switch-language option:focus {
+  background-color: var(--switch-language-bg-hover);
+  color: var(--switch-language-fg);
+}
 
-  .switch-language option:checked {
-    background-color: var(--switch-language-bg-hover);
-    color: var(--switch-language-fg);
-  }
+.switch-language option:checked {
+  background-color: var(--switch-language-bg-hover);
+  color: var(--switch-language-fg);
 }

--- a/packages/ui/src/styles/foundations.css
+++ b/packages/ui/src/styles/foundations.css
@@ -1,36 +1,34 @@
 /* Base design system palette other layers build upon. */
-@layer base {
-  :root {
-    /* Neutral grayscale */
-    --ds-gray-25: #fcfcfd;
-    --ds-gray-50: #f9fafb;
-    --ds-gray-75: #f8fafc;
-    --ds-gray-100: #f3f4f6;
-    --ds-gray-150: #f0f0f0;
-    --ds-gray-200: #e5e7eb;
-    --ds-gray-250: #e0e0e0;
-    --ds-gray-300: #d1d5db;
-    --ds-gray-400: #9ca3af;
-    --ds-gray-500: #6b7280;
-    --ds-gray-550: #666e80;
-    --ds-gray-600: #4b5563;
-    --ds-gray-650: #434c5a;
-    --ds-gray-700: #374151;
-    --ds-gray-750: #2d3648;
-    --ds-gray-800: #1f2937;
-    --ds-gray-850: #1e1e1e;
-    --ds-gray-900: #111827;
-    --ds-gray-950: #020617;
+:root {
+  /* Neutral grayscale */
+  --ds-gray-25: #fcfcfd;
+  --ds-gray-50: #f9fafb;
+  --ds-gray-75: #f8fafc;
+  --ds-gray-100: #f3f4f6;
+  --ds-gray-150: #f0f0f0;
+  --ds-gray-200: #e5e7eb;
+  --ds-gray-250: #e0e0e0;
+  --ds-gray-300: #d1d5db;
+  --ds-gray-400: #9ca3af;
+  --ds-gray-500: #6b7280;
+  --ds-gray-550: #666e80;
+  --ds-gray-600: #4b5563;
+  --ds-gray-650: #434c5a;
+  --ds-gray-700: #374151;
+  --ds-gray-750: #2d3648;
+  --ds-gray-800: #1f2937;
+  --ds-gray-850: #1e1e1e;
+  --ds-gray-900: #111827;
+  --ds-gray-950: #020617;
 
-    /* Accent palette */
-    --ds-blue-500: #3b82f6;
-    --ds-blue-600: #2563eb;
-    --ds-indigo-400: #818cf8;
-    --ds-indigo-500: #6366f1;
-    --ds-indigo-600: #4f46e5;
+  /* Accent palette */
+  --ds-blue-500: #3b82f6;
+  --ds-blue-600: #2563eb;
+  --ds-indigo-400: #818cf8;
+  --ds-indigo-500: #6366f1;
+  --ds-indigo-600: #4f46e5;
 
-    /* Neutral anchors */
-    --ds-white: #ffffff;
-    --ds-black: #000000;
-  }
+  /* Neutral anchors */
+  --ds-white: #ffffff;
+  --ds-black: #000000;
 }

--- a/packages/ui/src/styles/semantic.css
+++ b/packages/ui/src/styles/semantic.css
@@ -1,228 +1,226 @@
 /* Theme layer that projects the palette into semantic design tokens. */
-@layer base {
-  :root {
-    color-scheme: light;
+:root {
+  color-scheme: light;
 
-    /* Text + icon tokens */
-    --ds-text-primary: var(--ds-gray-900);
-    --ds-text-soft: var(--ds-gray-600);
-    --ds-text-placeholder: var(--ds-gray-500);
-    --ds-text-inverse: var(--ds-white);
-    --ds-icon-subtle: var(--ds-gray-500);
+  /* Text + icon tokens */
+  --ds-text-primary: var(--ds-gray-900);
+  --ds-text-soft: var(--ds-gray-600);
+  --ds-text-placeholder: var(--ds-gray-500);
+  --ds-text-inverse: var(--ds-white);
+  --ds-icon-subtle: var(--ds-gray-500);
 
-    /* Application surfaces */
-    --ds-surface-base: var(--ds-white);
-    --ds-surface-raised: var(--ds-gray-50);
-    --ds-surface-muted: var(--ds-gray-100);
-    --ds-surface-hover: var(--ds-gray-150);
-    --ds-surface-active: var(--ds-gray-200);
+  /* Application surfaces */
+  --ds-surface-base: var(--ds-white);
+  --ds-surface-raised: var(--ds-gray-50);
+  --ds-surface-muted: var(--ds-gray-100);
+  --ds-surface-hover: var(--ds-gray-150);
+  --ds-surface-active: var(--ds-gray-200);
 
-    --ds-shell-surface: var(--ds-gray-100);
-    --ds-shell-contrast: var(--ds-gray-200);
+  --ds-shell-surface: var(--ds-gray-100);
+  --ds-shell-contrast: var(--ds-gray-200);
 
-    --ds-sidebar-surface: var(--ds-gray-100);
-    --ds-sidebar-hover: var(--ds-gray-200);
-    --ds-sidebar-border: var(--ds-gray-200);
-    --ds-sidebar-icon: var(--ds-gray-500);
-    --ds-sidebar-icon-hover: var(--ds-gray-700);
+  --ds-sidebar-surface: var(--ds-gray-100);
+  --ds-sidebar-hover: var(--ds-gray-200);
+  --ds-sidebar-border: var(--ds-gray-200);
+  --ds-sidebar-icon: var(--ds-gray-500);
+  --ds-sidebar-icon-hover: var(--ds-gray-700);
 
-    --ds-main-surface: var(--ds-gray-50);
-    --ds-main-hover: var(--ds-gray-150);
-    --ds-main-icon: var(--ds-gray-500);
-    --ds-main-icon-hover: var(--ds-gray-400);
+  --ds-main-surface: var(--ds-gray-50);
+  --ds-main-hover: var(--ds-gray-150);
+  --ds-main-icon: var(--ds-gray-500);
+  --ds-main-icon-hover: var(--ds-gray-400);
 
-    --ds-modal-surface: var(--ds-white);
-    --ds-modal-input: var(--ds-gray-100);
-    --ds-modal-input-hover: var(--ds-gray-150);
+  --ds-modal-surface: var(--ds-white);
+  --ds-modal-input: var(--ds-gray-100);
+  --ds-modal-input-hover: var(--ds-gray-150);
 
-    /* Borders + outlines */
-    --ds-border-subtle: var(--ds-gray-200);
-    --ds-border-strong: var(--ds-gray-300);
-    --ds-border-focus: color-mix(in srgb, var(--ds-indigo-500) 40%, transparent);
+  /* Borders + outlines */
+  --ds-border-subtle: var(--ds-gray-200);
+  --ds-border-strong: var(--ds-gray-300);
+  --ds-border-focus: color-mix(in srgb, var(--ds-indigo-500) 40%, transparent);
 
-    /* Accents */
-    --ds-accent: var(--ds-indigo-500);
-    --ds-accent-hover: var(--ds-indigo-600);
-    --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 35%, transparent);
-    --ds-brand: var(--ds-blue-500);
+  /* Accents */
+  --ds-accent: var(--ds-indigo-500);
+  --ds-accent-hover: var(--ds-indigo-600);
+  --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 35%, transparent);
+  --ds-brand: var(--ds-blue-500);
 
-    /* Stateful layers */
-    --ds-overlay: rgba(15, 23, 42, 0.45);
+  /* Stateful layers */
+  --ds-overlay: rgba(15, 23, 42, 0.45);
 
-    /* Component-specific helpers */
-    --ds-button-filled-fg: var(--ds-text-inverse);
-    --ds-button-muted-fg: var(--ds-text-primary);
-    --ds-button-muted-bg: var(--ds-sidebar-surface);
-    --ds-button-muted-hover: var(--ds-sidebar-hover);
-    --ds-button-outline-border: var(--ds-border-subtle);
-    --ds-button-outline-hover-border: var(--ds-border-strong);
-    --ds-button-card-bg: var(--ds-surface-muted);
-    --ds-button-card-hover: var(--ds-surface-hover);
-    --ds-button-tab-selected: var(--ds-surface-active);
+  /* Component-specific helpers */
+  --ds-button-filled-fg: var(--ds-text-inverse);
+  --ds-button-muted-fg: var(--ds-text-primary);
+  --ds-button-muted-bg: var(--ds-sidebar-surface);
+  --ds-button-muted-hover: var(--ds-sidebar-hover);
+  --ds-button-outline-border: var(--ds-border-subtle);
+  --ds-button-outline-hover-border: var(--ds-border-strong);
+  --ds-button-card-bg: var(--ds-surface-muted);
+  --ds-button-card-hover: var(--ds-surface-hover);
+  --ds-button-tab-selected: var(--ds-surface-active);
 
-    --ds-switch-track-bg: var(--ds-sidebar-surface);
-    --ds-switch-track-hover: var(--ds-sidebar-hover);
+  --ds-switch-track-bg: var(--ds-sidebar-surface);
+  --ds-switch-track-hover: var(--ds-sidebar-hover);
 
-    --ds-input-bg: var(--ds-surface-base);
-    --ds-input-border: var(--ds-border-subtle);
-    --ds-input-focus-border: var(--ds-border-focus);
-    --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 22%, transparent);
-    --ds-input-placeholder: var(--ds-text-placeholder);
-    --ds-input-invalid-border: #e5484d;
+  --ds-input-bg: var(--ds-surface-base);
+  --ds-input-border: var(--ds-border-subtle);
+  --ds-input-focus-border: var(--ds-border-focus);
+  --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 22%, transparent);
+  --ds-input-placeholder: var(--ds-text-placeholder);
+  --ds-input-invalid-border: #e5484d;
 
-    /* Legacy + Tailwind aliases so existing components keep working */
-    --color-text: var(--ds-text-primary);
-    --color-text-soft: var(--ds-text-soft);
-    --color-text-inverse: var(--ds-text-inverse);
-    --color-text-placeholder: var(--ds-text-placeholder);
+  /* Legacy + Tailwind aliases so existing components keep working */
+  --color-text: var(--ds-text-primary);
+  --color-text-soft: var(--ds-text-soft);
+  --color-text-inverse: var(--ds-text-inverse);
+  --color-text-placeholder: var(--ds-text-placeholder);
 
-    --color-surface: var(--ds-surface-base);
-    --color-surface-soft: var(--ds-surface-raised);
-    --color-surface-hover: var(--ds-surface-hover);
-    --color-surface-active: var(--ds-surface-active);
+  --color-surface: var(--ds-surface-base);
+  --color-surface-soft: var(--ds-surface-raised);
+  --color-surface-hover: var(--ds-surface-hover);
+  --color-surface-active: var(--ds-surface-active);
 
-    --color-border: var(--ds-border-subtle);
-    --color-border-hover: var(--ds-border-strong);
+  --color-border: var(--ds-border-subtle);
+  --color-border-hover: var(--ds-border-strong);
 
-    --color-brand: var(--ds-accent);
-    --color-brand-hover: var(--ds-accent-hover);
-    --color-primary: var(--ds-accent);
+  --color-brand: var(--ds-accent);
+  --color-brand-hover: var(--ds-accent-hover);
+  --color-primary: var(--ds-accent);
 
-    --color-bg-0: var(--ds-surface-base);
-    --color-bg-1: var(--ds-surface-raised);
-    --color-bg-2: var(--ds-surface-muted);
-    --color-bg-3: var(--ds-surface-hover);
-    --color-bg-4: var(--ds-surface-active);
-    --color-bg-5: var(--ds-shell-surface);
-    --color-bg-6: var(--ds-shell-surface);
-    --color-bg-7: var(--ds-shell-contrast);
-    --color-bg-8: var(--ds-sidebar-surface);
-    --color-bg-9: var(--ds-sidebar-hover);
-    --color-bg-10: var(--ds-sidebar-hover);
-    --color-bg-hover: var(--ds-surface-hover);
+  --color-bg-0: var(--ds-surface-base);
+  --color-bg-1: var(--ds-surface-raised);
+  --color-bg-2: var(--ds-surface-muted);
+  --color-bg-3: var(--ds-surface-hover);
+  --color-bg-4: var(--ds-surface-active);
+  --color-bg-5: var(--ds-shell-surface);
+  --color-bg-6: var(--ds-shell-surface);
+  --color-bg-7: var(--ds-shell-contrast);
+  --color-bg-8: var(--ds-sidebar-surface);
+  --color-bg-9: var(--ds-sidebar-hover);
+  --color-bg-10: var(--ds-sidebar-hover);
+  --color-bg-hover: var(--ds-surface-hover);
 
-    --color-modal-bg: var(--ds-modal-surface);
-    --color-modal-hover-bg: var(--ds-modal-input-hover);
-    --color-modal-input-bg: var(--ds-modal-input);
-    --color-modal-input-hover-bg: var(--ds-modal-input-hover);
-    --color-modal-input-placeholder: var(--ds-input-placeholder);
+  --color-modal-bg: var(--ds-modal-surface);
+  --color-modal-hover-bg: var(--ds-modal-input-hover);
+  --color-modal-input-bg: var(--ds-modal-input);
+  --color-modal-input-hover-bg: var(--ds-modal-input-hover);
+  --color-modal-input-placeholder: var(--ds-input-placeholder);
 
-    --color-main-bg: var(--ds-main-surface);
-    --color-main-hover-bg: var(--ds-main-hover);
+  --color-main-bg: var(--ds-main-surface);
+  --color-main-hover-bg: var(--ds-main-hover);
 
-    --color-sidebar-light: var(--ds-sidebar-surface);
-    --color-sidebar-dark: var(--ds-sidebar-surface);
-    --color-sidebar-bg: var(--ds-sidebar-surface);
-    --color-sidebar-hover-bg: var(--ds-sidebar-hover);
-    --color-sidebar-border-light: var(--ds-sidebar-border);
-    --color-sidebar-border-dark: var(--ds-sidebar-border);
-    --color-sidebar-border: var(--ds-sidebar-border);
+  --color-sidebar-light: var(--ds-sidebar-surface);
+  --color-sidebar-dark: var(--ds-sidebar-surface);
+  --color-sidebar-bg: var(--ds-sidebar-surface);
+  --color-sidebar-hover-bg: var(--ds-sidebar-hover);
+  --color-sidebar-border-light: var(--ds-sidebar-border);
+  --color-sidebar-border-dark: var(--ds-sidebar-border);
+  --color-sidebar-border: var(--ds-sidebar-border);
 
-    --color-icon-sidebar: var(--ds-sidebar-icon);
-    --color-icon-sidebar-hover: var(--ds-sidebar-icon-hover);
-    --color-icon-main: var(--ds-main-icon);
-    --color-icon-main-hover: var(--ds-main-icon-hover);
+  --color-icon-sidebar: var(--ds-sidebar-icon);
+  --color-icon-sidebar-hover: var(--ds-sidebar-icon-hover);
+  --color-icon-main: var(--ds-main-icon);
+  --color-icon-main-hover: var(--ds-main-icon-hover);
 
-    --btn-default-bg: var(--ds-accent);
-    --btn-default-bg-hover: var(--ds-accent-hover);
-    --btn-default-fg: var(--ds-button-filled-fg);
-    --btn-default-ring: var(--ds-accent-ring);
+  --btn-default-bg: var(--ds-accent);
+  --btn-default-bg-hover: var(--ds-accent-hover);
+  --btn-default-fg: var(--ds-button-filled-fg);
+  --btn-default-ring: var(--ds-accent-ring);
 
-    --btn-titlebar-bg: var(--ds-shell-surface);
-    --btn-titlebar-bg-hover: var(--ds-shell-contrast);
-    --btn-titlebar-fg: var(--ds-text-primary);
+  --btn-titlebar-bg: var(--ds-shell-surface);
+  --btn-titlebar-bg-hover: var(--ds-shell-contrast);
+  --btn-titlebar-fg: var(--ds-text-primary);
 
-    --btn-list-bg: var(--ds-sidebar-surface);
-    --btn-list-bg-hover: var(--ds-sidebar-hover);
-    --btn-list-fg: var(--ds-text-primary);
+  --btn-list-bg: var(--ds-sidebar-surface);
+  --btn-list-bg-hover: var(--ds-sidebar-hover);
+  --btn-list-fg: var(--ds-text-primary);
 
-    --btn-icon-color: var(--ds-sidebar-icon);
-    --btn-icon-hover-color: var(--ds-sidebar-icon-hover);
+  --btn-icon-color: var(--ds-sidebar-icon);
+  --btn-icon-hover-color: var(--ds-sidebar-icon-hover);
 
-    --btn-card-bg: var(--ds-button-card-bg);
-    --btn-card-bg-hover: var(--ds-button-card-hover);
-    --btn-card-fg: var(--ds-text-primary);
+  --btn-card-bg: var(--ds-button-card-bg);
+  --btn-card-bg-hover: var(--ds-button-card-hover);
+  --btn-card-fg: var(--ds-text-primary);
 
-    --btn-panel-tab-bg: var(--ds-button-muted-bg);
-    --btn-panel-tab-bg-hover: var(--ds-button-muted-hover);
-    --btn-panel-tab-bg-selected: var(--ds-button-tab-selected);
-    --btn-panel-tab-fg: var(--ds-text-primary);
+  --btn-panel-tab-bg: var(--ds-button-muted-bg);
+  --btn-panel-tab-bg-hover: var(--ds-button-muted-hover);
+  --btn-panel-tab-bg-selected: var(--ds-button-tab-selected);
+  --btn-panel-tab-fg: var(--ds-text-primary);
 
-    --switch-language-bg: var(--ds-switch-track-bg);
-    --switch-language-bg-hover: var(--ds-switch-track-hover);
-    --switch-language-fg: var(--ds-text-primary);
+  --switch-language-bg: var(--ds-switch-track-bg);
+  --switch-language-bg-hover: var(--ds-switch-track-hover);
+  --switch-language-fg: var(--ds-text-primary);
 
-    --input-default-bg: var(--ds-input-bg);
-    --input-border: var(--ds-input-border);
-    --input-focus-border: var(--ds-input-focus-border);
-    --input-focus-ring: var(--ds-input-focus-ring);
-    --input-invalid-border: var(--ds-input-invalid-border);
-    --input-titlebar-bg: var(--btn-titlebar-bg);
-    --input-titlebar-bg-hover: var(--btn-titlebar-bg-hover);
-    --input-list-bg: var(--btn-list-bg);
-    --input-list-bg-hover: var(--btn-list-bg-hover);
-  }
+  --input-default-bg: var(--ds-input-bg);
+  --input-border: var(--ds-input-border);
+  --input-focus-border: var(--ds-input-focus-border);
+  --input-focus-ring: var(--ds-input-focus-ring);
+  --input-invalid-border: var(--ds-input-invalid-border);
+  --input-titlebar-bg: var(--btn-titlebar-bg);
+  --input-titlebar-bg-hover: var(--btn-titlebar-bg-hover);
+  --input-list-bg: var(--btn-list-bg);
+  --input-list-bg-hover: var(--btn-list-bg-hover);
+}
 
-  [data-theme='dark'] {
-    color-scheme: dark;
+[data-theme='dark'] {
+  color-scheme: dark;
 
-    --ds-text-primary: var(--ds-gray-100);
-    --ds-text-soft: var(--ds-gray-400);
-    --ds-text-placeholder: var(--ds-gray-500);
-    --ds-text-inverse: var(--ds-gray-950);
-    --ds-icon-subtle: var(--ds-gray-400);
+  --ds-text-primary: var(--ds-gray-100);
+  --ds-text-soft: var(--ds-gray-400);
+  --ds-text-placeholder: var(--ds-gray-500);
+  --ds-text-inverse: var(--ds-gray-950);
+  --ds-icon-subtle: var(--ds-gray-400);
 
-    --ds-surface-base: var(--ds-gray-850);
-    --ds-surface-raised: var(--ds-gray-800);
-    --ds-surface-muted: var(--ds-gray-750);
-    --ds-surface-hover: var(--ds-gray-750);
-    --ds-surface-active: var(--ds-gray-700);
+  --ds-surface-base: var(--ds-gray-850);
+  --ds-surface-raised: var(--ds-gray-800);
+  --ds-surface-muted: var(--ds-gray-750);
+  --ds-surface-hover: var(--ds-gray-750);
+  --ds-surface-active: var(--ds-gray-700);
 
-    --ds-shell-surface: var(--ds-gray-850);
-    --ds-shell-contrast: var(--ds-gray-800);
+  --ds-shell-surface: var(--ds-gray-850);
+  --ds-shell-contrast: var(--ds-gray-800);
 
-    --ds-sidebar-surface: var(--ds-gray-850);
-    --ds-sidebar-hover: var(--ds-gray-800);
-    --ds-sidebar-border: var(--ds-gray-700);
-    --ds-sidebar-icon: rgba(255, 255, 255, 0.65);
-    --ds-sidebar-icon-hover: rgba(255, 255, 255, 0.95);
+  --ds-sidebar-surface: var(--ds-gray-850);
+  --ds-sidebar-hover: var(--ds-gray-800);
+  --ds-sidebar-border: var(--ds-gray-700);
+  --ds-sidebar-icon: rgba(255, 255, 255, 0.65);
+  --ds-sidebar-icon-hover: rgba(255, 255, 255, 0.95);
 
-    --ds-main-surface: var(--ds-gray-850);
-    --ds-main-hover: var(--ds-gray-800);
-    --ds-main-icon: var(--ds-gray-400);
-    --ds-main-icon-hover: var(--ds-gray-300);
+  --ds-main-surface: var(--ds-gray-850);
+  --ds-main-hover: var(--ds-gray-800);
+  --ds-main-icon: var(--ds-gray-400);
+  --ds-main-icon-hover: var(--ds-gray-300);
 
-    --ds-modal-surface: var(--ds-gray-850);
-    --ds-modal-input: var(--ds-gray-800);
-    --ds-modal-input-hover: var(--ds-gray-750);
+  --ds-modal-surface: var(--ds-gray-850);
+  --ds-modal-input: var(--ds-gray-800);
+  --ds-modal-input-hover: var(--ds-gray-750);
 
-    --ds-border-subtle: var(--ds-gray-700);
-    --ds-border-strong: var(--ds-gray-600);
-    --ds-border-focus: color-mix(in srgb, var(--ds-indigo-500) 45%, transparent);
+  --ds-border-subtle: var(--ds-gray-700);
+  --ds-border-strong: var(--ds-gray-600);
+  --ds-border-focus: color-mix(in srgb, var(--ds-indigo-500) 45%, transparent);
 
-    --ds-accent: var(--ds-indigo-500);
-    --ds-accent-hover: var(--ds-indigo-400);
-    --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 30%, transparent);
+  --ds-accent: var(--ds-indigo-500);
+  --ds-accent-hover: var(--ds-indigo-400);
+  --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 30%, transparent);
 
-    --ds-overlay: rgba(2, 6, 23, 0.7);
+  --ds-overlay: rgba(2, 6, 23, 0.7);
 
-    --ds-button-filled-fg: var(--ds-text-primary);
-    --ds-button-muted-fg: var(--ds-text-primary);
-    --ds-button-muted-bg: var(--ds-gray-800);
-    --ds-button-muted-hover: var(--ds-gray-700);
-    --ds-button-outline-border: var(--ds-gray-700);
-    --ds-button-outline-hover-border: var(--ds-gray-600);
-    --ds-button-card-bg: var(--ds-gray-800);
-    --ds-button-card-hover: var(--ds-gray-750);
-    --ds-button-tab-selected: var(--ds-gray-750);
+  --ds-button-filled-fg: var(--ds-text-primary);
+  --ds-button-muted-fg: var(--ds-text-primary);
+  --ds-button-muted-bg: var(--ds-gray-800);
+  --ds-button-muted-hover: var(--ds-gray-700);
+  --ds-button-outline-border: var(--ds-gray-700);
+  --ds-button-outline-hover-border: var(--ds-gray-600);
+  --ds-button-card-bg: var(--ds-gray-800);
+  --ds-button-card-hover: var(--ds-gray-750);
+  --ds-button-tab-selected: var(--ds-gray-750);
 
-    --ds-switch-track-bg: var(--ds-gray-800);
-    --ds-switch-track-hover: var(--ds-gray-700);
+  --ds-switch-track-bg: var(--ds-gray-800);
+  --ds-switch-track-hover: var(--ds-gray-700);
 
-    --ds-input-bg: var(--ds-gray-850);
-    --ds-input-border: var(--ds-gray-700);
-    --ds-input-focus-border: color-mix(in srgb, var(--ds-indigo-500) 45%, transparent);
-    --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 25%, transparent);
-    --ds-input-placeholder: var(--ds-gray-500);
-  }
+  --ds-input-bg: var(--ds-gray-850);
+  --ds-input-border: var(--ds-gray-700);
+  --ds-input-focus-border: color-mix(in srgb, var(--ds-indigo-500) 45%, transparent);
+  --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 25%, transparent);
+  --ds-input-placeholder: var(--ds-gray-500);
 }


### PR DESCRIPTION
## Summary
- remove the Tailwind-specific `@layer components` wrapper from each shared UI component stylesheet so the CSS can compile without requiring a matching `@tailwind components` directive

## Testing
- pnpm --filter @grim/ui build *(fails: no matching workspace project for the filter)*
- pnpm --filter @grim/desktop build *(fails: workspace dependencies such as react are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6f74f14832e88838d48b4e94270