### PR TITLE
feat: cache base thumbnails on file upsert

### DIFF
--- a/apps/desktop/src-tauri/src/commands/file.rs
+++ b/apps/desktop/src-tauri/src/commands/file.rs
@@ -5,7 +5,7 @@ use crate::{
 #[tauri::command]
 /// Create a virtual folder and optionally mount the provided filesystem path.
 pub async fn create_folder(
-    _app_handle: tauri::AppHandle,
+    app_handle: tauri::AppHandle,
     moa_id: String,
     data: FolderData,
 ) -> Result<(), String> {
@@ -14,7 +14,7 @@ pub async fn create_folder(
         .map_err(|e| e.to_string())?;
 
     if let Some(path) = data.path.as_ref().filter(|path| !path.is_empty()) {
-        first_mount_folder(moa_id.clone(), node, path.clone())
+        first_mount_folder(app_handle, moa_id.clone(), node, path.clone())
             .await
             .map_err(|e| e.to_string())?;
     }

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -427,6 +427,13 @@ pub struct ThumbReqInfo {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ThumbPath(pub PathBuf);
 
+/// Width of the cached base thumbnail used for downstream resizing.
+pub const THUMB_BASE_WIDTH: u32 = 512;
+
+/// Path to the cached base thumbnail for a file hash.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ThumbBasePath(pub PathBuf);
+
 impl ThumbPath {
     /// path/to/ab/cd/<hash>/<hash>_<width>x<height>_dpr<1|2|3>[_modeToken].<ext>
     pub async fn new(
@@ -504,6 +511,65 @@ impl ThumbPath {
 
     pub fn as_path(&self) -> &Path {
         &self.0
+    }
+}
+
+impl ThumbBasePath {
+    /// Cached base thumbnail path "thumbs/base/vX/ab/cd/<hash>/<hash>_w512_auto_vX.webp".
+    pub fn new(
+        app: &AppHandle,
+        _moa_id: &str,
+        hash: &str,
+        schema_version: u8,
+    ) -> Result<Self> {
+        if hash.len() < 4 {
+            return Err(anyhow!("xxhs must be at least 4 chars long"));
+        }
+        if !is_ascii_hex(hash) {
+            return Err(anyhow!("xxhs must be ASCII-hex [0-9a-fA-F]"));
+        }
+
+        let xxhs = hash.to_ascii_lowercase();
+        let ab = &xxhs[0..2];
+        let cd = &xxhs[2..4];
+
+        let filename = format!(
+            "{}_w{}_auto_v{}.webp",
+            xxhs, THUMB_BASE_WIDTH, schema_version
+        );
+
+        let rel_path = PathBuf::from("thumbs")
+            .join("base")
+            .join(format!("v{}", schema_version))
+            .join(ab)
+            .join(cd)
+            .join(&xxhs)
+            .join(filename);
+
+        let path = app.path().resolve(rel_path, BaseDirectory::AppCache)?;
+        Ok(ThumbBasePath(path))
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl fmt::Display for ThumbBasePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.display())
+    }
+}
+
+impl AsRef<Path> for ThumbBasePath {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+impl From<ThumbBasePath> for PathBuf {
+    fn from(tp: ThumbBasePath) -> Self {
+        tp.0
     }
 }
 

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use async_recursion::async_recursion;
 use sqlx::{Sqlite, Transaction};
+use tauri::AppHandle;
 use tokio::fs;
+use tracing::warn;
 
 use crate::{
     db::repository::{
@@ -11,7 +13,7 @@ use crate::{
         sroot_repository::SrootRepository,
     },
     models::{
-        file::{FileInfo, FolderData, RealFolderData},
+        file::{FileInfo, FileType, FolderData, RealFolderData},
         node::Node,
     },
     services::{
@@ -21,7 +23,7 @@ use crate::{
     utils::{file_utils::file_mtime_epoch, path_utils::normalize_path},
 };
 
-use super::utils::check_is_hidden;
+use super::{thumbnail::ensure_base_thumbnail, utils::check_is_hidden};
 
 /// Create a new virtual folder inside a transaction.
 pub async fn create_folder(moa_id: String, data: FolderData) -> Result<Node> {
@@ -42,6 +44,7 @@ pub async fn create_folder(moa_id: String, data: FolderData) -> Result<Node> {
 
 /// Mount the first physical folder selected by the user into the virtual tree.
 pub async fn first_mount_folder(
+    app: AppHandle,
     moa_id: String,
     node: Node,
     path: String,
@@ -65,6 +68,8 @@ pub async fn first_mount_folder(
 
     upsert_folder(
         &mut tx,
+        &app,
+        &moa_id,
         real_folder_id.clone(),
         node.id,
         &norm_path,
@@ -92,6 +97,8 @@ pub async fn start_scan_job(
 #[async_recursion]
 async fn upsert_folder(
     tx: &mut Transaction<'_, Sqlite>,
+    app: &AppHandle,
+    moa_id: &str,
     parent_real_folder_id: String,
     parent_virtual_folder_id: String,
     abs_dir: &Path,
@@ -143,6 +150,8 @@ async fn upsert_folder(
         } else if file_type.is_file() {
             upsert_file_entry(
                 tx,
+                app,
+                moa_id,
                 &parent_real_folder_id,
                 &parent_virtual_folder_id,
                 &entry,
@@ -192,6 +201,8 @@ async fn upsert_folder(
 
             if let Err(e) = upsert_folder(
                 tx,
+                app,
+                moa_id,
                 child_real_folder_id,
                 child_vf.id,
                 &entry_path,
@@ -200,7 +211,7 @@ async fn upsert_folder(
             )
             .await
             {
-                tracing::warn!("upsert_folder error: {e}");
+                warn!("upsert_folder error: {e}");
             };
         }
     }
@@ -211,6 +222,8 @@ async fn upsert_folder(
 /// Upsert file metadata and associations for a single discovered entry.
 async fn upsert_file_entry(
     tx: &mut Transaction<'_, Sqlite>,
+    app: &AppHandle,
+    moa_id: &str,
     parent_real_folder_id: &str,
     parent_virtual_folder_id: &str,
     entry: &fs::DirEntry,
@@ -241,6 +254,22 @@ async fn upsert_file_entry(
         &file_content_id,
     )
     .await?;
+
+    if file_info.file_exists && file_info.kind_guess == FileType::Image {
+        if let Err(err) = ensure_base_thumbnail(
+            app,
+            moa_id,
+            &file_info.xxh3_64,
+            file_path.as_path(),
+        )
+        .await
+        {
+            warn!(
+                "failed to precache base thumbnail for {:?}: {}",
+                file_path, err
+            );
+        }
+    }
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
@@ -1,4 +1,8 @@
-use std::{sync::Arc, time::Instant};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Instant,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use fast_image_resize::{
@@ -12,10 +16,11 @@ use tokio::{
     sync::{mpsc, Semaphore},
     task,
 };
+use tracing::warn;
 
 use crate::models::file::{
-    ImageFmt, ThumbPath, ThumbRequest, ThumbResInfo, ThumbResSpec,
-    ThumbResponse, ThumbSpec, ThumbStatus,
+    ImageFmt, ThumbBasePath, ThumbPath, ThumbRequest, ThumbResInfo,
+    ThumbResSpec, ThumbResponse, ThumbSpec, ThumbStatus, THUMB_BASE_WIDTH,
 };
 
 use super::{
@@ -25,6 +30,133 @@ use super::{
 
 /// Version tag embedded in generated thumbnail paths.
 pub const SCHEMA_VERSION: u8 = 1;
+
+/// Metadata about the cached base thumbnail for a file hash.
+#[derive(Debug, Clone)]
+pub struct BaseThumbInfo {
+    pub path: ThumbBasePath,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Ensure a cached 512px-wide thumbnail exists for the provided file hash.
+pub async fn ensure_base_thumbnail(
+    app: &AppHandle,
+    moa_id: &str,
+    hash: &str,
+    source_path: &Path,
+) -> Result<BaseThumbInfo> {
+    let base_path = ThumbBasePath::new(app, moa_id, hash, SCHEMA_VERSION)?;
+
+    if tokio::fs::metadata(base_path.as_path()).await.is_ok() {
+        let dims = task::spawn_blocking({
+            let path = base_path.as_path().to_path_buf();
+            move || -> Result<(u32, u32)> {
+                image::image_dimensions(&path).map_err(|err| {
+                    anyhow!("failed to read cached base dimensions: {err}")
+                })
+            }
+        })
+        .await;
+
+        match dims {
+            Ok(Ok((width, height))) => {
+                return Ok(BaseThumbInfo { path: base_path, width, height });
+            }
+            Ok(Err(err)) => {
+                warn!(
+                    "invalid cached base thumbnail for {:?}: {}",
+                    base_path.as_path(),
+                    err
+                );
+                let _ = tokio::fs::remove_file(base_path.as_path()).await;
+            }
+            Err(err) => {
+                warn!(
+                    "failed to join cached base dimension task for {:?}: {}",
+                    base_path.as_path(),
+                    err
+                );
+                let _ = tokio::fs::remove_file(base_path.as_path()).await;
+            }
+        }
+    }
+
+    let data = tokio::fs::read(source_path).await.with_context(|| {
+        format!("failed to read source image: {}", source_path.display())
+    })?;
+
+    let image: DynamicImage = task::spawn_blocking({
+        let data = data.clone();
+        move || image::load_from_memory(&data).context("image decode failed")
+    })
+    .await
+    .context("join error")??;
+
+    let (w, h) = image.dimensions();
+    if w == 0 || h == 0 {
+        bail!("invalid image dimensions: {}x{}", w, h);
+    }
+
+    let scale = if w > THUMB_BASE_WIDTH {
+        THUMB_BASE_WIDTH as f32 / w as f32
+    } else {
+        1.0
+    };
+
+    let target_w = ((w as f32 * scale).round() as u32).max(1);
+    let target_h = ((h as f32 * scale).round() as u32).max(1);
+
+    let rgba = image.to_rgba8();
+    let (src_w, src_h) = rgba.dimensions();
+    let mut src_image =
+        Image::from_vec_u8(src_w, src_h, rgba.into_raw(), PixelType::U8x4)
+            .expect("invalid source image");
+    let mut dst_image = Image::new(target_w, target_h, src_image.pixel_type());
+
+    let mut resizer = Resizer::new();
+    resizer
+        .resize(
+            &src_image,
+            &mut dst_image,
+            &ResizeOptions::new()
+                .resize_alg(ResizeAlg::Convolution(FilterType::CatmullRom)),
+        )
+        .expect("resize failed");
+
+    if let Some(parent) = base_path.as_path().parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    } else {
+        bail!("bad base thumbnail path");
+    }
+
+    let encoded = task::spawn_blocking({
+        let buffer = dst_image.into_vec();
+        move || -> Result<Vec<u8>> {
+            let mut buf = Vec::new();
+            let mut encoder =
+                image::codecs::webp::WebPEncoder::new_lossless(&mut buf);
+            encoder
+                .encode(
+                    &buffer,
+                    target_w,
+                    target_h,
+                    image::ExtendedColorType::Rgba8,
+                )
+                .context("webp encode failed")?;
+            Ok(buf)
+        }
+    })
+    .await??;
+
+    let tmp_path = base_path.as_path().with_extension("tmp");
+    tokio::fs::write(&tmp_path, &encoded).await?;
+    tokio::fs::rename(&tmp_path, base_path.as_path())
+        .await
+        .context("rename failed")?;
+
+    Ok(BaseThumbInfo { path: base_path, width: target_w, height: target_h })
+}
 
 /// Fetch thumbnail metadata and queue missing thumbnails for background generation.
 pub async fn get_thumbs(
@@ -147,14 +279,37 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
     let source_path =
         fetch_one_file_path(job.moa_id.clone(), job.xxhs.clone()).await?;
 
-    let data =
-        tokio::fs::read(&source_path).await.context("read source failed")?;
     let file_kind = infer::get_from_path(&source_path)
         .context("failed to read file")?
         .ok_or_else(|| anyhow!("unknown file type"))?;
     if !infer::is_image(file_kind.mime_type().as_bytes()) {
         bail!("unsupported mime type for thumbnail generation");
     }
+
+    let (input_path, used_cache) =
+        match ensure_base_thumbnail(app, &job.moa_id, &job.xxhs, &source_path)
+            .await
+        {
+            Ok(info) => {
+                let BaseThumbInfo { path, width, height } = info;
+                if job.spec.width <= width && job.spec.height <= height {
+                    (PathBuf::from(path), true)
+                } else {
+                    (source_path.clone(), false)
+                }
+            }
+            Err(err) => {
+                warn!(
+                    "failed to ensure base thumbnail for {:?}: {}",
+                    source_path, err
+                );
+                (source_path.clone(), false)
+            }
+        };
+
+    let data = tokio::fs::read(&input_path).await.with_context(|| {
+        format!("read source failed: {}", input_path.display())
+    })?;
 
     let output_path = job.out_path.clone();
     let tmp_path = output_path.with_extension("tmp");
@@ -270,11 +425,12 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
     .await?;
 
     tracing::info!(
-        "[perf] decode: {:?} ms | resize: {:?} ms | encode: {:?} ms | total: {:?} ms",
+        "[perf] decode: {:?} ms | resize: {:?} ms | encode: {:?} ms | total: {:?} ms | source: {}",
         decode_elapsed.as_millis(),
         resize_elapsed.as_millis(),
         encode_elapsed.as_millis(),
-        timer_all.elapsed().as_millis()
+        timer_all.elapsed().as_millis(),
+        if used_cache { "cache" } else { "original" }
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- preload a shared 512px base thumbnail during folder scans so later renders can reuse the cached image data
- add `ThumbBasePath` utilities to resolve cache locations and persist the resized base asset
- update the thumbnail worker to prefer the cached base image while falling back to the original file when a larger render is needed

## Testing
- `cargo fmt`
- `cargo check` *(fails: unable to download crates index because CONNECT tunnel responded 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cae318ba38832e9b199892ded05657