### PR TITLE
Queue base thumbnail generation

### DIFF
--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -26,7 +26,10 @@ use crate::{
     utils::{file_utils::file_mtime_epoch, path_utils::normalize_path},
 };
 
-use super::{thumbnail::ensure_base_thumbnail, utils::check_is_hidden};
+use super::{
+    job_queue::{enqueue_base_job, BaseThumbnailJob},
+    utils::check_is_hidden,
+};
 
 #[derive(Default)]
 struct UpsertFolderMetrics {
@@ -35,8 +38,6 @@ struct UpsertFolderMetrics {
     folder_creation_count: u64,
     tree_scanning: Duration,
     tree_scanning_count: u64,
-    base_thumbnail: Duration,
-    base_thumbnail_count: u64,
     upsert_file: Duration,
     upsert_file_count: u64,
     file_size_buckets: HashMap<FileSizeBucket, BucketStats>,
@@ -51,11 +52,6 @@ impl UpsertFolderMetrics {
     fn record_tree_scanning(&mut self, elapsed: Duration) {
         self.tree_scanning += elapsed;
         self.tree_scanning_count += 1;
-    }
-
-    fn record_base_thumbnail(&mut self, elapsed: Duration) {
-        self.base_thumbnail += elapsed;
-        self.base_thumbnail_count += 1;
     }
 
     fn record_upsert_file(&mut self, size: Option<i64>, elapsed: Duration) {
@@ -100,7 +96,6 @@ impl UpsertFolderMetrics {
                 tree_scan          : {} ms ({} runs)
                 folder_creation    : {} ms ({} runs)
                 upsert_file        : {} ms ({} runs)
-                base_thumbnail     : {} ms ({} runs)
                 file_size_buckets  : {}
             ",
             root_dir.display(),
@@ -111,8 +106,6 @@ impl UpsertFolderMetrics {
             self.folder_creation_count,
             self.upsert_file.as_millis(),
             self.upsert_file_count,
-            self.base_thumbnail.as_millis(),
-            self.base_thumbnail_count,
             bucket_summary,
         );
     }
@@ -442,22 +435,12 @@ async fn upsert_file_entry(
     .await?;
 
     if file_info.file_exists && file_info.kind_guess == FileType::Image {
-        let base_timer = Instant::now();
-        let base_result = ensure_base_thumbnail(
-            app,
-            moa_id,
-            &file_info.xxh3_64,
-            file_path.as_path(),
-        )
+        enqueue_base_job(BaseThumbnailJob {
+            moa_id: moa_id.to_string(),
+            xxhs: file_info.xxh3_64.clone(),
+            source_path: file_path.clone(),
+        })
         .await;
-        metrics.record_base_thumbnail(base_timer.elapsed());
-
-        if let Err(err) = base_result {
-            warn!(
-                "failed to precache base thumbnail for {:?}: {}",
-                file_path, err
-            );
-        }
     }
     metrics.record_upsert_file(file_info.file_size, file_timer.elapsed());
 

--- a/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
@@ -13,6 +13,14 @@ use tokio::{
 
 use crate::models::file::ThumbSpec;
 
+/// Background job used to pre-render base thumbnails for file hashes.
+#[derive(Debug, Clone)]
+pub struct BaseThumbnailJob {
+    pub moa_id: String,
+    pub xxhs: String,
+    pub source_path: PathBuf,
+}
+
 /// Key used to track pending and inflight jobs.
 #[derive(Debug, Clone, Eq)]
 struct ThumbnailJobKey {
@@ -58,9 +66,17 @@ struct ThumbnailQueue {
     inflight: HashSet<ThumbnailJobKey>,
 }
 
+#[derive(Default)]
+struct BaseThumbnailQueue {
+    queue: VecDeque<BaseThumbnailJob>,
+    pending: HashSet<String>,
+    inflight: HashSet<String>,
+}
+
 /// Shared state for the thumbnail worker queue.
 pub struct ThumbnailWorkerState {
     pub queue: Mutex<ThumbnailQueue>,
+    pub base_queue: Mutex<BaseThumbnailQueue>,
     pub signal: OnceCell<mpsc::Sender<()>>,
 }
 
@@ -68,6 +84,7 @@ impl Default for ThumbnailWorkerState {
     fn default() -> Self {
         Self {
             queue: Mutex::new(ThumbnailQueue::default()),
+            base_queue: Mutex::new(BaseThumbnailQueue::default()),
             signal: OnceCell::new(),
         }
     }
@@ -107,6 +124,35 @@ pub async fn enqueue_jobs(mut jobs: Vec<ThumbnailJob>) {
     }
 }
 
+/// Queue a base thumbnail job if one is not already pending or in-flight.
+pub async fn enqueue_base_job(job: BaseThumbnailJob) {
+    let state = THUMBNAIL_WORKER_STATE.clone();
+
+    {
+        let mut queue = state.base_queue.lock().await;
+
+        if queue.inflight.contains(&job.xxhs) {
+            return;
+        }
+
+        if queue.pending.contains(&job.xxhs) {
+            if let Some(existing) =
+                queue.queue.iter_mut().find(|item| item.xxhs == job.xxhs)
+            {
+                *existing = job;
+            }
+            return;
+        }
+
+        queue.pending.insert(job.xxhs.clone());
+        queue.queue.push_back(job);
+    }
+
+    if let Some(tx) = state.signal.get() {
+        let _ = tx.try_send(());
+    }
+}
+
 /// Take the next job from the queue, prioritising high priority jobs.
 pub async fn take_next_job() -> Option<ThumbnailJob> {
     let mut queue = THUMBNAIL_WORKER_STATE.queue.lock().await;
@@ -126,4 +172,32 @@ pub async fn finish_job(job: &ThumbnailJob) {
     let key: ThumbnailJobKey = job.into();
     let mut queue = THUMBNAIL_WORKER_STATE.queue.lock().await;
     queue.inflight.remove(&key);
+}
+
+/// Take the next base thumbnail job from the queue.
+pub async fn take_next_base_job() -> Option<BaseThumbnailJob> {
+    let mut queue = THUMBNAIL_WORKER_STATE.base_queue.lock().await;
+    let job = queue.queue.pop_front();
+
+    if let Some(ref job) = job {
+        queue.pending.remove(&job.xxhs);
+        queue.inflight.insert(job.xxhs.clone());
+    }
+
+    job
+}
+
+/// Mark a base thumbnail job as finished.
+pub async fn finish_base_job(job: &BaseThumbnailJob) {
+    let mut queue = THUMBNAIL_WORKER_STATE.base_queue.lock().await;
+    queue.inflight.remove(&job.xxhs);
+}
+
+/// Cancel a pending base thumbnail job for the provided hash if it exists.
+pub async fn cancel_pending_base_job(hash: &str) {
+    let mut queue = THUMBNAIL_WORKER_STATE.base_queue.lock().await;
+
+    if queue.pending.remove(hash) {
+        queue.queue.retain(|job| job.xxhs != hash);
+    }
 }

--- a/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
@@ -25,7 +25,10 @@ use crate::models::file::{
 
 use super::{
     folder::fetch_one_file_path,
-    job_queue::{enqueue_jobs, finish_job, take_next_job, ThumbnailJob},
+    job_queue::{
+        cancel_pending_base_job, enqueue_jobs, finish_base_job, finish_job,
+        take_next_base_job, take_next_job, BaseThumbnailJob, ThumbnailJob,
+    },
 };
 
 /// Version tag embedded in generated thumbnail paths.
@@ -238,36 +241,64 @@ pub async fn worker_loop(app: AppHandle, mut rx: mpsc::Receiver<()>) {
         let _ = rx.recv().await;
 
         loop {
-            let Some(job) = take_next_job().await else {
+            let mut made_progress = false;
+
+            if let Some(base_job) = take_next_base_job().await {
+                let app_cloned = app.clone();
+                let semaphore_cloned = semaphore.clone();
+
+                tokio::spawn(async move {
+                    let _permit = semaphore_cloned.acquire().await.unwrap();
+                    let job_clone = base_job.clone();
+                    let result = process_base_job(&app_cloned, base_job).await;
+
+                    finish_base_job(&job_clone).await;
+
+                    if let Err(error) = result {
+                        warn!(
+                            "failed to precache base thumbnail for {}: {}",
+                            job_clone.xxhs, error
+                        );
+                    }
+                });
+
+                task::yield_now().await;
+                made_progress = true;
+            }
+
+            if let Some(job) = take_next_job().await {
+                let app_cloned = app.clone();
+                let semaphore_cloned = semaphore.clone();
+
+                tokio::spawn(async move {
+                    let _permit = semaphore_cloned.acquire().await.unwrap();
+                    let job_clone = job.clone();
+                    let result = process_job(&app_cloned, job).await;
+
+                    finish_job(&job_clone).await;
+
+                    if let Err(error) = result {
+                        let _ = emit_created(
+                            &app_cloned,
+                            vec![ThumbResSpec {
+                                thumb_key: job_clone.thumb_key,
+                                status: ThumbStatus::Error,
+                                url: None,
+                                enqueued: false,
+                                error_msg: Some(error.to_string()),
+                            }],
+                        )
+                        .await;
+                    }
+                });
+
+                task::yield_now().await;
+                made_progress = true;
+            }
+
+            if !made_progress {
                 break;
-            };
-
-            let app_cloned = app.clone();
-            let semaphore_cloned = semaphore.clone();
-
-            tokio::spawn(async move {
-                let _permit = semaphore_cloned.acquire().await.unwrap();
-                let job_clone = job.clone();
-                let result = process_job(&app_cloned, job).await;
-
-                finish_job(&job_clone).await;
-
-                if let Err(error) = result {
-                    let _ = emit_created(
-                        &app_cloned,
-                        vec![ThumbResSpec {
-                            thumb_key: job_clone.thumb_key,
-                            status: ThumbStatus::Error,
-                            url: None,
-                            enqueued: false,
-                            error_msg: Some(error.to_string()),
-                        }],
-                    )
-                    .await;
-                }
-            });
-
-            task::yield_now().await;
+            }
         }
     }
 }
@@ -278,6 +309,8 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
 
     let source_path =
         fetch_one_file_path(job.moa_id.clone(), job.xxhs.clone()).await?;
+
+    cancel_pending_base_job(&job.xxhs).await;
 
     let file_kind = infer::get_from_path(&source_path)
         .context("failed to read file")?
@@ -450,6 +483,28 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
         timer_all.elapsed().as_millis(),
         if used_cache { "cache" } else { "original" }
     );
+
+    Ok(())
+}
+
+/// Generate a base thumbnail for the provided job.
+async fn process_base_job(
+    app: &AppHandle,
+    job: BaseThumbnailJob,
+) -> Result<()> {
+    if !job.source_path.exists() {
+        bail!("base source missing: {}", job.source_path.display());
+    }
+
+    let file_kind = infer::get_from_path(&job.source_path)
+        .context("failed to read file")?
+        .ok_or_else(|| anyhow!("unknown file type"))?;
+    if !file_kind.mime_type().starts_with("image/") {
+        bail!("unsupported mime type for base thumbnail generation");
+    }
+
+    ensure_base_thumbnail(app, &job.moa_id, &job.xxhs, &job.source_path)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- enqueue base thumbnail generation jobs during folder scans instead of blocking on `ensure_base_thumbnail`
- extend the thumbnail worker queue with base-thumbnail jobs and cancel pending duplicates when regular thumbnails execute
- process base thumbnail jobs in the background worker alongside regular thumbnail generation

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: unable to download index due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbe786e4c832ea44b566388d80ca3