### PR TITLE
Add folder preview-based import selection workflow

### DIFF
--- a/apps/desktop/src-tauri/src/commands/file.rs
+++ b/apps/desktop/src-tauri/src/commands/file.rs
@@ -1,6 +1,10 @@
+use std::path::PathBuf;
+
 use crate::{
-    models::file::{FolderData, ThumbRequest, ThumbResponse},
-    services::file_service::{self, first_mount_folder, get_thumbs},
+    models::file::{FolderData, FolderPreview, ThumbRequest, ThumbResponse},
+    services::file_service::{
+        self, collect_folder_preview, first_mount_folder, get_thumbs,
+    },
 };
 #[tauri::command]
 /// Create a virtual folder and optionally mount the provided filesystem path.
@@ -14,9 +18,15 @@ pub async fn create_folder(
         .map_err(|e| e.to_string())?;
 
     if let Some(path) = data.path.as_ref().filter(|path| !path.is_empty()) {
-        first_mount_folder(app_handle, moa_id.clone(), node, path.clone())
-            .await
-            .map_err(|e| e.to_string())?;
+        first_mount_folder(
+            app_handle,
+            moa_id.clone(),
+            node,
+            path.clone(),
+            data.selection.clone(),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
     }
     Ok(())
 }
@@ -33,4 +43,13 @@ pub async fn get_thumbnails(
         .map_err(|e| e.to_string())?;
 
     Ok(response)
+}
+
+#[tauri::command]
+/// Produce a preview of the selected folder prior to import.
+pub async fn preview_folder_import(
+    path: String,
+) -> Result<FolderPreview, String> {
+    let path = PathBuf::from(path);
+    collect_folder_preview(path.as_path()).await.map_err(|e| e.to_string())
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -42,6 +42,7 @@ fn main() {
             commands::moa::bootstrap_status,
             commands::graph::get_graph_one,
             commands::file::get_thumbnails,
+            commands::file::preview_folder_import,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -183,7 +183,16 @@ pub struct StorageRootInfo {
 
 /// Logical file types derived from file extensions.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type, Default,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    Type,
+    Default,
+    Hash,
 )]
 #[sqlx(type_name = "TEXT")]
 #[sqlx(rename_all = "lowercase")]

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -45,6 +45,65 @@ pub struct FolderData {
     pub name: String,
     pub path: Option<String>,
     pub parent_id: String,
+    pub selection: Option<FolderSelection>,
+}
+
+/// Describes the folder/file-type filters chosen by the user before import.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderSelection {
+    #[serde(default)]
+    pub entries: Vec<FolderSelectionEntry>,
+}
+
+/// Specific folder override provided by the user.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderSelectionEntry {
+    pub relative_path: String,
+    pub include: bool,
+    #[serde(default)]
+    pub file_types: Option<Vec<FileType>>,
+}
+
+/// Aggregated file statistics grouped by file type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderPreviewFileStat {
+    pub file_type: FileType,
+    pub count: u64,
+    pub bytes: u64,
+}
+
+/// Preview information about a folder and its descendants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderPreviewNode {
+    pub name: String,
+    pub path: String,
+    pub relative_path: String,
+    pub total_files: u64,
+    pub total_bytes: u64,
+    pub file_stats: Vec<FolderPreviewFileStat>,
+    pub children: Vec<FolderPreviewNode>,
+}
+
+/// Summary of the entire preview tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderPreviewSummary {
+    pub total_folders: u64,
+    pub total_files: u64,
+    pub total_bytes: u64,
+    pub file_type_totals: Vec<FolderPreviewFileStat>,
+}
+
+/// Full preview payload returned to the renderer before import.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FolderPreview {
+    pub root: FolderPreviewNode,
+    pub summary: FolderPreviewSummary,
 }
 
 /// Supported operating systems for storage roots.

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use async_recursion::async_recursion;
 use sqlx::{Sqlite, Transaction};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -16,7 +16,11 @@ use crate::{
         sroot_repository::SrootRepository,
     },
     models::{
-        file::{FileInfo, FileType, FolderData, RealFolderData},
+        file::{
+            FileInfo, FileType, FolderData, FolderPreview,
+            FolderPreviewFileStat, FolderPreviewNode, FolderPreviewSummary,
+            FolderSelection, RealFolderData,
+        },
         node::Node,
     },
     services::{
@@ -160,6 +164,217 @@ struct BucketStats {
     count: u64,
 }
 
+const FILE_TYPE_ORDER: [FileType; 7] = [
+    FileType::Image,
+    FileType::Video,
+    FileType::Document,
+    FileType::GraphicTool,
+    FileType::Audio,
+    FileType::Archive,
+    FileType::Unknown,
+];
+
+#[derive(Default)]
+struct SelectionPlan {
+    entries: HashMap<String, SelectionNode>,
+}
+
+#[derive(Clone, Default)]
+struct SelectionNode {
+    include: bool,
+    allowed_types: Option<HashSet<FileType>>,
+}
+
+impl SelectionPlan {
+    fn from_selection(selection: FolderSelection) -> Self {
+        let mut entries = HashMap::new();
+        for entry in selection.entries {
+            let key = normalize_relative_key(&entry.relative_path);
+            let allowed_types = entry
+                .file_types
+                .map(|types| types.into_iter().collect::<HashSet<FileType>>());
+            entries.insert(
+                key,
+                SelectionNode { include: entry.include, allowed_types },
+            );
+        }
+
+        SelectionPlan { entries }
+    }
+
+    fn get(&self, key: &str) -> Option<&SelectionNode> {
+        self.entries.get(key)
+    }
+}
+
+#[derive(Default)]
+struct PreviewAccumulator {
+    total_folders: u64,
+    total_files: u64,
+    total_bytes: u64,
+    file_type_totals: HashMap<FileType, PreviewFileStats>,
+}
+
+#[derive(Default)]
+struct PreviewFileStats {
+    count: u64,
+    bytes: u64,
+}
+
+fn normalize_relative_key(value: &str) -> String {
+    if value.is_empty() {
+        return String::new();
+    }
+
+    let replaced = value.replace('\\', "/");
+    let trimmed = replaced.trim_matches('/');
+    if trimmed.is_empty() || trimmed == "." {
+        String::new()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn relative_path_key(root: &Path, current: &Path) -> String {
+    if let Ok(relative) = current.strip_prefix(root) {
+        if relative.as_os_str().is_empty() {
+            return String::new();
+        }
+        return join_path_components(relative);
+    }
+
+    join_path_components(current)
+}
+
+fn join_path_components(path: &Path) -> String {
+    path.components()
+        .map(|c| c.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn stats_map_to_vec(
+    map: &HashMap<FileType, PreviewFileStats>,
+) -> Vec<FolderPreviewFileStat> {
+    let mut out = Vec::new();
+    for file_type in FILE_TYPE_ORDER {
+        if let Some(stats) = map.get(&file_type) {
+            if stats.count > 0 {
+                out.push(FolderPreviewFileStat {
+                    file_type,
+                    count: stats.count,
+                    bytes: stats.bytes,
+                });
+            }
+        }
+    }
+
+    out
+}
+
+/// Traverse the filesystem and produce a preview tree for the selected folder.
+pub async fn collect_folder_preview(path: &Path) -> Result<FolderPreview> {
+    let norm = normalize_path(path);
+
+    let mut accumulator = PreviewAccumulator::default();
+    let root =
+        collect_folder_preview_impl(&norm, &norm, &mut accumulator).await?;
+
+    let summary = FolderPreviewSummary {
+        total_folders: accumulator.total_folders,
+        total_files: accumulator.total_files,
+        total_bytes: accumulator.total_bytes,
+        file_type_totals: stats_map_to_vec(&accumulator.file_type_totals),
+    };
+
+    Ok(FolderPreview { root, summary })
+}
+
+#[async_recursion]
+async fn collect_folder_preview_impl(
+    abs_dir: &Path,
+    root: &Path,
+    accumulator: &mut PreviewAccumulator,
+) -> Result<FolderPreviewNode> {
+    accumulator.total_folders += 1;
+
+    let mut dir = fs::read_dir(abs_dir)
+        .await
+        .with_context(|| format!("failed to read_dir {:?}", abs_dir))?;
+
+    let mut children = Vec::new();
+    let mut local_stats: HashMap<FileType, PreviewFileStats> = HashMap::new();
+    let mut total_files = 0_u64;
+    let mut total_bytes = 0_u64;
+
+    while let Some(entry) = dir
+        .next_entry()
+        .await
+        .with_context(|| format!("failed to read entry under {:?}", abs_dir))?
+    {
+        let entry_path = entry.path();
+
+        if check_is_hidden(&entry_path) {
+            continue;
+        }
+
+        let file_type = entry.file_type().await.with_context(|| {
+            format!("failed to get file_type for {:?}", entry_path)
+        })?;
+
+        if file_type.is_symlink() {
+            continue;
+        }
+
+        if file_type.is_dir() {
+            let child =
+                collect_folder_preview_impl(&entry_path, root, accumulator)
+                    .await?;
+            children.push(child);
+            continue;
+        }
+
+        if file_type.is_file() {
+            let kind = FileType::from(entry_path.as_path());
+            let metadata = entry.metadata().await.with_context(|| {
+                format!("failed to get metadata for {:?}", entry_path)
+            })?;
+            let size = metadata.len();
+
+            total_files += 1;
+            total_bytes += size;
+
+            let local_entry = local_stats.entry(kind).or_default();
+            local_entry.count += 1;
+            local_entry.bytes += size;
+
+            let global_entry =
+                accumulator.file_type_totals.entry(kind).or_default();
+            global_entry.count += 1;
+            global_entry.bytes += size;
+
+            accumulator.total_files += 1;
+            accumulator.total_bytes += size;
+        }
+    }
+
+    let name = abs_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| abs_dir.to_string_lossy().into_owned());
+
+    Ok(FolderPreviewNode {
+        name,
+        path: abs_dir.to_string_lossy().into_owned(),
+        relative_path: relative_path_key(root, abs_dir),
+        total_files,
+        total_bytes,
+        file_stats: stats_map_to_vec(&local_stats),
+        children,
+    })
+}
+
 /// Create a new virtual folder inside a transaction.
 pub async fn create_folder(moa_id: String, data: FolderData) -> Result<Node> {
     let mut tx: Transaction<'_, Sqlite> =
@@ -183,10 +398,13 @@ pub async fn first_mount_folder(
     moa_id: String,
     node: Node,
     path: String,
+    selection: Option<FolderSelection>,
 ) -> Result<()> {
     let mut tx = DB_MANAGER.create_new_tx(&moa_id).await?;
 
     let norm_path = normalize_path(Path::new(&path));
+
+    let selection_plan = selection.map(SelectionPlan::from_selection);
 
     let sroot_info = storage_root::detect_storage_root(&norm_path)?;
 
@@ -210,6 +428,8 @@ pub async fn first_mount_folder(
         &norm_path,
         true,
         Some(true),
+        selection_plan.as_ref(),
+        &norm_path,
     )
     .await?;
 
@@ -238,6 +458,8 @@ async fn upsert_folder(
     abs_dir: &Path,
     recursive: bool,
     make_virtual_folder: Option<bool>,
+    selection: Option<&SelectionPlan>,
+    root_path: &Path,
 ) -> Result<()> {
     let mut metrics = UpsertFolderMetrics::default();
     let total_timer = Instant::now();
@@ -251,6 +473,9 @@ async fn upsert_folder(
         abs_dir,
         recursive,
         make_virtual_folder,
+        selection,
+        root_path,
+        None,
         &mut metrics,
     )
     .await?;
@@ -272,16 +497,39 @@ async fn upsert_folder_impl(
     abs_dir: &Path,
     recursive: bool,
     make_virtual_folder: Option<bool>,
+    selection: Option<&SelectionPlan>,
+    root_path: &Path,
+    inherited_allowed_types: Option<HashSet<FileType>>,
     metrics: &mut UpsertFolderMetrics,
 ) -> Result<()> {
     let make_vf = make_virtual_folder.unwrap_or(true);
+
+    let relative_key = relative_path_key(root_path, abs_dir);
+    let mut current_allowed = inherited_allowed_types;
+
+    if let Some(plan) = selection {
+        if let Some(node_selection) = plan.get(&relative_key) {
+            if !node_selection.include {
+                return Ok(());
+            }
+
+            if let Some(mut allowed) = node_selection.allowed_types.clone() {
+                if let Some(parent_allowed) = current_allowed.as_ref() {
+                    allowed =
+                        allowed.intersection(parent_allowed).cloned().collect();
+                }
+                current_allowed = Some(allowed);
+            }
+        }
+    }
 
     let tree_scan_timer = Instant::now();
     let mut dir = fs::read_dir(abs_dir)
         .await
         .with_context(|| format!("failed to read_dir {:?}", abs_dir))?;
 
-    let mut folder_entries: Vec<(PathBuf, String)> = Vec::new();
+    let mut folder_entries: Vec<(PathBuf, String, Option<HashSet<FileType>>)> =
+        Vec::new();
     while let Some(entry) = dir
         .next_entry()
         .await
@@ -304,8 +552,34 @@ async fn upsert_folder_impl(
         if file_type.is_dir() {
             let name = entry.file_name().to_string_lossy().to_string();
 
+            let mut include_child = true;
+            let mut child_allowed = current_allowed.clone();
+
+            if let Some(plan) = selection {
+                let child_key = relative_path_key(root_path, &entry_path);
+                if let Some(child_selection) = plan.get(&child_key) {
+                    if !child_selection.include {
+                        include_child = false;
+                    } else if let Some(mut allowed) =
+                        child_selection.allowed_types.clone()
+                    {
+                        if let Some(parent_allowed) = child_allowed.as_ref() {
+                            allowed = allowed
+                                .intersection(parent_allowed)
+                                .cloned()
+                                .collect();
+                        }
+                        child_allowed = Some(allowed);
+                    }
+                }
+            }
+
+            if !include_child {
+                continue;
+            }
+
             if recursive {
-                folder_entries.push((entry_path, name));
+                folder_entries.push((entry_path, name, child_allowed));
             } else if make_vf {
                 let folder_timer = Instant::now();
                 FileRepository::create_virtual_folder(
@@ -327,6 +601,7 @@ async fn upsert_folder_impl(
                 &parent_real_folder_id,
                 &parent_virtual_folder_id,
                 &entry,
+                current_allowed.as_ref(),
                 metrics,
             )
             .await
@@ -347,7 +622,7 @@ async fn upsert_folder_impl(
     .ok_or_else(|| anyhow!("parent_real_folder_id not found: {}", parent_real_folder_id))?;
 
     if recursive {
-        for (entry_path, name) in folder_entries {
+        for (entry_path, name, child_allowed) in folder_entries {
             let folder_timer = Instant::now();
             let child_vf = FileRepository::create_virtual_folder(
                 tx.as_mut(),
@@ -384,6 +659,9 @@ async fn upsert_folder_impl(
                 &entry_path,
                 recursive,
                 Some(make_vf),
+                selection,
+                root_path,
+                child_allowed,
                 metrics,
             )
             .await
@@ -404,12 +682,20 @@ async fn upsert_file_entry(
     parent_real_folder_id: &str,
     parent_virtual_folder_id: &str,
     entry: &fs::DirEntry,
+    allowed_types: Option<&HashSet<FileType>>,
     metrics: &mut UpsertFolderMetrics,
 ) -> Result<()> {
     let file_timer = Instant::now();
-    let file_name = entry.file_name().to_string_lossy().to_string();
-
     let file_path = entry.path();
+    let kind_guess = FileType::from(file_path.as_path());
+
+    if let Some(allowed) = allowed_types {
+        if !allowed.contains(&kind_guess) {
+            return Ok(());
+        }
+    }
+
+    let file_name = entry.file_name().to_string_lossy().to_string();
     let file_info =
         FileInfo::new(&file_path, parent_real_folder_id.to_string(), file_name)
             .await?;

--- a/apps/desktop/src-tauri/src/services/file_service/mod.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/mod.rs
@@ -7,7 +7,8 @@ pub mod thumbnail;
 pub mod utils;
 
 pub use folder::{
-    create_folder, ensure_real_folder, first_mount_folder, start_scan_job,
+    collect_folder_preview, create_folder, ensure_real_folder,
+    first_mount_folder, start_scan_job,
 };
 pub use hash::{sha256_of_img, xxh3_64_of};
 pub use job_queue::{

--- a/apps/desktop/src/features/file/modal/NewFolderModal.tsx
+++ b/apps/desktop/src/features/file/modal/NewFolderModal.tsx
@@ -1,62 +1,625 @@
 import { open } from '@tauri-apps/plugin-dialog';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button } from '@tgim/ui/index';
 import { Input } from '@tgim/ui/Input';
-import React, { useState } from 'react';
+import { FileType, FolderPreview, FolderPreviewFileStat, FolderSelection } from '@tgim/types/file';
+
+import { ipc } from '../../../lib/ipc';
 
 interface Props {
   onClose: () => void;
-  onSubmit: (data: any) => void;
+  onSubmit: (data: {
+    name: string;
+    path: string;
+    selection?: FolderSelection;
+  }) => Promise<void> | void;
 }
 
+type SelectionState = {
+  include: boolean;
+  fileTypes: Set<FileType> | null;
+};
+
+type EffectiveSelection = {
+  include: boolean;
+  types: Set<FileType>;
+};
+
+type NodeIndexEntry = {
+  node: FolderPreview['root'];
+  parent: string | null;
+};
+
+const FILE_TYPE_ORDER: FileType[] = [
+  FileType.Image,
+  FileType.Video,
+  FileType.Document,
+  FileType.GraphicTool,
+  FileType.Audio,
+  FileType.Archive,
+  FileType.Unknown,
+];
+
+const FILE_TYPE_LABELS: Record<FileType, string> = {
+  [FileType.Image]: '이미지',
+  [FileType.Video]: '비디오',
+  [FileType.Document]: '문서',
+  [FileType.GraphicTool]: '그래픽',
+  [FileType.Audio]: '오디오',
+  [FileType.Archive]: '압축',
+  [FileType.Unknown]: '기타',
+};
+
+const formatBytes = (bytes: number) => {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let idx = 0;
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024;
+    idx += 1;
+  }
+  const fixed = value >= 10 ? value.toFixed(0) : value.toFixed(2);
+  return `${fixed} ${units[idx]}`;
+};
+
+const getStatForType = (stats: FolderPreviewFileStat[] | undefined, fileType: FileType) =>
+  stats?.find(stat => stat.fileType === fileType) ?? { count: 0, bytes: 0 };
+
+const areSetsEqual = (a: Set<FileType>, b: Set<FileType>) => {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+};
+
+const buildNodeIndex = (root: FolderPreview['root'] | null) => {
+  const map = new Map<string, NodeIndexEntry>();
+  if (!root) return map;
+
+  const walk = (node: FolderPreview['root'], parent: string | null) => {
+    const key = node.relativePath ?? '';
+    map.set(key, { node, parent });
+    node.children.forEach(child => walk(child, key));
+  };
+
+  walk(root, null);
+  return map;
+};
+
+const flattenNodes = (root: FolderPreview['root'] | null) => {
+  const out: FolderPreview['root'][] = [];
+  if (!root) return out;
+
+  const walk = (node: FolderPreview['root']) => {
+    node.children.forEach(child => {
+      out.push(child);
+      walk(child);
+    });
+  };
+
+  walk(root);
+  return out;
+};
+
+const initializeSelection = (preview: FolderPreview) => {
+  const initial = new Map<string, SelectionState>();
+  const rootKey = preview.root.relativePath ?? '';
+  const rootTypes = new Set<FileType>(preview.summary.fileTypeTotals.map(stat => stat.fileType));
+
+  if (rootTypes.size === 0) {
+    FILE_TYPE_ORDER.forEach(type => rootTypes.add(type));
+  }
+
+  const walk = (node: FolderPreview['root']) => {
+    const key = node.relativePath ?? '';
+    initial.set(key, {
+      include: true,
+      fileTypes: key === rootKey ? new Set(rootTypes) : null,
+    });
+    node.children.forEach(walk);
+  };
+
+  walk(preview.root);
+  return initial;
+};
+
+const buildEffectiveSelections = (
+  preview: FolderPreview | null,
+  selection: Map<string, SelectionState>,
+) => {
+  const effective = new Map<string, EffectiveSelection>();
+  if (!preview) return effective;
+
+  const rootKey = preview.root.relativePath ?? '';
+  const rootState = selection.get(rootKey);
+  const rootIncluded = rootState?.include ?? true;
+  const rootTypes = rootState?.fileTypes ? new Set(rootState.fileTypes) : new Set(FILE_TYPE_ORDER);
+
+  const walk = (
+    node: FolderPreview['root'],
+    parentTypes: Set<FileType>,
+    ancestorsIncluded: boolean,
+  ) => {
+    const key = node.relativePath ?? '';
+    const state = selection.get(key);
+    const isIncluded = ancestorsIncluded && (state?.include ?? true);
+
+    let allowedTypes: Set<FileType>;
+    if (!ancestorsIncluded || !isIncluded) {
+      allowedTypes = new Set<FileType>();
+    } else if (state?.fileTypes) {
+      allowedTypes = new Set(Array.from(state.fileTypes).filter(type => parentTypes.has(type)));
+    } else {
+      allowedTypes = new Set(parentTypes);
+    }
+
+    effective.set(key, { include: isIncluded, types: allowedTypes });
+
+    node.children.forEach(child => walk(child, allowedTypes, isIncluded));
+  };
+
+  walk(preview.root, rootTypes, rootIncluded);
+  return effective;
+};
+
+const computeSelectionSummary = (
+  preview: FolderPreview | null,
+  effective: Map<string, EffectiveSelection>,
+) => {
+  const totals = FILE_TYPE_ORDER.reduce(
+    (acc, type) => {
+      acc[type] = { count: 0, bytes: 0 };
+      return acc;
+    },
+    {} as Record<FileType, { count: number; bytes: number }>,
+  );
+
+  const summary = {
+    totalFolders: 0,
+    totalFiles: 0,
+    totalBytes: 0,
+    fileTypeTotals: totals,
+  };
+
+  if (!preview) return summary;
+
+  const walk = (node: FolderPreview['root']) => {
+    const key = node.relativePath ?? '';
+    const entry = effective.get(key);
+    if (!entry || !entry.include) return;
+
+    summary.totalFolders += 1;
+    node.fileStats.forEach(stat => {
+      if (!entry.types.has(stat.fileType)) return;
+      summary.totalFiles += stat.count;
+      summary.totalBytes += stat.bytes;
+      summary.fileTypeTotals[stat.fileType].count += stat.count;
+      summary.fileTypeTotals[stat.fileType].bytes += stat.bytes;
+    });
+
+    node.children.forEach(walk);
+  };
+
+  walk(preview.root);
+  return summary;
+};
+
+const buildSelectionPayload = (
+  selection: Map<string, SelectionState>,
+  rootKey: string,
+): FolderSelection => {
+  const entries = Array.from(selection.entries())
+    .map(([relativePath, state]) => ({
+      relativePath,
+      include: state.include,
+      fileTypes: state.fileTypes ? Array.from(state.fileTypes) : undefined,
+    }))
+    .filter(entry => {
+      if (entry.relativePath === rootKey) return true;
+      if (!entry.include) return true;
+      return entry.fileTypes !== undefined;
+    });
+
+  return { entries };
+};
+
 const NewFolderModal: React.FC<Props> = ({ onClose, onSubmit }) => {
+  const [step, setStep] = useState<'details' | 'selection'>('details');
   const [name, setName] = useState('');
   const [path, setPath] = useState('');
-  const handleSubmit = () => {
+  const [preview, setPreview] = useState<FolderPreview | null>(null);
+  const [selection, setSelection] = useState<Map<string, SelectionState>>(new Map());
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const nodeIndex = useMemo(() => buildNodeIndex(preview?.root ?? null), [preview]);
+  const effectiveSelections = useMemo(
+    () => buildEffectiveSelections(preview, selection),
+    [preview, selection],
+  );
+  const flattenedNodes = useMemo(() => flattenNodes(preview?.root ?? null), [preview]);
+  const summary = useMemo(
+    () => computeSelectionSummary(preview, effectiveSelections),
+    [preview, effectiveSelections],
+  );
+
+  const rootKey = preview?.root?.relativePath ?? '';
+  const rootState = selection.get(rootKey);
+  const rootEffective = effectiveSelections.get(rootKey);
+
+  const updateSelection = useCallback(
+    (key: string, updater: (current: SelectionState) => SelectionState) => {
+      setSelection(prev => {
+        const next = new Map(prev);
+        const current = next.get(key) ?? { include: true, fileTypes: null };
+        next.set(key, updater(current));
+        return next;
+      });
+    },
+    [],
+  );
+
+  const fetchPreview = useCallback(async (selectedPath: string) => {
+    setLoadingPreview(true);
+    setPreviewError(null);
+    try {
+      const data = await ipc.file.previewFolderImport(selectedPath);
+      setPreview(data);
+      setSelection(initializeSelection(data));
+    } catch (error) {
+      console.error(error);
+      setPreview(null);
+      setSelection(new Map());
+      setPreviewError('폴더 정보를 불러오는 데 실패했습니다.');
+    } finally {
+      setLoadingPreview(false);
+    }
+  }, []);
+
+  const handlePickFolder = useCallback(async () => {
+    const result = await open({ directory: true });
+    if (!result) return;
+
+    const selected = Array.isArray(result) ? result[0] : result;
+    if (!selected) return;
+
+    setPath(selected);
+    await fetchPreview(selected);
+  }, [fetchPreview]);
+
+  const handleRootIncludeToggle = useCallback(
+    (include: boolean) => {
+      if (!preview) return;
+      updateSelection(rootKey, current => ({ ...current, include }));
+    },
+    [preview, rootKey, updateSelection],
+  );
+
+  const handleRootFileTypeToggle = useCallback(
+    (fileType: FileType) => {
+      if (!rootState || !preview) return;
+      updateSelection(rootKey, current => {
+        const base = new Set(current.fileTypes ?? []);
+        if (base.has(fileType)) {
+          base.delete(fileType);
+        } else {
+          base.add(fileType);
+        }
+        return { ...current, fileTypes: base };
+      });
+    },
+    [preview, rootKey, rootState, updateSelection],
+  );
+
+  const handleFolderIncludeToggle = useCallback(
+    (key: string, include: boolean) => {
+      const parentKey = nodeIndex.get(key)?.parent ?? null;
+      if (parentKey !== null) {
+        const parentEffective = effectiveSelections.get(parentKey);
+        if (parentEffective && !parentEffective.include) {
+          return;
+        }
+      }
+      updateSelection(key, current => ({ ...current, include }));
+    },
+    [effectiveSelections, nodeIndex, updateSelection],
+  );
+
+  const handleFolderFileTypeToggle = useCallback(
+    (key: string, fileType: FileType) => {
+      const parentKey = nodeIndex.get(key)?.parent ?? null;
+      const parentEffective = parentKey !== null ? effectiveSelections.get(parentKey) : undefined;
+      if (parentEffective && !parentEffective.include) {
+        return;
+      }
+
+      const parentTypes = parentEffective?.types ?? new Set<FileType>();
+      updateSelection(key, current => {
+        const base = current.fileTypes ? new Set(current.fileTypes) : new Set(parentTypes);
+
+        if (base.has(fileType)) {
+          base.delete(fileType);
+        } else {
+          if (parentKey !== null && !parentTypes.has(fileType)) {
+            return current;
+          }
+          base.add(fileType);
+        }
+
+        const nextTypes = parentKey !== null && areSetsEqual(base, parentTypes) ? null : base;
+        return { ...current, fileTypes: nextTypes };
+      });
+    },
+    [effectiveSelections, nodeIndex, updateSelection],
+  );
+
+  const handleResetFolderTypes = useCallback(
+    (key: string) => {
+      updateSelection(key, current => ({ ...current, fileTypes: null }));
+    },
+    [updateSelection],
+  );
+
+  const handleNext = useCallback(() => {
     if (!name.trim()) {
       alert('폴더 이름을 입력하세요.');
       return;
     }
-    onSubmit({ name, path });
-    onClose();
-  };
+    if (!path) {
+      alert('실제 폴더 경로를 선택하세요.');
+      return;
+    }
+    if (previewError) {
+      alert('폴더 정보를 불러오는 데 실패했습니다. 다시 시도하세요.');
+      return;
+    }
+    if (!preview || loadingPreview) {
+      alert('폴더 구조를 불러오는 중입니다. 잠시만 기다려주세요.');
+      return;
+    }
+    setStep('selection');
+  }, [loadingPreview, name, path, preview, previewError]);
 
-  const pickFolder = async () => {
-    const result = await open({ directory: true });
-    setPath(result ?? '');
-  };
+  const handleSubmit = useCallback(async () => {
+    if (!preview) return;
+    setSubmitting(true);
+    try {
+      const payload = buildSelectionPayload(selection, rootKey);
+      await onSubmit({
+        name: name.trim(),
+        path,
+        selection: payload.entries.length ? payload : undefined,
+      });
+      onClose();
+    } catch (error) {
+      console.error(error);
+      alert('폴더를 생성하는 중 오류가 발생했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [name, onClose, onSubmit, path, preview, rootKey, selection]);
+
+  const canProceed = !!name.trim() && !!path && !!preview && !loadingPreview && !previewError;
 
   return (
     <div className="text-modal-text">
-      <div className="" onClick={onClose}></div>
-      <div className="">
-        <h2>새 폴더 만들기</h2>
-        <Input
-          className="bg-modal-input-bg hover:bg-modal-input-hover shadow-lg mt-5"
-          placeholder="폴더 이름"
-          value={name}
-          onChange={e => setName(e.target.value)}
-        />
-        <div className="flex mt-3">
-          <Input
-            className="read-only:bg-transparent shadow-lg truncate"
-            readOnly
-            placeholder="실제 폴더 경로"
-            value={path}
-            onChange={e => setName(e.target.value)}
-          />
-          <Button
-            variant="default"
-            className="whitespace-nowrap bg-modal-input-bg hover:bg-modal-input-hover ml-4"
-            onClick={pickFolder}
-          >
-            찾기
+      <div className="flex flex-col gap-6">
+        {step === 'details' ? (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">새 폴더 만들기</h2>
+            <Input
+              className="bg-modal-input-bg hover:bg-modal-input-hover shadow-lg"
+              placeholder="폴더 이름"
+              value={name}
+              onChange={event => setName(event.target.value)}
+            />
+            <div className="flex items-center gap-3">
+              <Input
+                className="read-only:bg-transparent shadow-lg truncate"
+                readOnly
+                placeholder="실제 폴더 경로"
+                value={path}
+              />
+              <Button
+                variant="default"
+                className="whitespace-nowrap bg-modal-input-bg hover:bg-modal-input-hover"
+                onClick={handlePickFolder}
+              >
+                찾기
+              </Button>
+            </div>
+            {loadingPreview && (
+              <p className="text-sm text-modal-text-secondary">폴더 구조를 불러오는 중입니다...</p>
+            )}
+            {previewError && <p className="text-sm text-red-400">{previewError}</p>}
+            {preview && !loadingPreview && !previewError && (
+              <div className="rounded-md bg-modal-input-bg/60 p-3 text-sm">
+                <div>폴더: {preview.summary.totalFolders.toLocaleString()}개</div>
+                <div>
+                  파일: {preview.summary.totalFiles.toLocaleString()}개 ·{' '}
+                  {formatBytes(preview.summary.totalBytes)}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-lg font-semibold">가져오기 옵션 선택</h2>
+              <p className="text-sm text-modal-text-secondary">
+                전체 요약에서 파일 유형을 선택하고, 하위 폴더별로 세부 옵션을 조정하세요.
+              </p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <section className="space-y-4 rounded-lg border border-modal-input-bg p-4">
+                <h3 className="font-medium">전체 요약</h3>
+                <div className="space-y-2 text-sm">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={rootState?.include ?? true}
+                      onChange={event => handleRootIncludeToggle(event.target.checked)}
+                    />
+                    전체 폴더 포함
+                  </label>
+                  <div>
+                    선택된 폴더:{' '}
+                    <span className="font-semibold">{summary.totalFolders.toLocaleString()}</span> /{' '}
+                    {preview?.summary.totalFolders.toLocaleString() ?? 0}
+                  </div>
+                  <div>
+                    선택된 파일:{' '}
+                    <span className="font-semibold">{summary.totalFiles.toLocaleString()}</span> /{' '}
+                    {preview?.summary.totalFiles.toLocaleString() ?? 0}
+                  </div>
+                  <div>
+                    선택된 용량:{' '}
+                    <span className="font-semibold">{formatBytes(summary.totalBytes)}</span> /{' '}
+                    {formatBytes(preview?.summary.totalBytes ?? 0)}
+                  </div>
+                </div>
+                <div className="space-y-2 text-sm">
+                  {FILE_TYPE_ORDER.map(type => {
+                    const total = getStatForType(preview?.summary.fileTypeTotals, type);
+                    const selected = summary.fileTypeTotals[type];
+                    const isChecked = rootEffective?.types.has(type) ?? true;
+                    return (
+                      <label key={type} className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          disabled={!rootState?.include}
+                          onChange={() => handleRootFileTypeToggle(type)}
+                        />
+                        <span className="flex-1">
+                          {FILE_TYPE_LABELS[type]} · {selected.count.toLocaleString()}개 /{' '}
+                          {total.count.toLocaleString()}개
+                        </span>
+                        <span className="text-xs text-modal-text-secondary">
+                          {formatBytes(selected.bytes)} / {formatBytes(total.bytes)}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </section>
+              <section className="space-y-3 rounded-lg border border-modal-input-bg p-4">
+                <h3 className="font-medium">폴더별 세부 설정</h3>
+                <div className="max-h-72 space-y-3 overflow-y-auto pr-2 text-sm">
+                  {flattenedNodes.map(node => {
+                    const key = node.relativePath ?? '';
+                    if (key === rootKey) return null;
+                    const state = selection.get(key) ?? {
+                      include: true,
+                      fileTypes: null,
+                    };
+                    const effective = effectiveSelections.get(key);
+                    const parentKey = nodeIndex.get(key)?.parent ?? null;
+                    const parentEffective =
+                      parentKey !== null ? effectiveSelections.get(parentKey) : undefined;
+                    const ancestorIncluded = parentEffective ? parentEffective.include : true;
+                    const depth = key ? key.split('/').filter(Boolean).length : 0;
+                    const containerClasses = ancestorIncluded
+                      ? 'rounded-md border border-modal-input-bg/60 p-3'
+                      : 'rounded-md border border-modal-input-bg/60 p-3 opacity-50';
+
+                    const typesForFolder = FILE_TYPE_ORDER.filter(type => {
+                      const stat = getStatForType(node.fileStats, type);
+                      const hasExplicit = state.fileTypes?.has(type) ?? false;
+                      return stat.count > 0 || hasExplicit;
+                    });
+
+                    return (
+                      <div key={key} className={containerClasses}>
+                        <div className="flex items-center justify-between">
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              checked={state.include}
+                              disabled={!ancestorIncluded}
+                              onChange={event =>
+                                handleFolderIncludeToggle(key, event.target.checked)
+                              }
+                            />
+                            <span className="font-medium" style={{ paddingLeft: depth * 12 }}>
+                              {node.name}
+                            </span>
+                          </label>
+                          {state.fileTypes && (
+                            <Button
+                              variant="ghost"
+                              className="px-2 py-1 text-xs text-modal-text-secondary"
+                              onClick={() => handleResetFolderTypes(key)}
+                            >
+                              초기화
+                            </Button>
+                          )}
+                        </div>
+                        {typesForFolder.length > 0 ? (
+                          <div className="mt-3 space-y-2">
+                            {typesForFolder.map(type => {
+                              const stat = getStatForType(node.fileStats, type);
+                              const isAllowed = effective?.types.has(type) ?? false;
+                              const parentTypes = parentEffective?.types ?? new Set<FileType>();
+                              const disabled =
+                                !ancestorIncluded ||
+                                !state.include ||
+                                (parentKey !== null && !parentTypes.has(type));
+                              return (
+                                <label key={type} className="flex items-center gap-2">
+                                  <input
+                                    type="checkbox"
+                                    checked={isAllowed}
+                                    disabled={disabled}
+                                    onChange={() => handleFolderFileTypeToggle(key, type)}
+                                  />
+                                  <span className="flex-1">
+                                    {FILE_TYPE_LABELS[type]} · {stat.count.toLocaleString()}개
+                                  </span>
+                                  <span className="text-xs text-modal-text-secondary">
+                                    {formatBytes(stat.bytes)}
+                                  </span>
+                                </label>
+                              );
+                            })}
+                          </div>
+                        ) : (
+                          <p className="mt-3 text-xs text-modal-text-secondary">
+                            표시할 파일이 없습니다.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                  {flattenedNodes.length === 0 && (
+                    <p className="text-xs text-modal-text-secondary">하위 폴더가 없습니다.</p>
+                  )}
+                </div>
+              </section>
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end gap-3">
+          <Button onClick={onClose} disabled={submitting}>
+            취소
           </Button>
-        </div>
-        <div className="w-full flex justify-end mt-5">
-          <Button onClick={onClose}>취소</Button>
-          <Button variant="primary" onClick={handleSubmit}>
-            생성
-          </Button>
+          {step === 'selection' ? (
+            <>
+              <Button variant="outline" onClick={() => setStep('details')} disabled={submitting}>
+                이전
+              </Button>
+              <Button variant="primary" onClick={handleSubmit} disabled={submitting}>
+                업서트
+              </Button>
+            </>
+          ) : (
+            <Button variant="primary" onClick={handleNext} disabled={!canProceed}>
+              다음
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/apps/desktop/src/features/file/modal/NewFolderModal.tsx
+++ b/apps/desktop/src/features/file/modal/NewFolderModal.tsx
@@ -550,7 +550,7 @@ const NewFolderModal: React.FC<Props> = ({ onClose, onSubmit }) => {
                           </label>
                           {state.fileTypes && (
                             <Button
-                              variant="ghost"
+                              variant="default"
                               className="px-2 py-1 text-xs text-modal-text-secondary"
                               onClick={() => handleResetFolderTypes(key)}
                             >
@@ -608,7 +608,7 @@ const NewFolderModal: React.FC<Props> = ({ onClose, onSubmit }) => {
           </Button>
           {step === 'selection' ? (
             <>
-              <Button variant="outline" onClick={() => setStep('details')} disabled={submitting}>
+              <Button variant="default" onClick={() => setStep('details')} disabled={submitting}>
                 이전
               </Button>
               <Button variant="primary" onClick={handleSubmit} disabled={submitting}>

--- a/apps/desktop/src/features/main/panel/FileTreePanel.tsx
+++ b/apps/desktop/src/features/main/panel/FileTreePanel.tsx
@@ -196,16 +196,18 @@ export const FileTree = () => {
         <Modal onClose={() => setIsFolderModal(false)} className="bg-modal-bg">
           <NewFolderModal
             onClose={() => setIsFolderModal(false)}
-            onSubmit={d => {
+            onSubmit={async d => {
               if (!moaId) return;
               try {
-                ipc.graph.createFolder(moaId, {
+                await ipc.graph.createFolder(moaId, {
                   name: d.name,
                   path: d.path,
                   parent_id: optionNode?.id ?? 'root',
+                  selection: d.selection,
                 });
               } catch (err) {
                 console.error(err);
+                throw err;
               }
             }}
           />

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -7,7 +7,6 @@ import { useMoa } from '@tgim/hooks/useMoa';
 import GraphView from './panels/GraphView';
 import {
   Connection,
-  FileType,
   GraphConnection,
   GraphData,
   GraphNode,
@@ -22,7 +21,7 @@ import { createNewId } from '@tgim/utils/identifier';
 import GridView from './panels/GridView';
 import { GridData, ImageItem } from '@tgim/types/grid';
 import { listen } from '@tauri-apps/api/event';
-import { ThumbResSpec } from '@tgim/types/file';
+import { FileType, ThumbResSpec } from '@tgim/types/file';
 import { Button } from '@tgim/ui';
 import cn from '@tgim/utils/cn';
 import { GitBranch, LayoutGrid } from 'lucide-react';
@@ -90,8 +89,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
 
     const getGraphNodeData = (node: Node, graphNodeId?: string): GraphNode => {
       const defaultSize = 14;
-      const nodeSize =
-        node.id == graphData.root_node_id ? defaultSize * 1.6 : defaultSize;
+      const nodeSize = node.id == graphData.root_node_id ? defaultSize * 1.6 : defaultSize;
       if (!graphNodeId) graphNodeId = createNewId();
 
       if (node.kind == NodeKind.File && node.data['File']) {
@@ -231,8 +229,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   }, [graphData, rootNodeId]);
   if (!panel || !container) return null;
 
-  const showGraph =
-    viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
+  const showGraph = viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
   const showGrid = viewType === 'grid' && !!gridData;
 
   return ReactDOM.createPortal(

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1,17 +1,13 @@
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
-import { ThumbRequest, ThumbResponse } from '@tgim/types/file';
+import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
+
 const appWindow = getCurrentWindow();
 
 // Thin wrappers around Tauri invoke calls to keep React components lean.
 const windowControllerIpc = {
-  minimize: async () => {
-    await appWindow.minimize();
-  minimize: () => {
-    appWindow.minimize();
-  },
-  maximize: async () => {
+  minimize: () => appWindow.minimize(),
   maximize: async () => {
     const isMaximized = await appWindow.isMaximized();
     if (isMaximized) {
@@ -20,11 +16,7 @@ const windowControllerIpc = {
     }
     await appWindow.maximize();
   },
-  close: async () => {
-    await appWindow.close();
-  close: () => {
-    appWindow.close();
-  },
+  close: () => appWindow.close(),
 };
 
 const moaIpc = {
@@ -36,15 +28,13 @@ const moaIpc = {
     }[];
     return response;
   },
-  createMoa: async (data: {
-    name: string;
-    path: string;
-  }): Promise<{ name: string; path: string; moaId: string }> => {
+  createMoa: async (data: { name: string; path: string }) => {
     const response = (await invoke('create_moa', { moa: data })) as {
       name: string;
       path: string;
       moaId: string;
     };
+    return response;
   },
   openMoa: async (moaId: string) => {
     await invoke('open_moa', { moaId });
@@ -56,8 +46,8 @@ const moaIpc = {
 };
 
 const graphIpc = {
-  createFolder: (moaId: string, data: { name: string; path: string; parent_id: string }) => {
-    invoke('create_folder', { moaId, data });
+  createFolder: async (moaId: string, data: CreateFolderPayload) => {
+    await invoke('create_folder', { moaId, data });
   },
   getGraphOne: async (moaId: string, nodeId: string): Promise<GraphResponse> => {
     const response = await invoke('get_graph_one', { moaId, nodeId });
@@ -66,9 +56,13 @@ const graphIpc = {
 };
 
 const fileIpc = {
-  getThumbnails: async (moaId: String, data: ThumbRequest) => {
+  getThumbnails: async (moaId: string, data: ThumbRequest) => {
     const response = await invoke('get_thumbnails', { data, moaId });
     return response as ThumbResponse;
+  },
+  previewFolderImport: async (path: string): Promise<FolderPreview> => {
+    const response = await invoke('preview_folder_import', { path });
+    return response as FolderPreview;
   },
 };
 

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -1,4 +1,12 @@
-import { FileType } from './graph';
+export enum FileType {
+  Image = 'image',
+  Video = 'video',
+  Document = 'document',
+  GraphicTool = 'graphictool',
+  Audio = 'audio',
+  Archive = 'archive',
+  Unknown = 'unknown',
+}
 
 export type ThumbJobStatus = 'ready' | 'pending' | 'error';
 

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -1,3 +1,5 @@
+import { FileType } from './graph';
+
 export type ThumbJobStatus = 'ready' | 'pending' | 'error';
 
 export type ThumbEntry = {
@@ -62,4 +64,49 @@ export interface ThumbResInfo {
 
 export interface ThumbResponse {
   items: ThumbResInfo[];
+}
+
+export interface FolderPreviewFileStat {
+  fileType: FileType;
+  count: number;
+  bytes: number;
+}
+
+export interface FolderPreviewNode {
+  name: string;
+  path: string;
+  relativePath: string;
+  totalFiles: number;
+  totalBytes: number;
+  fileStats: FolderPreviewFileStat[];
+  children: FolderPreviewNode[];
+}
+
+export interface FolderPreviewSummary {
+  totalFolders: number;
+  totalFiles: number;
+  totalBytes: number;
+  fileTypeTotals: FolderPreviewFileStat[];
+}
+
+export interface FolderPreview {
+  root: FolderPreviewNode;
+  summary: FolderPreviewSummary;
+}
+
+export interface FolderSelectionEntry {
+  relativePath: string;
+  include: boolean;
+  fileTypes?: FileType[];
+}
+
+export interface FolderSelection {
+  entries: FolderSelectionEntry[];
+}
+
+export interface CreateFolderPayload {
+  name: string;
+  path: string;
+  parent_id: string;
+  selection?: FolderSelection;
 }

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -1,3 +1,5 @@
+import { FileType } from './file';
+
 export interface GraphResponse {
   nodes: Node[];
   connections: Connection[];
@@ -74,16 +76,6 @@ export interface NodeFile {
   kind: FileType;
   file_name: string;
   size: number;
-}
-
-export enum FileType {
-  Image = 'image',
-  Video = 'video',
-  Document = 'document',
-  GraphicTool = 'graphictool',
-  Audio = 'audio',
-  Archive = 'archive',
-  Unknown = 'unknown',
 }
 
 export enum RelationType {


### PR DESCRIPTION
## Summary
* introduce folder preview and selection structures plus IPC endpoints so the desktop app can request a filtered import tree before mounting
* extend the folder service to build preview trees and respect the user’s allowed folders/file types when creating mounts and ingesting files
* refresh the new-folder modal, IPC utilities, and shared types to drive the multi-step preview UI and submit the chosen selection back to Tauri

## Testing
* `cargo fmt`
* `cargo clippy --all-targets -- -D warnings` *(fails: index fetch blocked with 403)*
* `pnpm format:write`
* `pnpm lint:check` *(fails: missing npm dependencies due to registry 403)*
* `pnpm --filter @grim/desktop build` *(fails: missing npm dependencies due to registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0e194bfc832ebb41587e77a826f7