### PR TITLE
Fix thumbnail event wiring and masonry fetching

### DIFF
--- a/apps/desktop/src/features/main/Main.tsx
+++ b/apps/desktop/src/features/main/Main.tsx
@@ -9,14 +9,12 @@ import useSidebarStore from '@tgim/stores/sidebarStore';
 import { useShallow } from 'zustand/shallow';
 import useFileTreeStore from '@tgim/stores/fileTreeStore';
 import { useMoa } from '@tgim/hooks';
-import { listen } from '@tauri-apps/api/event';
 import ProgressWindow from './ProgressWindow';
 
 import usePanelsStore from '@tgim/stores/panelStore';
 import PanelContainer from './panel/Container';
-import { ThumbResSpec } from '@tgim/types/file';
-import useThumbStore from '@tgim/stores/thumbStore';
 import { useTheme } from '../../theme/ThemeProvider';
+import { ensureThumbEventListener, disposeThumbEventListener } from '../../hooks/thumbs';
 
 interface LayoutPorps {
   layoutId: string;
@@ -153,39 +151,37 @@ const Main: React.FC = () => {
       leftSidebar: state.sidebars.left,
     })),
   );
-  const { upsertThumb } = useThumbStore(
-    useShallow(state => ({
-      upsertThumb: state.upsert,
-    })),
-  );
   // React to thumbnail worker updates to keep local caches in sync.
   useEffect(() => {
     if (!moaId) {
       return undefined;
     }
 
+    let disposed = false;
     let unlisten: (() => void) | undefined;
-    const initListener = async () => {
-      unlisten = await listen<{ items: ThumbResSpec[] }>(
-        'thumbnails://created',
-        event => {
-          event.payload.items.forEach(item => {
-            upsertThumb(item.thumb_key, {
-              status: 'ready',
-              url: item.url,
-              updatedAt: Date.now(),
-            });
-          });
-        },
-      );
-    };
 
-    void initListener();
+    ensureThumbEventListener()
+      .then(stop => {
+        if (disposed) {
+          stop();
+          return;
+        }
+        unlisten = stop;
+      })
+      .catch(error => {
+        console.error('Failed to bind thumbnail events', error);
+      });
 
     return () => {
-      unlisten?.();
+      disposed = true;
+      if (unlisten) {
+        unlisten();
+        unlisten = undefined;
+      } else {
+        void disposeThumbEventListener();
+      }
     };
-  }, [moaId, upsertThumb]);
+  }, [moaId]);
 
   // Load the initial graph and subscribe to bootstrap progress events.
   useEffect(() => {
@@ -208,12 +204,9 @@ const Main: React.FC = () => {
     void load();
 
     const initListener = async () => {
-      unlisten = await listen<AppProgressEvent>(
-        `bootstrap://progress/${moaId}`,
-        event => {
-          setProgressQueue(prev => [...prev, event.payload]);
-        },
-      );
+      unlisten = await listen<AppProgressEvent>(`bootstrap://progress/${moaId}`, event => {
+        setProgressQueue(prev => [...prev, event.payload]);
+      });
     };
 
     void initListener();
@@ -239,7 +232,10 @@ const Main: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden" data-theme={theme}>
+    <div
+      className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden"
+      data-theme={theme}
+    >
       {!isMac && (
         <div className="fixed w-full top-0 z-50">
           <TitleBar />

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -90,8 +90,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
 
     const getGraphNodeData = (node: Node, graphNodeId?: string): GraphNode => {
       const defaultSize = 14;
-      const nodeSize =
-        node.id == graphData.root_node_id ? defaultSize * 1.6 : defaultSize;
+      const nodeSize = node.id == graphData.root_node_id ? defaultSize * 1.6 : defaultSize;
       if (!graphNodeId) graphNodeId = createNewId();
 
       if (node.kind == NodeKind.File && node.data['File']) {
@@ -110,6 +109,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           label: data.file_name ?? 'file',
           size: nodeSize,
           type: type,
+          hash: data.xxh3_64,
         };
       } else if (node.kind == NodeKind.Folder && node.data['Folder']) {
         let data = node.data['Folder'];
@@ -231,8 +231,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   }, [graphData, rootNodeId]);
   if (!panel || !container) return null;
 
-  const showGraph =
-    viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
+  const showGraph = viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
   const showGrid = viewType === 'grid' && !!gridData;
 
   return ReactDOM.createPortal(

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -3,11 +3,14 @@ import { Connection, GraphConnection, GraphData } from '@tgim/types/graph';
 import { NodeRenderer, clearNodeSpriteCaches, getGraphPalette } from '@tgim/ui/index';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
-import { useShallow } from 'zustand/shallow';
 import * as d3 from 'd3-force';
-import useThumbStore from '@tgim/stores/thumbStore';
+import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
 import { useMoa } from '@tgim/hooks/useMoa';
 import { useTheme } from '../../../../theme/ThemeProvider';
+import { prefetchThumbs } from '@tgim/hooks/useThumb';
+import { ResizeMode } from '@tgim/types/file';
+import { makeThumbFetcher } from '../../../../hooks/thumbs';
+import { useShallow } from 'zustand/shallow';
 
 interface Props {
   graphData: GraphData;
@@ -45,13 +48,6 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
       }
     };
   }, []);
-  const { upsertThumb, thumb } = useThumbStore(
-    useShallow(s => ({
-      upsertThumb: s.upsert,
-      thumb: s.byKey,
-    })),
-  );
-
   const nodesById = useMemo(() => {
     if (!graphData) return {};
     const nodesById = Object.fromEntries(graphData.nodes.map(node => [node.id, node]));
@@ -67,12 +63,42 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
   }, [graphData.nodes]);
   const { moaId } = useMoa(location);
 
+  const [dpr] = useState(() =>
+    typeof window !== 'undefined' ? Math.min(2, Math.round(window.devicePixelRatio || 1)) : 1,
+  );
+  const thumbFetcher = useMemo(() => makeThumbFetcher(moaId), [moaId]);
+
   useEffect(() => {
-    graphData.nodes.forEach(node => {
-      if (node.type == 'image' && !node.url) {
-      }
+    if (!moaId) {
+      return;
+    }
+    const imageNodes = graphData.nodes.filter(node => node.type === 'image' && (node as any).hash);
+    if (imageNodes.length === 0) {
+      return;
+    }
+
+    imageNodes.forEach(node => {
+      const hash = (node as any).hash;
+      if (!hash) return;
+      node.thumbKey = convertToThumbKey(hash, {
+        width: 64,
+        height: 64,
+        dpr,
+        mode: ResizeMode.Original,
+      });
     });
-  }, [moaId, graphData.nodes]);
+
+    void prefetchThumbs(
+      imageNodes.map(node => ({
+        hash: (node as any).hash,
+        spec: { width: 64, height: 64, dpr, mode: ResizeMode.Original },
+      })),
+      thumbFetcher,
+      { attach: true },
+    ).then(() => {
+      fgRef.current?.refresh();
+    });
+  }, [graphData.nodes, thumbFetcher, dpr, moaId]);
 
   const GAP = 90;
   const LEAF_OFFSET = 10;
@@ -135,6 +161,18 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
     });
     setPrunedTree(getPrunedTree());
   };
