### PR TITLE
Add modal progress tracking for folder imports

### DIFF
--- a/apps/desktop/src-tauri/src/commands/file.rs
+++ b/apps/desktop/src-tauri/src/commands/file.rs
@@ -24,6 +24,8 @@ pub async fn create_folder(
             node,
             path.clone(),
             data.selection.clone(),
+            data.expected_bytes,
+            data.expected_files,
         )
         .await
         .map_err(|e| e.to_string())?;

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -46,6 +46,10 @@ pub struct FolderData {
     pub path: Option<String>,
     pub parent_id: String,
     pub selection: Option<FolderSelection>,
+    #[serde(default, rename = "expectedBytes")]
+    pub expected_bytes: Option<u64>,
+    #[serde(default, rename = "expectedFiles")]
+    pub expected_files: Option<u64>,
 }
 
 /// Describes the folder/file-type filters chosen by the user before import.

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
 use tokio::{fs, sync::Mutex};
 use tracing::{info, warn};
 

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -1,13 +1,15 @@
 use anyhow::{anyhow, bail, Context, Result};
 use async_recursion::async_recursion;
+use serde::Serialize;
 use sqlx::{Sqlite, Transaction};
 use std::{
     collections::{HashMap, HashSet},
     path::{Path, PathBuf},
+    sync::Arc,
     time::{Duration, Instant},
 };
 use tauri::AppHandle;
