### PR TITLE
Centralize desktop theme synchronization

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -5,7 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>eolgae</title>
   </head>
-  <body data-theme="dark">
+  <body>
+    <script>
+      (function () {
+        var theme = 'dark';
+        try {
+          var stored = window.localStorage.getItem('grim-theme');
+          if (stored === 'light' || stored === 'dark') {
+            theme = stored;
+          } else if (window.matchMedia) {
+            theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+        } catch (error) {
+          theme = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+
+        document.documentElement.setAttribute('data-theme', theme);
+        if (document.body) {
+          document.body.setAttribute('data-theme', theme);
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="./src/index.tsx"></script>
   </body>

--- a/apps/desktop/src/features/main/Main.tsx
+++ b/apps/desktop/src/features/main/Main.tsx
@@ -16,6 +16,7 @@ import usePanelsStore from '@tgim/stores/panelStore';
 import PanelContainer from './panel/Container';
 import { ThumbResSpec } from '@tgim/types/file';
 import useThumbStore from '@tgim/stores/thumbStore';
+import { useTheme } from '../../theme/ThemeProvider';
 
 interface LayoutPorps {
   layoutId: string;
@@ -61,6 +62,7 @@ const Layout: React.FC<LayoutPorps> = ({ layoutId }) => {
 // Bootstraps the main workspace once backend bootstrap has finished.
 const Main: React.FC = () => {
   const { moaId } = useMoa(location);
+  const { theme } = useTheme();
   const [progress, setProgress] = useState<AppProgressEvent>({
     stage: 'Migrating',
     percent: 0,
@@ -237,7 +239,7 @@ const Main: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden" data-theme="dark">
+    <div className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden" data-theme={theme}>
       {!isMac && (
         <div className="fixed w-full top-0 z-50">
           <TitleBar />

--- a/apps/desktop/src/features/main/ProgressWindow.tsx
+++ b/apps/desktop/src/features/main/ProgressWindow.tsx
@@ -9,7 +9,7 @@ const ProgressWindow: React.FC<Props> = ({ progress }) => {
         <div className="w-full h-3 rounded-full bg-surface-muted">
           <div
             className={`h-3 rounded-full ${
-              progress.stage === 'Error' ? 'bg-red-500' : 'bg-accent'
+              progress.stage === 'Error' ? 'bg-[var(--color-status-danger)]' : 'bg-accent'
             }`}
             style={{ width: `${progress.percent}%` }}
           ></div>

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -230,7 +230,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   return ReactDOM.createPortal(
     <div
       className={`p-2 rounded border w-full h-full 
-        ${isActive ? 'border-blue-500' : 'border-gray-300'} 
+        ${isActive ? 'border-accent' : 'border-border'}
         ${hidden ? 'hidden' : ''}`}
     >
       <div onClick={() => setViewType('graph')}>graph</div>

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -1,6 +1,6 @@
 import usePanelsStore from '@tgim/stores/panelStore';
 import { Connection, GraphConnection, GraphData } from '@tgim/types/graph';
-import { NodeRenderer } from '@tgim/ui/index';
+import { NodeRenderer, getGraphPalette } from '@tgim/ui/index';
 import { use, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
 import { useShallow } from 'zustand/shallow';
@@ -146,7 +146,7 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
         // onEngineStop={() => openAllNode()}
         // linkDirectionalArrowLength={3.5}
         // linkDirectionalArrowRelPos={0.96}
-        linkColor={() => '#f3f3f3'}
+        linkColor={() => getGraphPalette().link}
         linkWidth={0.1}
         linkCurvature={0}
         nodeCanvasObject={(node, ctx, globalScale) => {

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -621,8 +621,8 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
         )}
       </div>
       {layout === 'grid' && (
-        <div className="absolute bottom-0 left-0 right-0 p-2 bg-gradient-to-t from-black/60 to-transparent">
-          <p className="text-white text-xs font-medium truncate" title={img.name}>
+        <div className="absolute bottom-0 left-0 right-0 p-2 bg-gradient-to-t from-[color-mix(in_srgb,var(--ds-overlay)_85%,transparent)] via-[color-mix(in_srgb,var(--ds-overlay)_35%,transparent)] to-transparent">
+          <p className="text-text-inverse text-xs font-medium truncate" title={img.name}>
             {img.name}
           </p>
         </div>

--- a/apps/desktop/src/features/moa/Moa.tsx
+++ b/apps/desktop/src/features/moa/Moa.tsx
@@ -7,9 +7,11 @@ import MoaDetail from './MoaDetail';
 import { ToastContainer } from 'react-toastify';
 import { platform } from '@tauri-apps/plugin-os';
 import { useEffect, useState } from 'react';
+import { useTheme } from '../../theme/ThemeProvider';
 
 const Moa: React.FC = () => {
   const [isMac, setIsMac] = useState(false);
+  const { theme } = useTheme();
 
   useEffect(() => {
     let mounted = true;
@@ -35,7 +37,7 @@ const Moa: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex w-full h-full bg-shell-base text-text overflow-hidden" data-theme="dark">
+    <div className="flex w-full h-full bg-shell-base text-text overflow-hidden" data-theme={theme}>
       <ManageMoaSidebar />
       {!isMac && (
         <div className="fixed w-full top-0 z-50">

--- a/apps/desktop/src/index.tsx
+++ b/apps/desktop/src/index.tsx
@@ -3,10 +3,13 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import '@tgim/ui/styles/index.css';
 import App from './App';
+import { ThemeProvider } from './theme/ThemeProvider';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/apps/desktop/src/theme/ThemeProvider.tsx
+++ b/apps/desktop/src/theme/ThemeProvider.tsx
@@ -1,0 +1,138 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { setTheme as applyTheme } from '@tgim/ui/theme/theme';
+
+type ThemeMode = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: ThemeMode;
+  setTheme: (mode: ThemeMode) => void;
+  resetToSystem: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const prefersDark = () =>
+  typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+
+const ensureAttributes = (mode: ThemeMode) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  applyTheme(mode, document.documentElement);
+  if (document.body) {
+    applyTheme(mode, document.body);
+  }
+};
+
+type ThemeState = {
+  mode: ThemeMode;
+  explicit: boolean;
+};
+
+const readInitialState = (): ThemeState => {
+  if (typeof window === 'undefined') {
+    return { mode: 'dark', explicit: false };
+  }
+
+  try {
+    const stored = window.localStorage.getItem('grim-theme');
+    if (stored === 'light' || stored === 'dark') {
+      return { mode: stored, explicit: true };
+    }
+  } catch {
+    // ignore storage access issues (tauri, private mode, etc.)
+  }
+
+  return { mode: prefersDark() ? 'dark' : 'light', explicit: false };
+};
+
+export const ThemeProvider = ({ children }: PropsWithChildren) => {
+  const [{ mode, explicit }, setState] = useState<ThemeState>(() => readInitialState());
+  const explicitRef = useRef(explicit);
+
+  useEffect(() => {
+    explicitRef.current = explicit;
+  }, [explicit]);
+
+  useEffect(() => {
+    ensureAttributes(mode);
+
+    try {
+      if (explicit) {
+        window.localStorage.setItem('grim-theme', mode);
+      } else {
+        window.localStorage.removeItem('grim-theme');
+      }
+    } catch {
+      // ignore persistence failures
+    }
+  }, [mode, explicit]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const media = window.matchMedia?.('(prefers-color-scheme: dark)');
+    if (!media) {
+      return;
+    }
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (explicitRef.current) {
+        return;
+      }
+
+      setState({ mode: event.matches ? 'dark' : 'light', explicit: false });
+    };
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handleChange);
+      return () => media.removeEventListener('change', handleChange);
+    }
+
+    if (typeof media.addListener === 'function') {
+      media.addListener(handleChange);
+      return () => media.removeListener(handleChange);
+    }
+
+    return;
+  }, []);
+
+  const setTheme = useCallback((next: ThemeMode) => {
+    setState({ mode: next, explicit: true });
+  }, []);
+
+  const resetToSystem = useCallback(() => {
+    setState({ mode: prefersDark() ? 'dark' : 'light', explicit: false });
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme: mode,
+      setTheme,
+      resetToSystem,
+    }),
+    [mode, setTheme, resetToSystem],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -1,5 +1,6 @@
 import { sharedConfig } from '../../.config/tailwind-css/base';
 export default {
+  darkMode: ['class', '[data-theme="dark"]'],
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -4,6 +4,185 @@
 
 import { GraphNodeType } from '@tgim/types/graph';
 
+type GraphPalette = {
+  label: string;
+  circleFill: string;
+  circleStroke: string;
+  tagStroke: string;
+  folderBack: string;
+  folderFrontLight: string;
+  folderFrontDark: string;
+  folderEdge: string;
+  documentPaper: string;
+  documentEdge: string;
+  documentShadow: string;
+  documentLine: string;
+  imageBg: string;
+  imageBorder: string;
+  placeholderStroke: string;
+  placeholderAccent: string;
+  placeholderFill: string;
+  link: string;
+};
+
+const FALLBACK_PALETTE: GraphPalette = {
+  label: '#111827',
+  circleFill: '#6366f1',
+  circleStroke: '#4338ca',
+  tagStroke: '#4338ca',
+  folderBack: '#bfdbfe',
+  folderFrontLight: '#dbeafe',
+  folderFrontDark: '#bfdbfe',
+  folderEdge: '#2563eb',
+  documentPaper: '#f7fafc',
+  documentEdge: '#a0aec0',
+  documentShadow: '#e2e8f0',
+  documentLine: '#94a3b8',
+  imageBg: '#dbeafe',
+  imageBorder: '#60a5fa',
+  placeholderStroke: 'rgba(255, 255, 255, 0.9)',
+  placeholderAccent: 'rgba(255, 255, 255, 0.85)',
+  placeholderFill: 'rgba(255, 255, 255, 0.75)',
+  link: '#94a3b8',
+};
+
+let graphPalette: GraphPalette = FALLBACK_PALETTE;
+
+const COLOR_TOKENS: Array<[keyof GraphPalette, string]> = [
+  ['label', '--ds-graph-node-label'],
+  ['circleFill', '--ds-graph-node-default-bg'],
+  ['circleStroke', '--ds-graph-node-default-border'],
+  ['tagStroke', '--ds-graph-node-tag-stroke'],
+  ['folderBack', '--ds-graph-node-folder-back'],
+  ['folderFrontLight', '--ds-graph-node-folder-front-light'],
+  ['folderFrontDark', '--ds-graph-node-folder-front-dark'],
+  ['folderEdge', '--ds-graph-node-folder-edge'],
+  ['documentPaper', '--ds-graph-node-document-paper'],
+  ['documentEdge', '--ds-graph-node-document-edge'],
+  ['documentShadow', '--ds-graph-node-document-shadow'],
+  ['documentLine', '--ds-graph-node-document-line'],
+  ['imageBg', '--ds-graph-node-image-bg'],
+  ['imageBorder', '--ds-graph-node-image-border'],
+  ['placeholderStroke', '--ds-graph-node-placeholder-stroke'],
+  ['placeholderAccent', '--ds-graph-node-placeholder-accent'],
+  ['placeholderFill', '--ds-graph-node-placeholder-fill'],
+  ['link', '--ds-graph-link'],
+];
+
+const readToken = (styles: CSSStyleDeclaration, token: string, fallback: string) => {
+  const value = styles.getPropertyValue(token).trim();
+  return value || fallback;
+};
+
+const updateGraphPalette = () => {
+  if (typeof window === 'undefined') {
+    graphPalette = FALLBACK_PALETTE;
+    return;
+  }
+
+  const styles = getComputedStyle(document.documentElement);
+  const next: GraphPalette = { ...FALLBACK_PALETTE };
+  COLOR_TOKENS.forEach(([key, token]) => {
+    next[key] = readToken(styles, token, FALLBACK_PALETTE[key]);
+  });
+  graphPalette = next;
+};
+
+const ensurePaletteObservers = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  updateGraphPalette();
+
+  if (typeof MutationObserver === 'undefined') {
+    return;
+  }
+
+  const observer = new MutationObserver(updateGraphPalette);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class', 'data-theme'],
+  });
+
+  const attachBodyObserver = () => {
+    if (!document.body) return;
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme'],
+    });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      updateGraphPalette();
+      attachBodyObserver();
+    });
+  } else {
+    attachBodyObserver();
+  }
+
+  const media = window.matchMedia?.('(prefers-color-scheme: dark)');
+  if (media) {
+    if ('addEventListener' in media) {
+      media.addEventListener('change', updateGraphPalette);
+    } else if ('addListener' in media) {
+      media.addListener(updateGraphPalette);
+    }
+  }
+};
+
+ensurePaletteObservers();
+
+const getGraphPaletteInternal = () => graphPalette;
+
+const colorParsingCtx =
+  typeof document !== 'undefined'
+    ? document.createElement('canvas').getContext('2d')
+    : null;
+
+const normalizeColor = (value: string) => {
+  if (!colorParsingCtx) return value;
+  try {
+    colorParsingCtx.fillStyle = '#000000';
+    colorParsingCtx.fillStyle = value;
+    return colorParsingCtx.fillStyle;
+  } catch (error) {
+    return value;
+  }
+};
+
+const hexToRgba = (hex: string, alpha: number) => {
+  let normalized = hex.replace('#', '');
+  if (normalized.length === 3) {
+    normalized = normalized
+      .split('')
+      .map(ch => ch + ch)
+      .join('');
+  }
+  if (normalized.length !== 6) return hex;
+
+  const r = parseInt(normalized.substring(0, 2), 16);
+  const g = parseInt(normalized.substring(2, 4), 16);
+  const b = parseInt(normalized.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+const withAlpha = (color: string, alpha: number) => {
+  const normalized = normalizeColor(color);
+  if (normalized.startsWith('#')) {
+    return hexToRgba(normalized, alpha);
+  }
+  const match = normalized
+    .replace(/\s+/g, '')
+    .match(/^rgba?\((\d+),(\d+),(\d+)(?:,(\d*\.?\d+))?\)$/i);
+  if (match) {
+    const [, r, g, b] = match;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  return color;
+};
+
 type NodeProp = {
   [key: string]: any; // extensible payload
   x: number;
@@ -153,7 +332,8 @@ function getLabelSprite(
 
 function drawLabelCached(ctx: CanvasRenderingContext2D, node: NodeProp) {
   const font = '7px sans-serif';
-  const color = node.fgColor ?? '#e0f2fe';
+  const palette = getGraphPaletteInternal();
+  const color = node.fgColor ?? palette.label;
   const maxWidth = node.size * 4;
   const text = String(node.label ?? '');
 
@@ -200,8 +380,9 @@ function getCircleSpriteNode(node: NodeProp, globalScale: number) {
   const h = r * 2;
 
   const scaleB = bucketScale(globalScale);
-  const bg = node.color ?? node.bgColor ?? '#60a5fa';
-  const fg = node.fgColor ?? '#1e3a8a';
+  const palette = getGraphPaletteInternal();
+  const bg = node.color ?? node.bgColor ?? palette.circleFill;
+  const fg = node.fgColor ?? palette.circleStroke;
   const key = `circle|${w}|${h}|${bg}|${fg}|${scaleB}`;
 
   return getOrCreateSprite(key, w, h, g => {
@@ -223,7 +404,8 @@ function getTagSpriteNode(node: NodeProp, globalScale: number) {
   const h = s;
 
   const scaleB = bucketScale(globalScale);
-  const fg = node.fgColor ?? '#e0f2fe';
+  const palette = getGraphPaletteInternal();
+  const fg = node.fgColor ?? palette.tagStroke;
   const key = `tag|${w}|${h}|${fg}|${scaleB}`;
 
   return getOrCreateSprite(key, w, h, g => {
@@ -257,10 +439,11 @@ function getFolderSpriteNode(node: NodeProp, globalScale: number) {
   const h = r * 2.0 * 1.0;
 
   const scaleB = bucketScale(globalScale);
-  const bgBack = '#4299e1';
-  const frontLight = '#63b3ed';
-  const frontDark = '#3182ce';
-  const edge = '#2c5282';
+  const palette = getGraphPaletteInternal();
+  const bgBack = palette.folderBack;
+  const frontLight = palette.folderFrontLight;
+  const frontDark = palette.folderFrontDark;
+  const edge = palette.folderEdge;
   const key = `folder|${w}|${h}|${bgBack}|${frontLight}|${frontDark}|${edge}|${scaleB}`;
 
   return getOrCreateSprite(key, w, h, g => {
@@ -270,7 +453,7 @@ function getFolderSpriteNode(node: NodeProp, globalScale: number) {
     const x = 0,
       y = 0;
 
-    g.shadowColor = 'rgba(0,0,0,0.2)';
+    g.shadowColor = withAlpha(edge, 0.28);
     g.shadowBlur = 10;
     g.shadowOffsetY = 4;
 
@@ -309,7 +492,7 @@ function getFolderSpriteNode(node: NodeProp, globalScale: number) {
     g.beginPath();
     g.moveTo(x + cornerRadius, frontY);
     g.lineTo(x + w - cornerRadius, frontY);
-    g.strokeStyle = 'rgba(255,255,255,0.4)';
+    g.strokeStyle = withAlpha(palette.label, 0.35);
     g.lineWidth = Math.max(1, 2 / Math.max(0.001, scaleB));
     g.stroke();
   });
@@ -321,10 +504,11 @@ function getDocumentSpriteNode(node: NodeProp, globalScale: number) {
   const h = r * 2.0 * 1.3;
 
   const scaleB = bucketScale(globalScale);
-  const paper = '#f7fafc';
-  const edge = '#a0aec0';
-  const shadow = '#e2e8f0';
-  const line = '#cbd5e0';
+  const palette = getGraphPaletteInternal();
+  const paper = palette.documentPaper;
+  const edge = palette.documentEdge;
+  const shadow = palette.documentShadow;
+  const line = palette.documentLine;
   const key = `document|${w}|${h}|${paper}|${edge}|${shadow}|${line}|${scaleB}`;
 
   return getOrCreateSprite(key, w, h, g => {
@@ -332,7 +516,7 @@ function getDocumentSpriteNode(node: NodeProp, globalScale: number) {
     const x = 0,
       y = 0;
 
-    g.shadowColor = 'rgba(0,0,0,0.15)';
+    g.shadowColor = withAlpha(edge, 0.25);
     g.shadowBlur = 12;
     g.shadowOffsetY = 4;
 
@@ -472,8 +656,9 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
   const radius = 8;
 
   // backplate sprite
-  const bg = node.bgColor ?? '#0ea5e9';
-  const fg = node.fgColor ?? '#0c4a6e';
+  const palette = getGraphPaletteInternal();
+  const bg = node.bgColor ?? palette.imageBg;
+  const fg = node.fgColor ?? palette.imageBorder;
   const scaleB = bucketScale(globalScale);
   const backKey = `imgback|${w}|${h}|${radius}|${bg}|${fg}|${scaleB}`;
   const backplate = getOrCreateSprite(backKey, w, h, g => {
@@ -499,13 +684,13 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
     const phKey = `imgph|${w}|${h}|${radius}|${scaleB}`;
     const placeholder = getOrCreateSprite(phKey, w, h, g => {
       roundRect(g, 4, 4, w - 8, h - 8, 6);
-      g.strokeStyle = 'rgba(255,255,255,0.9)';
+      g.strokeStyle = palette.placeholderStroke;
       g.lineWidth = Math.max(1, 1.5 / Math.max(0.001, scaleB));
       g.stroke();
 
       g.beginPath();
       g.arc(w * 0.25, h * 0.32, Math.min(w, h) * 0.07, 0, Math.PI * 2);
-      g.fillStyle = 'rgba(255,255,255,0.85)';
+      g.fillStyle = palette.placeholderAccent;
       g.fill();
 
       g.beginPath();
@@ -517,7 +702,7 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
       g.lineTo(w * 0.7, h * 0.55);
       g.lineTo(w * 0.88, baseY);
       g.closePath();
-      g.fillStyle = 'rgba(255,255,255,0.75)';
+      g.fillStyle = palette.placeholderFill;
       g.fill();
     });
     ctx.drawImage(placeholder, node.x - w / 2, node.y - h / 2, w, h);
@@ -531,6 +716,8 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
 // =========================
 
 type NodeRendererType = { [key in GraphNodeType]: NodeRenderer };
+
+export const getGraphPalette = () => graphPalette;
 
 export default (key: GraphNodeType): NodeRenderer => {
   const map: Partial<NodeRendererType> = {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -9,3 +9,4 @@ export * from './FileTree';
 export { default as Modal } from './Modal';
 export { default as Tab } from './Tab';
 export { default as NodeRenderer } from './Node';
+export { getGraphPalette } from './Node';

--- a/packages/ui/src/styles/foundations.css
+++ b/packages/ui/src/styles/foundations.css
@@ -28,6 +28,11 @@
   --ds-indigo-500: #6366f1;
   --ds-indigo-600: #4f46e5;
 
+  /* Supporting accents */
+  --ds-red-400: #f87171;
+  --ds-red-500: #ef4444;
+  --ds-red-600: #dc2626;
+
   /* Neutral anchors */
   --ds-white: #ffffff;
   --ds-black: #000000;

--- a/packages/ui/src/styles/semantic.css
+++ b/packages/ui/src/styles/semantic.css
@@ -1,5 +1,9 @@
 /* Theme layer that projects the palette into semantic design tokens. */
-:root {
+:root,
+:root[data-theme='light'],
+[data-theme='light'],
+.light,
+.theme-light {
   color-scheme: light;
 
   /* Text + icon tokens */
@@ -45,6 +49,9 @@
   --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 35%, transparent);
   --ds-brand: var(--ds-blue-500);
 
+  /* Status tokens */
+  --ds-status-danger: var(--ds-red-600);
+
   /* Stateful layers */
   --ds-overlay: rgba(15, 23, 42, 0.45);
 
@@ -67,6 +74,26 @@
   --ds-input-focus-border: var(--ds-border-focus);
   --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 22%, transparent);
   --ds-input-placeholder: var(--ds-text-placeholder);
+
+  /* Graph view helpers */
+  --ds-graph-node-label: var(--ds-text-primary);
+  --ds-graph-node-default-bg: color-mix(in srgb, var(--ds-accent) 28%, var(--ds-surface-base));
+  --ds-graph-node-default-border: color-mix(in srgb, var(--ds-accent) 65%, transparent);
+  --ds-graph-node-tag-stroke: color-mix(in srgb, var(--ds-accent) 55%, var(--ds-text-primary) 45%);
+  --ds-graph-node-folder-back: color-mix(in srgb, var(--ds-accent) 14%, var(--ds-surface-muted));
+  --ds-graph-node-folder-front-light: color-mix(in srgb, var(--ds-accent) 12%, var(--ds-surface-raised));
+  --ds-graph-node-folder-front-dark: color-mix(in srgb, var(--ds-accent) 18%, var(--ds-surface-active));
+  --ds-graph-node-folder-edge: color-mix(in srgb, var(--ds-accent) 45%, transparent);
+  --ds-graph-node-document-paper: var(--ds-surface-base);
+  --ds-graph-node-document-edge: var(--ds-border-subtle);
+  --ds-graph-node-document-shadow: color-mix(in srgb, var(--ds-surface-hover) 80%, transparent);
+  --ds-graph-node-document-line: color-mix(in srgb, var(--ds-text-soft) 92%, transparent);
+  --ds-graph-node-image-bg: color-mix(in srgb, var(--ds-accent) 18%, var(--ds-surface-active));
+  --ds-graph-node-image-border: color-mix(in srgb, var(--ds-accent) 55%, transparent);
+  --ds-graph-node-placeholder-stroke: color-mix(in srgb, var(--ds-text-inverse) 92%, transparent);
+  --ds-graph-node-placeholder-accent: color-mix(in srgb, var(--ds-text-inverse) 82%, transparent);
+  --ds-graph-node-placeholder-fill: color-mix(in srgb, var(--ds-text-inverse) 70%, transparent);
+  --ds-graph-link: color-mix(in srgb, var(--ds-border-subtle) 65%, transparent);
   --ds-input-invalid-border: #e5484d;
 
   /* Legacy + Tailwind aliases so existing components keep working */
@@ -82,6 +109,8 @@
 
   --color-border: var(--ds-border-subtle);
   --color-border-hover: var(--ds-border-strong);
+
+  --color-status-danger: var(--ds-status-danger);
 
   --color-brand: var(--ds-accent);
   --color-brand-hover: var(--ds-accent-hover);
@@ -122,6 +151,8 @@
   --color-icon-main: var(--ds-main-icon);
   --color-icon-main-hover: var(--ds-main-icon-hover);
 
+  --color-graph-link: var(--ds-graph-link);
+
   --btn-default-bg: var(--ds-accent);
   --btn-default-bg-hover: var(--ds-accent-hover);
   --btn-default-fg: var(--ds-button-filled-fg);
@@ -160,9 +191,12 @@
   --input-titlebar-bg-hover: var(--btn-titlebar-bg-hover);
   --input-list-bg: var(--btn-list-bg);
   --input-list-bg-hover: var(--btn-list-bg-hover);
-}
 
-[data-theme='dark'] {
+:root[data-theme='dark'],
+[data-theme='dark'],
+:root.dark,
+.dark,
+.theme-dark {
   color-scheme: dark;
 
   --ds-text-primary: var(--ds-gray-100);
@@ -203,6 +237,9 @@
   --ds-accent-hover: var(--ds-indigo-400);
   --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 30%, transparent);
 
+  /* Status tokens */
+  --ds-status-danger: var(--ds-red-400);
+
   --ds-overlay: rgba(2, 6, 23, 0.7);
 
   --ds-button-filled-fg: var(--ds-text-primary);
@@ -223,4 +260,24 @@
   --ds-input-focus-border: color-mix(in srgb, var(--ds-indigo-500) 45%, transparent);
   --ds-input-focus-ring: color-mix(in srgb, var(--ds-indigo-500) 25%, transparent);
   --ds-input-placeholder: var(--ds-gray-500);
+
+  /* Graph view helpers */
+  --ds-graph-node-label: var(--ds-text-primary);
+  --ds-graph-node-default-bg: color-mix(in srgb, var(--ds-accent) 32%, var(--ds-surface-base));
+  --ds-graph-node-default-border: color-mix(in srgb, var(--ds-accent) 68%, transparent);
+  --ds-graph-node-tag-stroke: color-mix(in srgb, var(--ds-accent) 52%, var(--ds-text-primary) 48%);
+  --ds-graph-node-folder-back: color-mix(in srgb, var(--ds-accent) 18%, var(--ds-surface-muted));
+  --ds-graph-node-folder-front-light: color-mix(in srgb, var(--ds-accent) 16%, var(--ds-surface-raised));
+  --ds-graph-node-folder-front-dark: color-mix(in srgb, var(--ds-accent) 22%, var(--ds-surface-active));
+  --ds-graph-node-folder-edge: color-mix(in srgb, var(--ds-accent) 48%, transparent);
+  --ds-graph-node-document-paper: var(--ds-surface-base);
+  --ds-graph-node-document-edge: var(--ds-border-subtle);
+  --ds-graph-node-document-shadow: color-mix(in srgb, var(--ds-surface-hover) 78%, transparent);
+  --ds-graph-node-document-line: color-mix(in srgb, var(--ds-text-soft) 88%, transparent);
+  --ds-graph-node-image-bg: color-mix(in srgb, var(--ds-accent) 20%, var(--ds-surface-active));
+  --ds-graph-node-image-border: color-mix(in srgb, var(--ds-accent) 58%, transparent);
+  --ds-graph-node-placeholder-stroke: color-mix(in srgb, var(--ds-text-inverse) 94%, transparent);
+  --ds-graph-node-placeholder-accent: color-mix(in srgb, var(--ds-text-inverse) 86%, transparent);
+  --ds-graph-node-placeholder-fill: color-mix(in srgb, var(--ds-text-inverse) 74%, transparent);
+  --ds-graph-link: color-mix(in srgb, var(--ds-border-subtle) 70%, transparent);
 }


### PR DESCRIPTION
## Summary
- add a reusable theme provider that syncs `data-theme` to the document root/body, tracks explicit overrides, and falls back to the system scheme
- hydrate the initial markup with a theme script and wrap the React tree in the provider so route shells can read the active mode
- update the Main and Moa shells to consume the provider and forward the active `data-theme` down to their component trees

## Testing
- `pnpm lint:check` *(fails: Cannot find package '@eslint/js' because workspace dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad1ead438832ea5b637b8903be5d0