+
+  useEffect(() => {
+    const unsubscribe = useThumbStore.subscribe(
+      state => state.lru,
+      () => {
+        fgRef.current?.refresh();
+      },
+    );
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   const { openNode } = usePanelsStore(useShallow(s => ({ openNode: s.addPanelWithoutContainer })));
   useEffect(() => {

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -1,15 +1,13 @@
-import { listen } from '@tauri-apps/api/event';
 import { useMoa } from '@tgim/hooks/useMoa';
 import { GridData, ImageItem } from '@tgim/types/grid';
-import { ipc } from '../../../../lib/ipc';
-import React, { useEffect, useMemo, useRef, useState, useCallback, CSSProperties } from 'react';
-import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { useThumb, type ThumbFetcher, type ThumbEventBus } from '@tgim/hooks/useThumb';
 import { ResizeMode } from '@tgim/types/file';
-import { useShallow } from 'zustand/shallow';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import Masonry from 'react-masonry-css';
 import { FixedSizeGrid as WindowGrid } from 'react-window';
 import { Button } from '@tgim/ui';
+import { makeThumbFetcher, thumbEventBus } from '../../../../hooks/thumbs';
 
 /* ---------------------------------------------
  * Helper Icon Components (unchanged)
@@ -67,17 +65,6 @@ type Layout = 'grid' | 'masonry';
 
 const SIZES: Size[] = ['small', 'medium', 'large'];
 const LAYOUTS: Layout[] = ['grid', 'masonry'];
-const MAX_ITEMS_PER_REQ = 100;
-const INITIAL_FETCH_COUNT = 50;
-
-// Debounce Hook (unchanged)
-function useDebouncedEffect(fn: () => void, deps: React.DependencyList, delay: number) {
-  useEffect(() => {
-    const handler = setTimeout(() => fn(), delay);
-    return () => clearTimeout(handler);
-  }, [fn, ...deps]);
-}
-
 // Visibility Hook (unchanged)
 function useVisibilityMap(rootRef: React.RefObject<HTMLElement>, overscanPx = 600) {
   const ioRef = useRef<IntersectionObserver | null>(null);
@@ -168,122 +155,36 @@ const GridView: React.FC<Props> = ({ gridData }) => {
   const [images] = useState(gridData.images);
 
   // Map for quick lookup by hash
-  const hashToImgMap = useMemo(() => {
-    const map: Record<string, ImageItem> = {};
-    images.forEach(img => (map[img.hash] = img));
-    return map;
-  }, [images]);
-
-  const { upsertThumb } = useThumbStore(
-    useShallow(state => ({
-      upsertThumb: state.upsert,
-    })),
-  );
-
   const scrollRef = useRef<HTMLDivElement>(null);
   // @ts-expect-error.
   const { visible, observe, unobserve } = useVisibilityMap(scrollRef, 800);
 
-  const thumbSize = useMemo(() => {
+  const [dpr] = useState(() =>
+    typeof window !== 'undefined' ? Math.min(2, Math.round(window.devicePixelRatio || 1)) : 1,
+  );
+  const thumbFetcher = useMemo(() => makeThumbFetcher(moaId), [moaId]);
+
+  const gridThumbSize = useMemo(() => {
     switch (size) {
       case 'small':
         return 96;
       case 'large':
-        return 256;
+        return 192;
       default:
-        return 128;
+        return 144;
     }
   }, [size]);
 
-  /* -------------------------------------------------
-   * Thumbnail fetcher
-   * NOTE: Prevent duplicate work by checking store.
-   * ------------------------------------------------- */
-  const fetchThumbnails = useCallback(
-    async (itemsToFetch: ImageItem[]) => {
-      if (moaId === null || itemsToFetch.length === 0) return;
-
-      const currentThumbs = useThumbStore.getState().byKey;
-
-      const toRequest = itemsToFetch
-        .map(img => {
-          const key = convertToThumbKey(img.hash, {
-            width: thumbSize,
-            height: thumbSize,
-            dpr: 1,
-            mode: ResizeMode.Original,
-          });
-          // Skip if already ready
-          if (currentThumbs[key]?.status === 'ready') return null;
-          return {
-            xxhs: img.hash,
-            specs: [
-              { width: thumbSize, height: thumbSize, dpr: 1, mode: ResizeMode.Original, key },
-            ],
-          };
-        })
-        .filter(Boolean) as any[];
-
-      if (toRequest.length === 0) return;
-
-      for (let i = 0; i < toRequest.length; i += MAX_ITEMS_PER_REQ) {
-        const chunk = toRequest.slice(i, i + MAX_ITEMS_PER_REQ);
-        try {
-          const responses = await ipc.file.getThumbnails(moaId, { items: chunk });
-          responses.items.forEach((item: any) => {
-            item.specs.forEach((spec: any) => {
-              upsertThumb(spec.thumb_key ?? spec.key, {
-                status: spec.status === 'hit' ? 'ready' : 'pending',
-                url: spec.status === 'hit' ? spec.url : undefined,
-                updatedAt: Date.now(),
-              });
-            });
-          });
-        } catch (error) {
-          console.error('Failed to fetch thumbnails:', error);
-        }
-      }
-    },
-    [moaId, thumbSize, upsertThumb],
-  );
-
-  // Stable ref to avoid stale closure
-  const stableFetchThumbnails = useRef(fetchThumbnails);
-  useEffect(() => {
-    stableFetchThumbnails.current = fetchThumbnails;
-  }, [fetchThumbnails]);
-
-  // Initial warm-up
-  useEffect(() => {
-    const initialItems = images.slice(0, INITIAL_FETCH_COUNT);
-    stableFetchThumbnails.current(initialItems);
-  }, [images]);
-
-  /* -------------------------------------------------
-   * Fetch for Masonry via IntersectionObserver
-   * (Grid uses react-window onItemsRendered; see below)
-   * ------------------------------------------------- */
-  const visibleItems = useMemo(() => {
-    return Object.keys(visible)
-      .filter(k => visible[k])
-      .map(hash => hashToImgMap[hash])
-      .filter(Boolean);
-  }, [visible, hashToImgMap]);
-
-  useDebouncedEffect(
-    () => {
-      if (layout === 'masonry' && visibleItems.length > 0) {
-        stableFetchThumbnails.current(visibleItems);
-      }
-    },
-    [visibleItems, layout],
-    120,
-  );
-
-  // Handler for grid layout to request thumbs by index ranges
-  const handleNeedThumbs = useCallback((items: ImageItem[]) => {
-    if (items.length) stableFetchThumbnails.current(items);
-  }, []);
+  const masonryThumbWidth = useMemo(() => {
+    switch (size) {
+      case 'small':
+        return 160;
+      case 'large':
+        return 320;
+      default:
+        return 256;
+    }
+  }, [size]);
 
   const gridItemSizeClass = useMemo(() => {
     if (layout === 'masonry') {
@@ -309,12 +210,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
         <div className="flex items-center gap-6">
           <div className="flex items-center gap-1 rounded-full border border-border bg-surface-muted p-1 shadow-inner">
             {SIZES.map(s => (
-              <Button
-                key={s}
-                variant="toggle"
-                active={size === s}
-                onClick={() => setSize(s)}
-              >
+              <Button key={s} variant="toggle" active={size === s} onClick={() => setSize(s)}>
                 {s.charAt(0).toUpperCase() + s.slice(1)}
               </Button>
             ))}
@@ -354,8 +250,10 @@ const GridView: React.FC<Props> = ({ gridData }) => {
             observe={() => {}}
             unobserve={() => {}}
             selectMode={selectMode}
-            thumbSize={thumbSize}
-            onNeedThumbs={handleNeedThumbs}
+            thumbSize={gridThumbSize}
+            fetcher={thumbFetcher}
+            dpr={dpr}
+            eventBus={thumbEventBus}
           />
         ) : (
           <MasonryLayout
@@ -365,7 +263,11 @@ const GridView: React.FC<Props> = ({ gridData }) => {
             onItemClick={handleItemClick}
             observe={observe}
             unobserve={unobserve}
-            thumbSize={thumbSize}
+            thumbSize={masonryThumbWidth}
+            fetcher={thumbFetcher}
+            dpr={dpr}
+            visibleMap={visible}
+            eventBus={thumbEventBus}
           />
         )}
       </div>
@@ -389,7 +291,9 @@ function VirtualGridLayout({
   unobserve, // no-op in grid path
   selectMode,
   thumbSize,
-  onNeedThumbs,
+  fetcher,
+  dpr,
+  eventBus,
 }: {
   images: ImageItem[];
   size: Size;
@@ -398,7 +302,9 @@ function VirtualGridLayout({
   unobserve: (el: Element | null) => void;
   selectMode: boolean;
   thumbSize: number;
-  onNeedThumbs: (items: ImageItem[]) => void;
+  fetcher: ThumbFetcher;
+  dpr: number;
+  eventBus: ThumbEventBus;
 }) {
   const itemW = size === 'small' ? 96 : size === 'large' ? 192 : 144;
   const itemH = itemW;
@@ -410,36 +316,6 @@ function VirtualGridLayout({
 
   const cols = Math.max(1, Math.floor((width + gap) / (itemW + gap)));
   const rowCount = Math.ceil(images.length / cols);
-
-  // Request thumbs for rows/cols in overscan range (debounced via RAF)
-  const rafRef = useRef<number | null>(null);
-  const pendingRangeRef = useRef<{ rs: number; re: number } | null>(null);
-
-  const scheduleFetchForRange = useCallback(
-    (rs: number, re: number) => {
-      // Merge with pending range to reduce calls
-      if (!pendingRangeRef.current) {
-        pendingRangeRef.current = { rs, re };
-      } else {
-        pendingRangeRef.current = {
-          rs: Math.min(pendingRangeRef.current.rs, rs),
-          re: Math.max(pendingRangeRef.current.re, re),
-        };
-      }
-      if (rafRef.current != null) return;
-      rafRef.current = requestAnimationFrame(() => {
-        const r = pendingRangeRef.current;
-        rafRef.current = null;
-        pendingRangeRef.current = null;
-        if (!r) return;
-        const startIdx = r.rs * cols;
-        const endIdxExclusive = Math.min(images.length, (r.re + 1) * cols);
-        const slice = images.slice(startIdx, endIdxExclusive);
-        onNeedThumbs(slice);
-      });
-    },
-    [cols, images, onNeedThumbs],
-  );
 
   const Cell = useCallback(
     ({ columnIndex, rowIndex, style }: any) => {
@@ -464,11 +340,28 @@ function VirtualGridLayout({
             observe={observe}
             unobserve={unobserve}
             thumbSize={thumbSize}
+            fetcher={fetcher}
+            dpr={dpr}
+            isVisible
+            eventBus={eventBus}
           />
         </div>
       );
     },
-    [cols, images, itemW, itemH, onItemClick, selectMode, observe, unobserve, gap, thumbSize],
+    [
+      cols,
+      images,
+      itemW,
+      itemH,
+      onItemClick,
+      selectMode,
+      observe,
+      unobserve,
+      gap,
+      thumbSize,
+      fetcher,
+      dpr,
+    ],
   );
 
   return (
@@ -483,10 +376,6 @@ function VirtualGridLayout({
           width={width}
           overscanRowCount={5} // ↑ a bit more generous overscan to hide fetch latency
           overscanColumnCount={1}
-          onItemsRendered={({ overscanRowStartIndex, overscanRowStopIndex }) => {
-            // Proactively fetch thumbnails for overscanned rows
-            scheduleFetchForRange(overscanRowStartIndex, overscanRowStopIndex);
-          }}
         >
           {Cell}
         </WindowGrid>
@@ -507,7 +396,23 @@ function MasonryLayout({
   observe,
   unobserve,
   thumbSize,
-}: any) {
+  fetcher,
+  dpr,
+  visibleMap,
+  eventBus,
+}: {
+  images: ImageItem[];
+  onItemClick: (img: ImageItem) => void;
+  sizeClass: string;
+  selectMode: boolean;
+  observe: (el: Element | null, key: string) => void;
+  unobserve: (el: Element | null) => void;
+  thumbSize: number;
+  fetcher: ThumbFetcher;
+  dpr: number;
+  visibleMap: Record<string, boolean>;
+  eventBus: ThumbEventBus;
+}) {
   const breakpointColumnsObj = { default: 6, 1536: 6, 1280: 5, 1024: 4, 768: 3, 640: 2 };
   return (
     <Masonry
@@ -526,6 +431,10 @@ function MasonryLayout({
             observe={observe}
             unobserve={unobserve}
             thumbSize={thumbSize}
+            fetcher={fetcher}
+            dpr={dpr}
+            isVisible={!!visibleMap[img.hash]}
+            eventBus={eventBus}
           />
         </div>
       ))}
@@ -545,6 +454,10 @@ type ThumbCardProps = {
   unobserve: (el: Element | null) => void;
   thumbSize: number;
   sizeClass?: string;
+  fetcher: ThumbFetcher;
+  dpr: number;
+  isVisible?: boolean;
+  eventBus: ThumbEventBus;
 };
 
 const ThumbCardComponent: React.FC<ThumbCardProps> = ({
@@ -556,44 +469,96 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
   unobserve,
   sizeClass,
   thumbSize,
+  fetcher,
+  dpr,
+  isVisible = false,
+  eventBus,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const lastRequestRef = useRef(0);
 
-  const key = useMemo(
-    () =>
-      convertToThumbKey(img.hash, {
-        width: thumbSize,
-        height: thumbSize,
-        dpr: 1,
-        mode: ResizeMode.Original,
-      }),
-    [img.hash, thumbSize],
+  const spec = useMemo(
+    () => ({
+      width: thumbSize,
+      height: layout === 'masonry' ? 0 : thumbSize,
+      dpr,
+      mode: ResizeMode.Original,
+    }),
+    [thumbSize, layout, dpr],
   );
 
-  const { entry } = useThumbStore(useShallow(state => ({ entry: state.byKey[key] })));
+  const { url, status, refetch } = useThumb(img.hash, spec, {
+    fetcher,
+    attach: true,
+    retryOnError: true,
+    autoFetch: layout !== 'masonry',
+    eventBus,
+  });
+
   const [stableSrc, setStableSrc] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (entry?.status === 'ready' && entry.url) {
-      setStableSrc(convertFileSrc(entry.url));
+    if (!url) {
+      setStableSrc(undefined);
+      setLoaded(false);
+      return;
     }
-  }, [entry]);
+    const resolved = url.startsWith('blob:') ? url : convertFileSrc(url);
+    setStableSrc(resolved);
+    setLoaded(false);
+  }, [url]);
 
   useEffect(() => {
+    if (layout !== 'masonry') {
+      return undefined;
+    }
     const el = containerRef.current;
-    // Observe by hash to match visibility map keys
     observe(el, img.hash);
     return () => unobserve(el);
-  }, [img.hash, observe, unobserve]);
+  }, [layout, img.hash, observe, unobserve]);
+
+  useEffect(() => {
+    if (!isVisible) {
+      lastRequestRef.current = 0;
+    }
+  }, [isVisible]);
+
+  useEffect(() => {
+    if (layout !== 'masonry') return;
+    if (!isVisible) return;
+    if (status === 'ready' || status === 'pending') return;
+
+    const now = Date.now();
+    if (now - lastRequestRef.current < 750) return;
+
+    lastRequestRef.current = now;
+    refetch();
+  }, [layout, isVisible, status, refetch]);
 
   const handleImageLoad = useCallback(() => setLoaded(true), []);
   const handleCardClick = useCallback(() => onClick(img), [onClick, img]);
 
+  const containerClasses = `group relative w-full ${
+    layout === 'masonry' ? 'h-auto' : 'h-full'
+  } overflow-hidden rounded-lg border border-border bg-surface shadow-sm transition-all duration-200 hover:border-accent hover:shadow-lg hover:-translate-y-1 cursor-pointer ${
+    sizeClass ?? ''
+  }`;
+
+  const imageWrapperClass = `relative w-full ${
+    layout === 'masonry' ? 'h-auto min-h-[6rem]' : 'h-full'
+  }`;
+
+  const imageClass = `w-full ${
+    layout === 'masonry' ? 'h-auto' : 'h-full'
+  } object-cover transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`;
+
+  const showPlaceholder = !stableSrc || !loaded;
+
   return (
     <div
       ref={containerRef}
-      className={`group relative w-full h-full overflow-hidden rounded-lg border border-border bg-surface shadow-sm transition-all duration-200 hover:border-accent hover:shadow-lg hover:-translate-y-1 cursor-pointer ${sizeClass ?? ''}`}
+      className={containerClasses}
       onClick={handleCardClick}
       role="button"
       tabIndex={0}
@@ -607,13 +572,13 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
           />
         </div>
       )}
-      <div className="relative w-full h-full">
-        {!stableSrc && <div className="w-full h-full bg-surface-muted animate-pulse" />}
+      <div className={imageWrapperClass}>
+        {showPlaceholder && <div className="w-full h-full bg-surface-muted animate-pulse" />}
         {stableSrc && (
           <img
             src={stableSrc}
             alt={img.name}
-            className={`w-full h-full object-cover transition-opacity duration-300 ${loaded ? 'opacity-100' : 'opacity-0'}`}
+            className={imageClass}
             onLoad={handleImageLoad}
             loading="lazy"
             decoding="async"

--- a/apps/desktop/src/hooks/thumbs.ts
+++ b/apps/desktop/src/hooks/thumbs.ts
@@ -1,0 +1,127 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { ThumbFetcher, type ThumbEventBus } from '@tgim/hooks/useThumb';
+import useThumbStore, { parseThumbKey, type ThumbKey } from '@tgim/stores/thumbStore';
+import {
+  ResizeMode,
+  ThumbRequest,
+  ThumbResSpec,
+  ThumbStatus as ThumbResponseStatus,
+} from '@tgim/types/file';
+import { ipc } from '../lib/ipc';
+
+type ThumbEventHandler = (payload: { key: ThumbKey; url?: string; error?: string }) => void;
+
+class IpcThumbEventBus implements ThumbEventBus {
+  private listeners: Record<'thumb_ready' | 'thumb_error', Set<ThumbEventHandler>> = {
+    thumb_ready: new Set(),
+    thumb_error: new Set(),
+  };
+
+  on(event: 'thumb_ready' | 'thumb_error', cb: ThumbEventHandler) {
+    const bucket = this.listeners[event];
+    bucket.add(cb);
+    return () => {
+      bucket.delete(cb);
+    };
+  }
+
+  emit(
+    event: 'thumb_ready' | 'thumb_error',
+    payload: { key: ThumbKey; url?: string; error?: string },
+  ) {
+    for (const handler of this.listeners[event]) {
+      handler(payload);
+    }
+  }
+}
+
+export const thumbEventBus = new IpcThumbEventBus();
+
+const applyThumbSpecs = (specs: ThumbResSpec[]) => {
+  const store = useThumbStore.getState();
+
+  for (const spec of specs) {
+    const key = spec.thumb_key ?? spec.key;
+    if (!key) continue;
+
+    if (spec.status === ThumbResponseStatus.Hit && spec.url) {
+      store.upsert(key, { status: 'ready', url: spec.url });
+      thumbEventBus.emit('thumb_ready', { key, url: spec.url });
+    } else if (spec.status === ThumbResponseStatus.Error) {
+      const message = spec.error_msg ?? 'thumbnail error';
+      store.upsert(key, { status: 'error', error: message });
+      thumbEventBus.emit('thumb_error', { key, error: message });
+    } else if (spec.status === ThumbResponseStatus.Miss) {
+      store.upsert(key, { status: 'missing' });
+    }
+  }
+
+  store.evictLRU();
+};
+
+let thumbEventListener: Promise<UnlistenFn> | null = null;
+
+export const ensureThumbEventListener = () => {
+  if (!thumbEventListener) {
+    thumbEventListener = listen<{ items: ThumbResSpec[] }>('thumbnails://created', event => {
+      const items = event.payload?.items ?? [];
+      applyThumbSpecs(items);
+    });
+  }
+  return thumbEventListener;
+};
+
+export const disposeThumbEventListener = async () => {
+  if (!thumbEventListener) return;
+  const unlisten = await thumbEventListener;
+  unlisten();
+  thumbEventListener = null;
+};
+
+export const makeThumbFetcher = (moaId: string | null): ThumbFetcher => {
+  return async ({ key, hash }) => {
+    if (!moaId) {
+      return { missing: true } as const;
+    }
+
+    const parsed = parseThumbKey(key);
+    if (!parsed) {
+      throw new Error(`Invalid thumbnail key: ${key}`);
+    }
+
+    const request: ThumbRequest = {
+      items: [
+        {
+          xxhs: hash,
+          specs: [
+            {
+              width: parsed.width,
+              height: parsed.height,
+              dpr: (parsed.dpr as 1 | 2 | 3) ?? 1,
+              mode: parsed.mode === 'upscale' ? ResizeMode.Upscale : ResizeMode.Original,
+              key,
+            },
+          ],
+        },
+      ],
+    };
+
+    const response = await ipc.file.getThumbnails(moaId, request);
+    const info = response.items?.find(item => item.xxhs === hash);
+    const spec = info?.specs?.find(s => (s.thumb_key ?? s.key) === key);
+
+    if (!spec) {
+      return { missing: true } as const;
+    }
+
+    if (spec.status === ThumbResponseStatus.Hit && spec.url) {
+      return { url: spec.url } as const;
+    }
+
+    if (spec.status === ThumbResponseStatus.Error) {
+      throw new Error(spec.error_msg ?? 'thumbnail error');
+    }
+
+    return { missing: true } as const;
+  };
+};

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,1 +1,2 @@
 export * from './useMoa';
+export * from './useThumb';

--- a/packages/hooks/src/useThumb.ts
+++ b/packages/hooks/src/useThumb.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ThumbSpec } from '@tgim/types/file';
+import useThumbStore, {
+  ThumbEntryEx,
+  ThumbKey,
+  ThumbStatus,
+  convertToThumbKey,
+} from '@tgim/stores/thumbStore';
+
+export type ThumbFetcher = (params: {
+  key: ThumbKey;
+  hash: string;
+}) => Promise<{ url: string } | { blob: Blob } | { missing: true }>;
+
+export interface ThumbEventBus {
+  on: (
+    event: 'thumb_ready' | 'thumb_error',
+    cb: (payload: { key: ThumbKey; url?: string; error?: string }) => void,
+  ) => () => void;
+}
+
+export interface UseThumbOptions {
+  /** Custom fetcher used when the cache is stale or missing. */
+  fetcher: ThumbFetcher;
+  /** Auto-attach hash -> key relationship for easier invalidation. */
+  attach?: boolean;
+  /** Automatically retry when the previous status was error or missing. */
+  retryOnError?: boolean;
+  /** Automatically trigger fetch on mount. */
+  autoFetch?: boolean;
+  /** Optional bus for late notifications from background workers. */
+  eventBus?: ThumbEventBus;
+}
+
+export interface UseThumbResult {
+  url?: string;
+  status: ThumbStatus;
+  error?: string;
+  refetch: () => void;
+  key: ThumbKey;
+  updatedAt: number;
+}
+
+const isBrowser = typeof window !== 'undefined' && typeof URL !== 'undefined';
+
+export const useThumb = (
+  hash: string,
+  spec: Partial<ThumbSpec> & { v?: number },
+  options: UseThumbOptions,
+): UseThumbResult => {
+  const { fetcher, attach = true, retryOnError = true, autoFetch = true, eventBus } = options;
+  const key = useMemo(
+    () =>
+      convertToThumbKey(hash, {
+        width: spec.width,
+        height: spec.height,
+        dpr: spec.dpr,
+        mode: spec.mode,
+        v: spec.v,
+      }),
+    [hash, spec.width, spec.height, spec.dpr, spec.mode, spec.v],
+  );
+  const store = useThumbStore;
+  const entry = store.getState().getByKey(key);
+
+  useEffect(() => {
+    if (!attach) return;
+    store.getState().attach(hash, key);
+  }, [attach, hash, key, store]);
+
+  const [, forceRender] = useState(0);
+  useEffect(() => {
+    const unsub = store.subscribe(
+      state => state.byKey[key],
+      () => forceRender(prev => prev + 1),
+    );
+    return () => unsub();
+  }, [key, store]);
+
+  const doFetch = useCallback(async () => {
+    const st = store.getState();
+
+    const inflight = st.inflight.get(key);
+    if (inflight) return inflight;
+
+    st.upsert(key, { status: 'pending', error: undefined });
+
+    const promise: Promise<ThumbEntryEx> = (async () => {
+      try {
+        const result = await fetcher({ key, hash });
+        if ('missing' in result) {
+          st.upsert(key, { status: 'missing' });
+        } else if ('blob' in result) {
+          const url = isBrowser ? URL.createObjectURL(result.blob) : '';
+          st.upsert(key, { status: 'ready', url });
+        } else if ('url' in result) {
+          st.upsert(key, { status: 'ready', url: result.url });
+        }
+        st.evictLRU();
+        return st.getByKey(key)!;
+      } catch (error: any) {
+        st.upsert(key, { status: 'error', error: String(error?.message ?? error) });
+        return st.getByKey(key)!;
+      } finally {
+        store.getState().setInflight(key, undefined);
+      }
+    })();
+
+    store.getState().setInflight(key, promise);
+    return promise;
+  }, [fetcher, hash, key, store]);
+
+  useEffect(() => {
+    if (!autoFetch) return;
+    const current = store.getState().getByKey(key);
+    if (!current || current.status === 'missing' || (retryOnError && current.status === 'error')) {
+      void doFetch();
+    }
+  }, [autoFetch, doFetch, key, retryOnError, store]);
+
+  useEffect(() => {
+    if (!eventBus) return;
+    const offReady = eventBus.on('thumb_ready', ({ key: readyKey, url }) => {
+      if (readyKey === key && url) {
+        store.getState().upsert(key, { status: 'ready', url });
+      }
+    });
+    const offError = eventBus.on('thumb_error', ({ key: errorKey, error }) => {
+      if (errorKey === key) {
+        store.getState().upsert(key, { status: 'error', error });
+      }
+    });
+    return () => {
+      offReady();
+      offError();
+    };
+  }, [eventBus, key, store]);
+
+  return {
+    url: entry?.url,
+    status: entry?.status ?? 'pending',
+    error: entry?.error,
+    refetch: () => {
+      void doFetch();
+    },
+    key,
+    updatedAt: entry?.updatedAt ?? 0,
+  };
+};
+
+export const prefetchThumbs = async (
+  items: Array<{ hash: string; spec: Partial<ThumbSpec> & { v?: number } }>,
+  fetcher: ThumbFetcher,
+  options: { attach?: boolean } = {},
+) => {
+  const { attach = false } = options;
+  const st = useThumbStore.getState();
+  const tasks: Promise<ThumbEntryEx>[] = [];
+
+  for (const { hash, spec } of items) {
+    const key = convertToThumbKey(hash, spec);
+    const existing = st.getByKey(key);
+    if (attach) {
+      st.attach(hash, key);
+    }
+
+    if (existing && existing.status === 'ready') {
+      continue;
+    }
+
+    if (st.inflight.get(key)) {
+      continue;
+    }
+
+    st.upsert(key, { status: 'pending', error: undefined });
+
+    const task: Promise<ThumbEntryEx> = (async () => {
+      try {
+        const result = await fetcher({ key, hash });
+        if ('missing' in result) {
+          st.upsert(key, { status: 'missing' });
+        } else if ('blob' in result) {
+          const url = isBrowser ? URL.createObjectURL(result.blob) : '';
+          st.upsert(key, { status: 'ready', url });
+        } else if ('url' in result) {
+          st.upsert(key, { status: 'ready', url: result.url });
+        }
+        return st.getByKey(key)!;
+      } catch (error: any) {
+        st.upsert(key, { status: 'error', error: String(error?.message ?? error) });
+        return st.getByKey(key)!;
+      } finally {
+        useThumbStore.getState().setInflight(key, undefined);
+      }
+    })();
+
+    useThumbStore.getState().setInflight(key, task);
+    tasks.push(task);
+  }
+
+  if (tasks.length > 0) {
+    await Promise.allSettled(tasks);
+    st.evictLRU();
+  }
+};
+
+export type { ThumbStatus } from '@tgim/stores/thumbStore';

--- a/packages/stores/src/thumbStore.ts
+++ b/packages/stores/src/thumbStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
-import { ThumbEntry, ThumbSpec } from '@tgim/types/file';
+import type { ThumbEntry, ThumbSpec } from '@tgim/types/file';
 
 /**
  * key_format:
@@ -9,51 +9,99 @@ import { ThumbEntry, ThumbSpec } from '@tgim/types/file';
  * - `<hash>`: xxhs_64
  * - `<WxH>`: width x height
  * - `dpr<1|2>`: device pixel ratio
- * - `<upscale|original>`: is resized when original image smaller than requested size
+ * - `<upscale|original>`: resize strategy
  * - `<version>`: schema version
- *
- * @example
- * const k1 = "adsfas_128x128_dpr1_upscale_v1";
- * const k2 = "xyz123_512x512_dpr2_original_v3";
  */
-type ThumbKey = string;
-type Hash = string;
+export type ThumbKey = string;
+export type Hash = string;
+
+const isBrowser = typeof window !== 'undefined' && typeof URL !== 'undefined';
+
+export type ThumbStatus = 'pending' | 'ready' | 'error' | 'missing';
+
+export interface ThumbEntryEx extends ThumbEntry {
+  status: ThumbStatus;
+  /** blob/object URL */
+  url?: string;
+  /** epoch ms */
+  updatedAt: number;
+  /** optional error payload */
+  error?: string;
+  /** optional schema version */
+  v?: number;
+}
+
+export interface ThumbStoreOptions {
+  /** LRU capacity (number of keys to keep with blob URLs). */
+  maxLRU: number;
+  /** TTL in ms to consider an entry stale (only for `pending` or `error`). */
+  ttlMs: number;
+}
 
 interface ThumbState {
-  byKey: Record<ThumbKey, ThumbEntry>;
+  byKey: Record<ThumbKey, ThumbEntryEx>;
   byHash: Record<Hash, ThumbKey[]>; // hash -> set of key
-  lru: ThumbKey[]; // least resently used cache. (oldest first, least end)
+  lru: ThumbKey[]; // least recently used (oldest first)
+  options: ThumbStoreOptions;
 
-  upsert: (thumbKey: ThumbKey, patch: Partial<ThumbEntry>) => void;
+  // runtime: in-flight fetches (dedupe)
+  inflight: Map<ThumbKey, Promise<ThumbEntryEx>>;
+
+  // mutations
+  upsert: (thumbKey: ThumbKey, patch: Partial<ThumbEntryEx>) => void;
   touch: (thumbKey: ThumbKey) => void;
   attach: (hash: string, thumbKey: ThumbKey) => void;
-  evictLRU: (max: number) => void;
+  evictLRU: (max?: number) => void;
+  purgeStale: () => void;
+  clearAll: () => void;
+  detachByHash: (hash: string) => void;
 
+  // getters
   getThumbPathByKey: (key: ThumbKey) => string | undefined;
+  getByKey: (key: ThumbKey) => ThumbEntryEx | undefined;
+  getKeysByHash: (hash: string) => ThumbKey[];
+
+  // inflight helpers
+  setInflight: (key: ThumbKey, p?: Promise<ThumbEntryEx>) => void;
 }
+
+export const defaultThumbOptions: ThumbStoreOptions = {
+  maxLRU: 500,
+  ttlMs: 30_000,
+};
 
 export const useThumbStore = create<ThumbState>()(
   immer((set, get) => ({
     byKey: {},
     byHash: {},
     lru: [],
+    options: defaultThumbOptions,
+    inflight: new Map(),
 
     upsert: (key, patch) => {
-      const cur = get().byKey[key] ?? { status: 'pending', updatedAt: 0, v: 1 };
-      const prevUrl = cur.url;
-      const next = { ...cur, ...patch, updatedAt: Date.now() };
+      const cur = get().byKey[key];
+      const prevUrl = cur?.url;
+      const now = Date.now();
+      const next: ThumbEntryEx = {
+        ...cur,
+        ...patch,
+        status: patch.status ?? cur?.status ?? 'pending',
+        updatedAt: now,
+        v: patch.v ?? cur?.v ?? 1,
+      } as ThumbEntryEx;
+
       set(s => {
         s.byKey[key] = next;
 
-        // Revoke previous blob URL if replaced to avoid leaks
-        // (safe-guard: don't revoke if same string)
-        if (prevUrl && prevUrl !== next.url && prevUrl.startsWith('blob:')) {
+        if (isBrowser && prevUrl && prevUrl !== next.url && prevUrl.startsWith('blob:')) {
           try {
             URL.revokeObjectURL(prevUrl);
-          } catch {}
+          } catch {
+            /* noop */
+          }
         }
       });
-      // Move to MRU only when entry becomes ready
+
       if (next.status === 'ready') {
         set(s => {
           const lru = s.lru.filter(k => k !== key);
@@ -63,7 +111,6 @@ export const useThumbStore = create<ThumbState>()(
       }
     },
 
-    // Touch for read-access MRU update
     touch: key => {
       set(s => {
         const lru = s.lru.filter(k => k !== key);
@@ -75,57 +122,149 @@ export const useThumbStore = create<ThumbState>()(
     attach: (hash, key) => {
       set(s => {
         const setForHash = s.byHash[hash] ?? [];
-        setForHash.push(key);
+        if (!setForHash.includes(key)) {
+          setForHash.push(key);
+        }
         s.byHash[hash] = setForHash;
       });
     },
 
     evictLRU: max => {
-      const { lru, byKey } = get();
-      if (lru.length <= max) return;
+      const { lru, byKey, options } = get();
+      const capacity = max ?? options.maxLRU;
+      if (lru.length <= capacity) return;
 
-      const cut = lru.length - max;
+      const cut = lru.length - capacity;
       const toEvict = lru.slice(0, cut);
-      const evictSet = new Set(toEvict); // lookups
+      const evictSet = new Set(toEvict);
 
-      // revoke Blob URLs for evicted keys
-      for (const k of toEvict) {
-        const e = byKey[k];
-        if (e?.url?.startsWith('blob:')) {
-          try {
-            URL.revokeObjectURL(e.url);
-          } catch {}
+      if (isBrowser) {
+        for (const k of toEvict) {
+          const entry = byKey[k];
+          if (entry?.url && entry.url.startsWith('blob:')) {
+            try {
+              URL.revokeObjectURL(entry.url);
+            } catch {
+              /* noop */
+            }
+          }
         }
       }
 
       set(s => {
         s.lru = s.lru.slice(cut);
-
         for (const k of Object.keys(s.byKey)) {
           if (evictSet.has(k)) {
-            const v = s.byKey[k];
-            if (v) s.byKey[k] = { ...v, url: undefined };
+            const value = s.byKey[k];
+            if (value) {
+              s.byKey[k] = { ...value, url: undefined } as ThumbEntryEx;
+            }
           }
         }
       });
     },
 
+    purgeStale: () => {
+      const now = Date.now();
+      const { byKey, options } = get();
+      const ttl = options.ttlMs;
+      for (const [k, entry] of Object.entries(byKey)) {
+        if (
+          (entry.status === 'pending' || entry.status === 'error') &&
+          now - entry.updatedAt > ttl
+        ) {
+          get().upsert(k, { status: 'missing', error: undefined });
+        }
+      }
+    },
+
+    clearAll: () => {
+      const { byKey } = get();
+      if (isBrowser) {
+        for (const entry of Object.values(byKey)) {
+          if (entry?.url && entry.url.startsWith('blob:')) {
+            try {
+              URL.revokeObjectURL(entry.url);
+            } catch {
+              /* noop */
+            }
+          }
+        }
+      }
+
+      set(s => {
+        s.byKey = {};
+        s.byHash = {};
+        s.lru = [];
+        s.inflight.clear();
+      });
+    },
+
+    detachByHash: hash => {
+      set(s => {
+        delete s.byHash[hash];
+      });
+    },
+
     getThumbPathByKey: key => {
       const thumb = get().byKey[key];
-      if (thumb && thumb.status === 'ready') {
+      if (thumb && thumb.status === 'ready' && thumb.url) {
         get().touch(key);
         return thumb.url;
       }
       return undefined;
     },
+
+    getByKey: key => get().byKey[key],
+    getKeysByHash: hash => get().byHash[hash] ?? [],
+
+    setInflight: (key, promise) => {
+      set(state => {
+        if (!promise) {
+          state.inflight.delete(key);
+        } else {
+          state.inflight.set(key, promise);
+        }
+      });
+    },
   })),
 );
 
-export const convertToThumbKey = (hash: string, spec: Partial<ThumbSpec>) => {
-  const { width, height, dpr, mode } = spec;
-  const result = `${hash}_${width}x${height}_dpr${dpr}_${mode}`;
+export const convertToThumbKey = (hash: string, spec: Partial<ThumbSpec> & { v?: number }) => {
+  const width = spec.width ?? 0;
+  const height = spec.height ?? 0;
+  const dpr = spec.dpr ?? 1;
+  const mode = String(spec.mode ?? 'original');
+  const version = spec.v ?? 1;
+  return `${hash}_${width}x${height}_dpr${dpr}_${mode}_v${version}`;
+};
 
-  return result;
+export const parseThumbKey = (key: ThumbKey) => {
+  const modern = key.match(/^(.+?)_(\d+)x(\d+)_dpr(\d+)_(upscale|original)_v(\d+)$/);
+  if (modern) {
+    return {
+      hash: modern[1],
+      width: Number(modern[2]),
+      height: Number(modern[3]),
+      dpr: Number(modern[4]),
+      mode: modern[5] as 'upscale' | 'original',
+      v: Number(modern[6]),
+    };
+  }
+
+  const legacy = key.match(/^(.+?)_(\d+)x(\d+)_dpr(\d+)_(upscale|original)$/);
+  if (legacy) {
+    return {
+      hash: legacy[1],
+      width: Number(legacy[2]),
+      height: Number(legacy[3]),
+      dpr: Number(legacy[4]),
+      mode: legacy[5] as 'upscale' | 'original',
+      v: 1,
+    };
+  }
+
+  return null;
 };
 
 export default useThumbStore;

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -1,4 +1,4 @@
-export type ThumbJobStatus = 'ready' | 'pending' | 'error';
+export type ThumbJobStatus = 'ready' | 'pending' | 'error' | 'missing';
 
 export type ThumbEntry = {
   status: ThumbJobStatus;

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -3,6 +3,8 @@
 // =========================
 
 import { GraphNodeType } from '@tgim/types/graph';
+import useThumbStore from '@tgim/stores/thumbStore';
+import { convertFileSrc } from '@tauri-apps/api/core';
 
 type GraphPalette = {
   label: string;
@@ -137,9 +139,7 @@ ensurePaletteObservers();
 const getGraphPaletteInternal = () => graphPalette;
 
 const colorParsingCtx =
-  typeof document !== 'undefined'
-    ? document.createElement('canvas').getContext('2d')
-    : null;
+  typeof document !== 'undefined' ? document.createElement('canvas').getContext('2d') : null;
 
 const normalizeColor = (value: string) => {
   if (!colorParsingCtx) return value;
@@ -353,7 +353,21 @@ function drawLabelCached(ctx: CanvasRenderingContext2D, node: NodeProp) {
 // =========================
 
 function resolveImageSrc(_node: NodeProp): string | undefined {
-  // TODO: Implement project-specific mapping from node payload to URL
+  const node: any = _node;
+  const store = useThumbStore.getState();
+  const key: string | undefined = node.thumbKey;
+  if (key) {
+    const path = store.getThumbPathByKey(key);
+    if (path) {
+      return path.startsWith('blob:') ? path : convertFileSrc(path);
+    }
+  }
+
+  const directUrl: string | undefined = node.url;
+  if (typeof directUrl === 'string' && directUrl.length > 0) {
+    return directUrl.startsWith('blob:') ? directUrl : convertFileSrc(directUrl);
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- add an IPC-driven thumbnail event bus that mirrors worker updates into the shared store and expose the ready/error notifications to hooks
- replace the ad-hoc listener in `Main.tsx` with the shared bridge and tighten the grid view to request width-only masonry thumbnails while throttling manual refetches
- extend the reusable `useThumb` hook and backing store to surface freshness metadata and avoid direct Map mutations

## Testing
- `pnpm format:write` *(fails: existing syntax errors in apps/desktop/src/lib/ipc.ts)*
- `pnpm lint:check` *(fails: workspace is missing the @eslint/js dependency)*
- `pnpm --filter @grim/desktop build` *(fails: existing syntax errors in apps/desktop/src/lib/ipc.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0eda6a28832e8b302384017a5777