-use tokio::fs;
+use tokio::{fs, sync::Mutex};
 use tracing::{info, warn};
 
 use crate::{
@@ -112,6 +114,119 @@ impl UpsertFolderMetrics {
             self.upsert_file_count,
             bucket_summary,
         );
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum ImportState {
+    Running,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FolderImportProgressPayload {
+    folder_id: String,
+    state: ImportState,
+    processed_bytes: u64,
+    total_bytes: Option<u64>,
+    processed_files: u64,
+    total_files: Option<u64>,
+    elapsed_ms: u64,
+}
+
+struct ImportProgressTracker {
+    app_handle: AppHandle,
+    moa_id: String,
+    folder_id: String,
+    total_bytes: Option<u64>,
+    total_files: Option<u64>,
+    processed_bytes: u64,
+    processed_files: u64,
+    started_at: Instant,
+}
+
+impl ImportProgressTracker {
+    fn new(
+        app_handle: AppHandle,
+        moa_id: String,
+        folder_id: String,
+        total_bytes: Option<u64>,
+        total_files: Option<u64>,
+    ) -> Self {
+        Self {
+            app_handle,
+            moa_id,
+            folder_id,
+            total_bytes,
+            total_files,
+            processed_bytes: 0,
+            processed_files: 0,
+            started_at: Instant::now(),
+        }
+    }
+
+    fn emit(&self, state: ImportState) {
+        let elapsed = self.started_at.elapsed().as_millis();
+        let elapsed_ms = if elapsed > u128::from(u64::MAX) {
+            u64::MAX
+        } else {
+            elapsed as u64
+        };
+
+        let payload = FolderImportProgressPayload {
+            folder_id: self.folder_id.clone(),
+            state,
+            processed_bytes: self.processed_bytes,
+            total_bytes: self.total_bytes,
+            processed_files: self.processed_files,
+            total_files: self.total_files,
+            elapsed_ms,
+        };
+
+        let topic = format!("folder-import://progress/{}", self.moa_id);
+        let _ = self.app_handle.emit(&topic, payload);
+    }
+
+    fn notify_start(&self) {
+        self.emit(ImportState::Running);
+    }
+
+    fn record_file(&mut self, bytes: Option<i64>) {
+        self.processed_files = self.processed_files.saturating_add(1);
+        if let Some(size) = bytes {
+            if size > 0 {
+                self.processed_bytes =
+                    self.processed_bytes.saturating_add(size as u64);
+            }
+        }
+        self.emit(ImportState::Running);
+    }
+
+    fn finish(&mut self) {
+        if let Some(total) = self.total_bytes {
+            if self.processed_bytes < total {
+                self.processed_bytes = total;
+            }
+        } else {
+            self.total_bytes = Some(self.processed_bytes);
+        }
+
+        if let Some(total) = self.total_files {
+            if self.processed_files < total {
+                self.processed_files = total;
+            }
+        } else {
+            self.total_files = Some(self.processed_files);
+        }
+
+        self.emit(ImportState::Completed);
+    }
+
+    fn fail(&self) {
+        self.emit(ImportState::Failed);
     }
 }
 
@@ -399,6 +514,8 @@ pub async fn first_mount_folder(
     node: Node,
     path: String,
     selection: Option<FolderSelection>,
+    expected_bytes: Option<u64>,
+    expected_files: Option<u64>,
 ) -> Result<()> {
     let mut tx = DB_MANAGER.create_new_tx(&moa_id).await?;
 
@@ -408,30 +525,59 @@ pub async fn first_mount_folder(
 
     let sroot_info = storage_root::detect_storage_root(&norm_path)?;
 
+    let virtual_folder_id = node.id.clone();
     let real_folder_id =
         ensure_storage_root_and_real_folder(&mut tx, &sroot_info, &norm_path)
             .await?;
 
     FileRepository::create_virtual_folder_mount(
         tx.as_mut(),
-        node.id.clone(),
+        virtual_folder_id.clone(),
         real_folder_id.clone(),
     )
     .await?;
 
-    upsert_folder(
+    let progress = Arc::new(Mutex::new(ImportProgressTracker::new(
+        app.clone(),
+        moa_id.clone(),
+        virtual_folder_id.clone(),
+        expected_bytes,
+        expected_files,
+    )));
+
+    {
+        let guard = progress.lock().await;
+        guard.notify_start();
+    }
+
+    let upsert_result = upsert_folder(
         &mut tx,
         &app,
         &moa_id,
         real_folder_id.clone(),
-        node.id,
+        virtual_folder_id.clone(),
         &norm_path,
         true,
         Some(true),
         selection_plan.as_ref(),
         &norm_path,
+        Some(progress.clone()),
     )
-    .await?;
+    .await;
+
+    match upsert_result {
+        Ok(()) => {
+            let mut guard = progress.lock().await;
+            guard.finish();
+        }
+        Err(err) => {
+            {
+                let guard = progress.lock().await;
+                guard.fail();
+            }
+            return Err(err);
+        }
+    }
 
     let _scan_id = start_scan_job(moa_id.clone(), real_folder_id).await?;
 
@@ -460,6 +606,7 @@ async fn upsert_folder(
     make_virtual_folder: Option<bool>,
     selection: Option<&SelectionPlan>,
     root_path: &Path,
+    progress: Option<Arc<Mutex<ImportProgressTracker>>>,
 ) -> Result<()> {
     let mut metrics = UpsertFolderMetrics::default();
     let total_timer = Instant::now();
@@ -477,6 +624,7 @@ async fn upsert_folder(
         root_path,
         None,
         &mut metrics,
+        progress,
     )
     .await?;
 
@@ -501,6 +649,7 @@ async fn upsert_folder_impl(
     root_path: &Path,
     inherited_allowed_types: Option<HashSet<FileType>>,
     metrics: &mut UpsertFolderMetrics,
+    progress: Option<Arc<Mutex<ImportProgressTracker>>>,
 ) -> Result<()> {
     let make_vf = make_virtual_folder.unwrap_or(true);
 
@@ -603,6 +752,7 @@ async fn upsert_folder_impl(
                 &entry,
                 current_allowed.as_ref(),
                 metrics,
+                progress.clone(),
             )
             .await
             .with_context(|| {
@@ -663,6 +813,7 @@ async fn upsert_folder_impl(
                 root_path,
                 child_allowed,
                 metrics,
+                progress.clone(),
             )
             .await
             {
@@ -684,6 +835,7 @@ async fn upsert_file_entry(
     entry: &fs::DirEntry,
     allowed_types: Option<&HashSet<FileType>>,
     metrics: &mut UpsertFolderMetrics,
+    progress: Option<Arc<Mutex<ImportProgressTracker>>>,
 ) -> Result<()> {
     let file_timer = Instant::now();
     let file_path = entry.path();
@@ -729,6 +881,11 @@ async fn upsert_file_entry(
         .await;
     }
     metrics.record_upsert_file(file_info.file_size, file_timer.elapsed());
+
+    if let Some(tracker) = &progress {
+        let mut guard = tracker.lock().await;
+        guard.record_file(file_info.file_size);
+    }
 
     Ok(())
 }

--- a/apps/desktop/src/features/file/modal/FolderImportProgressModal.tsx
+++ b/apps/desktop/src/features/file/modal/FolderImportProgressModal.tsx
@@ -1,0 +1,158 @@
+import React, { useMemo } from 'react';
+import { Button, Modal } from '@tgim/ui/index';
+
+interface Props {
+  progress: FolderImportProgressEvent;
+  onClose: () => void;
+  folderName: string;
+  totalBytesFallback?: number;
+  totalFilesFallback?: number;
+  startedAt: number;
+}
+
+const formatBytes = (bytes: number) => {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let idx = 0;
+
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024;
+    idx += 1;
+  }
+
+  const fixed = value >= 10 ? value.toFixed(0) : value.toFixed(2);
+  return `${fixed} ${units[idx]}`;
+};
+
+const formatDuration = (milliseconds: number) => {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+    return '0초';
+  }
+
+  const totalSeconds = Math.floor(milliseconds / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}시간`);
+  if (minutes > 0) parts.push(`${minutes}분`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}초`);
+
+  return parts.join(' ');
+};
+
+const FolderImportProgressModal: React.FC<Props> = ({
+  progress,
+  onClose,
+  folderName,
+  totalBytesFallback,
+  totalFilesFallback,
+  startedAt,
+}) => {
+  const safeName = folderName || '선택한 폴더';
+  const totalBytes = progress.totalBytes ?? totalBytesFallback ?? 0;
+  const processedBytes = totalBytes
+    ? Math.min(progress.processedBytes, totalBytes)
+    : progress.processedBytes;
+  const totalFiles = progress.totalFiles ?? totalFilesFallback ?? 0;
+  const processedFiles = totalFiles
+    ? Math.min(progress.processedFiles, totalFiles)
+    : progress.processedFiles;
+  const elapsedMs =
+    progress.elapsedMs > 0 ? progress.elapsedMs : Math.max(Date.now() - startedAt, 0);
+
+  const percent =
+    totalBytes > 0 ? Math.min(100, Math.round((processedBytes / totalBytes) * 100)) : 0;
+
+  const remainingText = useMemo(() => {
+    if (progress.state === 'completed') return '0초';
+    if (progress.state === 'failed') return '계산 불가';
+    if (!totalBytes || processedBytes <= 0 || elapsedMs <= 0) {
+      return '계산 중...';
+    }
+
+    const remainingBytes = Math.max(totalBytes - processedBytes, 0);
+    if (remainingBytes === 0) return '0초';
+
+    const ratePerSecond = processedBytes / (elapsedMs / 1000);
+    if (!Number.isFinite(ratePerSecond) || ratePerSecond <= 0) {
+      return '계산 중...';
+    }
+
+    const remainingSeconds = Math.ceil(remainingBytes / ratePerSecond);
+    return formatDuration(remainingSeconds * 1000);
+  }, [elapsedMs, processedBytes, progress.state, totalBytes]);
+
+  const { title, description } = useMemo(() => {
+    switch (progress.state) {
+      case 'completed':
+        return {
+          title: '업서트 완료',
+          description: `"${safeName}" 폴더 업서트가 완료되었습니다.`,
+        };
+      case 'failed':
+        return {
+          title: '업서트 실패',
+          description: `"${safeName}" 폴더 업서트 중 오류가 발생했습니다.`,
+        };
+      default:
+        return {
+          title: '업서트 진행 중',
+          description: `"${safeName}" 폴더를 업서트하는 중입니다.`,
+        };
+    }
+  }, [progress.state, safeName]);
+
+  const dismissible = progress.state === 'completed' || progress.state === 'failed';
+  const barColor = progress.state === 'failed' ? 'bg-[var(--color-status-danger)]' : 'bg-accent';
+
+  return (
+    <Modal onClose={onClose} className="bg-modal-bg w-[28rem]" dismissible={dismissible}>
+      <div className="p-6 space-y-5 text-text">
+        <div>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <p className="mt-1 text-sm text-text-soft">{description}</p>
+        </div>
+
+        <div>
+          <div className="h-3 w-full overflow-hidden rounded-full bg-surface-muted">
+            <div
+              className={`h-full rounded-full transition-all ${barColor}`}
+              style={{ width: `${percent}%` }}
+            ></div>
+          </div>
+          <div className="mt-2 flex items-center justify-between text-sm font-medium">
+            <span>{formatBytes(processedBytes)}</span>
+            <span>{totalBytes ? formatBytes(totalBytes) : '총 용량 정보 없음'}</span>
+          </div>
+          {totalFiles ? (
+            <div className="mt-1 text-xs text-text-soft">
+              파일 {processedFiles.toLocaleString()} / {totalFiles.toLocaleString()}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-text-soft">경과 시간</div>
+            <div className="font-medium">{formatDuration(elapsedMs)}</div>
+          </div>
+          <div>
+            <div className="text-xs uppercase tracking-wide text-text-soft">남은 시간</div>
+            <div className="font-medium">{remainingText}</div>
+          </div>
+        </div>
+
+        {dismissible ? (
+          <div className="flex justify-end">
+            <Button onClick={onClose}>닫기</Button>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  );
+};
+
+export default FolderImportProgressModal;

--- a/apps/desktop/src/features/file/modal/NewFolderModal.tsx
+++ b/apps/desktop/src/features/file/modal/NewFolderModal.tsx
@@ -12,6 +12,8 @@ interface Props {
     name: string;
     path: string;
     selection?: FolderSelection;
+    expectedBytes: number;
+    expectedFiles: number;
   }) => Promise<void> | void;
 }
 
@@ -392,6 +394,8 @@ const NewFolderModal: React.FC<Props> = ({ onClose, onSubmit }) => {
         name: name.trim(),
         path,
         selection: payload.entries.length ? payload : undefined,
+        expectedBytes: summary.totalBytes,
+        expectedFiles: summary.totalFiles,
       });
       onClose();
     } catch (error) {

--- a/apps/desktop/src/features/main/panel/FileTreePanel.tsx
+++ b/apps/desktop/src/features/main/panel/FileTreePanel.tsx
@@ -1,5 +1,5 @@
 import { FileTreeData } from '@tgim/types/index';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   useHoverOpen,
   useMultiSelect,
@@ -17,6 +17,8 @@ import NewFolderModal from '../../file/modal/NewFolderModal';
 import { ipc } from '../../../lib/ipc';
 import { useMoa } from '@tgim/hooks/useMoa';
 import usePanelsStore from '@tgim/stores/panelStore';
+import { listen } from '@tauri-apps/api/event';
+import FolderImportProgressModal from '../../file/modal/FolderImportProgressModal';
 
 /* local utils for rendering */
 
@@ -58,6 +60,13 @@ const flattenVisible = (tree: FileTreeData[], expanded: Set<string>): string[] =
   };
   walk(tree);
   return out;
+};
+
+type ImportContext = {
+  folderName: string;
+  totalBytes: number;
+  totalFiles: number;
+  startedAt: number;
 };
 
 export const FileTree = () => {
@@ -113,6 +122,73 @@ export const FileTree = () => {
   };
 
   const { moaId } = useMoa(location);
+
+  const [importContext, setImportContext] = useState<ImportContext | null>(null);
+  const [importProgress, setImportProgress] = useState<FolderImportProgressEvent | null>(null);
+  const [importModalOpen, setImportModalOpen] = useState(false);
+  const importContextRef = useRef<ImportContext | null>(null);
+
+  useEffect(() => {
+    importContextRef.current = importContext;
+  }, [importContext]);
+
+  useEffect(() => {
+    if (!moaId) {
+      return;
+    }
+
+    let unlisten: (() => void) | undefined;
+
+    const setup = async () => {
+      try {
+        unlisten = await listen<FolderImportProgressEvent>(
+          `folder-import://progress/${moaId}`,
+          event => {
+            const context = importContextRef.current;
+            if (!context) {
+              return;
+            }
+
+            setImportModalOpen(true);
+            setImportProgress(prev => {
+              const payload = event.payload;
+              const totalBytes = payload.totalBytes ?? prev?.totalBytes ?? context.totalBytes;
+              const totalFiles = payload.totalFiles ?? prev?.totalFiles ?? context.totalFiles;
+
+              return {
+                ...payload,
+                totalBytes,
+                totalFiles,
+              };
+            });
+
+            setImportContext(prev => {
+              if (!prev) return prev;
+              return {
+                ...prev,
+                totalBytes: event.payload.totalBytes ?? prev.totalBytes,
+                totalFiles: event.payload.totalFiles ?? prev.totalFiles,
+              };
+            });
+          },
+        );
+      } catch (error) {
+        console.error('Failed to listen for folder import progress', error);
+      }
+    };
+
+    void setup();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [moaId]);
+
+  const handleImportModalClose = () => {
+    setImportModalOpen(false);
+    setImportProgress(null);
+    setImportContext(null);
+  };
 
   return (
     <div className="w-full h-full text-sidebar-text" onClick={clearSelection}>
@@ -198,14 +274,42 @@ export const FileTree = () => {
             onClose={() => setIsFolderModal(false)}
             onSubmit={async d => {
               if (!moaId) return;
+              const hasPath = Boolean(d.path);
+              if (hasPath) {
+                const context: ImportContext = {
+                  folderName: d.name,
+                  totalBytes: d.expectedBytes ?? 0,
+                  totalFiles: d.expectedFiles ?? 0,
+                  startedAt: Date.now(),
+                };
+                importContextRef.current = context;
+                setImportContext(context);
+                setImportProgress({
+                  folderId: '',
+                  state: 'running',
+                  processedBytes: 0,
+                  totalBytes: d.expectedBytes ?? 0,
+                  processedFiles: 0,
+                  totalFiles: d.expectedFiles ?? 0,
+                  elapsedMs: 0,
+                });
+                setImportModalOpen(true);
+              }
               try {
                 await ipc.graph.createFolder(moaId, {
                   name: d.name,
                   path: d.path,
                   parent_id: optionNode?.id ?? 'root',
                   selection: d.selection,
+                  expectedBytes: d.expectedBytes,
+                  expectedFiles: d.expectedFiles,
                 });
               } catch (err) {
+                if (hasPath) {
+                  setImportModalOpen(false);
+                  setImportProgress(null);
+                  setImportContext(null);
+                }
                 console.error(err);
                 throw err;
               }
@@ -213,6 +317,16 @@ export const FileTree = () => {
           />
         </Modal>
       )}
+      {importModalOpen && importProgress && importContext ? (
+        <FolderImportProgressModal
+          progress={importProgress}
+          onClose={handleImportModalClose}
+          folderName={importContext.folderName}
+          totalBytesFallback={importContext.totalBytes}
+          totalFilesFallback={importContext.totalFiles}
+          startedAt={importContext.startedAt}
+        />
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/types/global.d.ts
+++ b/apps/desktop/src/types/global.d.ts
@@ -29,6 +29,18 @@ declare global {
     percent: number;
     note?: string;
   }
+
+  type FolderImportState = 'running' | 'completed' | 'failed';
+
+  interface FolderImportProgressEvent {
+    folderId: string;
+    state: FolderImportState;
+    processedBytes: number;
+    totalBytes?: number | null;
+    processedFiles: number;
+    totalFiles?: number | null;
+    elapsedMs: number;
+  }
 }
 
 export {};

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -117,4 +117,6 @@ export interface CreateFolderPayload {
   path: string;
   parent_id: string;
   selection?: FolderSelection;
+  expectedBytes?: number;
+  expectedFiles?: number;
 }

--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -8,9 +8,10 @@ interface Props {
   className?: string;
   children?: React.ReactNode;
   rootId?: string;
+  dismissible?: boolean;
 }
 
-const Modal: React.FC<Props> = ({ onClose, children, className, rootId }) => {
+const Modal: React.FC<Props> = ({ onClose, children, className, rootId, dismissible = true }) => {
   const targetId = rootId ?? 'modal_root';
 
   const modalRoot = useMemo(() => {
@@ -27,18 +28,20 @@ const Modal: React.FC<Props> = ({ onClose, children, className, rootId }) => {
     event.stopPropagation();
   }, []);
 
+  const handleOverlayClick = useCallback(() => {
+    if (!dismissible) return;
+    onClose();
+  }, [dismissible, onClose]);
+
   // Render inside a detached root so modals can escape stacking context issues.
   return createPortal(
-    <div className="modal-overlay" onClick={onClose}>
+    <div className="modal-overlay" onClick={handleOverlayClick}>
       <div className={cn('modal', className)} onClick={handleInnerClick}>
-        <Button
-          variant="icon"
-          className="modal-close"
-          onClick={onClose}
-          aria-label="Close modal"
-        >
-          ×
-        </Button>
+        {dismissible ? (
+          <Button variant="icon" className="modal-close" onClick={onClose} aria-label="Close modal">
+            ×
+          </Button>
+        ) : null}
         {children}
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- allow shared modal to disable overlay and close button until dismissal is permitted
- extend folder import payloads and services to include expected byte/file counts and broadcast progress updates
- add a folder import progress modal and update the file tree workflow to display progress, ETA, and completion state

## Testing
- `pnpm format:write`
- `pnpm lint:check` *(fails: missing @eslint/js because dependencies cannot be installed without registry access)*
- `pnpm install` *(fails: npm registry returns 403)*
- `pnpm --filter @grim/desktop build` *(fails: missing node modules due to install failure)*
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: crates.io index download blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3dda232c832e9cac6da0caa41dcd