### PR TITLE
feat: manage grid selection with useMultiSelect

### DIFF
--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -1,8 +1,9 @@
 import { listen } from '@tauri-apps/api/event';
 import { useMoa } from '@tgim/hooks/useMoa';
+import { useMultiSelect } from '@tgim/dnd/index';
 import { GridData, ImageItem } from '@tgim/types/grid';
 import { ipc } from '../../../../lib/ipc';
-import React, { useEffect, useMemo, useRef, useState, useCallback, CSSProperties } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
 import { ResizeMode } from '@tgim/types/file';
 import { useShallow } from 'zustand/shallow';
@@ -167,6 +168,17 @@ const GridView: React.FC<Props> = ({ gridData }) => {
   const [selectMode, setSelectMode] = useState(false);
   const [images] = useState(gridData.images);
 
+  const visibleOrder = useMemo(() => images.map(img => img.hash), [images]);
+
+  const {
+    selected,
+    onItemClick: handleSelectionClick,
+    clearSelection,
+    isSelected,
+  } = useMultiSelect(visibleOrder, {
+    pruneOnVisibilityChange: true,
+  });
+
   // Map for quick lookup by hash
   const hashToImgMap = useMemo(() => {
     const map: Record<string, ImageItem> = {};
@@ -299,9 +311,32 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     return '';
   }, [size, layout]);
 
-  const handleItemClick = useCallback((img: ImageItem) => {
-    console.log(img);
-  }, []);
+  const selectedCount = selected.size;
+
+  const handleToggleSelectMode = useCallback(() => {
+    setSelectMode(prev => {
+      if (prev) {
+        clearSelection();
+        return false;
+      }
+      return true;
+    });
+  }, [clearSelection]);
+
+  const handleBackgroundClick = useCallback(() => {
+    clearSelection();
+  }, [clearSelection]);
+
+  const handleItemClick = useCallback(
+    (event: React.MouseEvent, img: ImageItem) => {
+      handleSelectionClick(event, img.hash);
+
+      if (!selectMode) {
+        console.log(img);
+      }
+    },
+    [handleSelectionClick, selectMode],
+  );
 
   return (
     <div className="flex flex-col w-full h-full bg-surface text-text font-sans">
@@ -331,15 +366,15 @@ const GridView: React.FC<Props> = ({ gridData }) => {
         </div>
         <Button
           variant={selectMode ? 'primary' : 'secondary'}
-          onClick={() => setSelectMode(v => !v)}
+          onClick={handleToggleSelectMode}
           aria-pressed={selectMode}
           className="min-w-[7rem] px-4 py-2 text-sm font-medium"
         >
-          {selectMode ? 'Done' : 'Select'}
+          {selectMode && selectedCount ? `Done (${selectedCount})` : selectMode ? 'Done' : 'Select'}
         </Button>
       </div>
 
-      <div ref={scrollRef} className="flex-1 overflow-auto p-4">
+      <div ref={scrollRef} className="flex-1 overflow-auto p-4" onClick={handleBackgroundClick}>
         {layout === 'grid' ? (
           <VirtualGridLayout
             images={images}
@@ -351,6 +386,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
             selectMode={selectMode}
             thumbSize={thumbSize}
             onNeedThumbs={handleNeedThumbs}
+            isSelected={isSelected}
           />
         ) : (
           <MasonryLayout
@@ -361,6 +397,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
             observe={observe}
             unobserve={unobserve}
             thumbSize={thumbSize}
+            isSelected={isSelected}
           />
         )}
       </div>
@@ -385,15 +422,17 @@ function VirtualGridLayout({
   selectMode,
   thumbSize,
   onNeedThumbs,
+  isSelected,
 }: {
   images: ImageItem[];
   size: Size;
-  onItemClick: (img: ImageItem) => void;
+  onItemClick: (event: React.MouseEvent, img: ImageItem) => void;
   observe: (el: Element | null, key: string) => void;
   unobserve: (el: Element | null) => void;
   selectMode: boolean;
   thumbSize: number;
   onNeedThumbs: (items: ImageItem[]) => void;
+  isSelected: (id: string) => boolean;
 }) {
   const itemW = size === 'small' ? 96 : size === 'large' ? 192 : 144;
   const itemH = itemW;
@@ -459,11 +498,24 @@ function VirtualGridLayout({
             observe={observe}
             unobserve={unobserve}
             thumbSize={thumbSize}
+            selected={isSelected(img.hash)}
           />
         </div>
       );
     },
-    [cols, images, itemW, itemH, onItemClick, selectMode, observe, unobserve, gap, thumbSize],
+    [
+      cols,
+      images,
+      itemW,
+      itemH,
+      onItemClick,
+      selectMode,
+      observe,
+      unobserve,
+      gap,
+      thumbSize,
+      isSelected,
+    ],
   );
 
   return (
@@ -502,7 +554,17 @@ function MasonryLayout({
   observe,
   unobserve,
   thumbSize,
-}: any) {
+  isSelected,
+}: {
+  images: ImageItem[];
+  onItemClick: (event: React.MouseEvent, img: ImageItem) => void;
+  sizeClass: string;
+  selectMode: boolean;
+  observe: (el: Element | null, key: string) => void;
+  unobserve: (el: Element | null) => void;
+  thumbSize: number;
+  isSelected: (id: string) => boolean;
+}) {
   const breakpointColumnsObj = { default: 6, 1536: 6, 1280: 5, 1024: 4, 768: 3, 640: 2 };
   return (
     <Masonry
@@ -521,6 +583,7 @@ function MasonryLayout({
             observe={observe}
             unobserve={unobserve}
             thumbSize={thumbSize}
+            selected={isSelected(img.hash)}
           />
         </div>
       ))}
@@ -533,8 +596,9 @@ function MasonryLayout({
  * --------------------------------------------- */
 type ThumbCardProps = {
   img: ImageItem;
-  onClick: (img: ImageItem) => void;
+  onClick: (event: React.MouseEvent, img: ImageItem) => void;
   showCheckbox: boolean;
+  selected: boolean;
   layout: Layout;
   observe: (el: Element | null, key: string) => void;
   unobserve: (el: Element | null) => void;
@@ -546,6 +610,7 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
   img,
   onClick,
   showCheckbox,
+  selected,
   layout,
   observe,
   unobserve,
@@ -583,15 +648,26 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
   }, [img.hash, observe, unobserve]);
 
   const handleImageLoad = useCallback(() => setLoaded(true), []);
-  const handleCardClick = useCallback(() => onClick(img), [onClick, img]);
+  const handleCardClick = useCallback(
+    (event: React.MouseEvent) => {
+      onClick(event, img);
+    },
+    [onClick, img],
+  );
+
+  const selectionClasses = selected
+    ? 'border-accent ring-2 ring-accent/60 ring-offset-1 ring-offset-surface-raised'
+    : 'border-border';
 
   return (
     <div
       ref={containerRef}
-      className={`group relative w-full h-full overflow-hidden rounded-lg border border-border bg-surface shadow-sm transition-all duration-200 hover:border-accent hover:shadow-lg hover:-translate-y-1 cursor-pointer ${sizeClass ?? ''}`}
+      className={`group relative w-full h-full overflow-hidden rounded-lg border ${selectionClasses} bg-surface shadow-sm transition-all duration-200 hover:border-accent hover:shadow-lg hover:-translate-y-1 cursor-pointer ${sizeClass ?? ''}`}
       onClick={handleCardClick}
       role="button"
       tabIndex={0}
+      aria-selected={selected}
+      data-selected={selected ? 'true' : 'false'}
     >
       {showCheckbox && (
         <div className="absolute left-2 top-2 z-10">
@@ -599,6 +675,7 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
             type="checkbox"
             className="w-4 h-4 rounded text-accent bg-surface-muted border-border focus:ring-accent"
             readOnly
+            checked={selected}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- integrate `useMultiSelect` in the grid view to manage thumbnail selection
- surface the current selection count in the select toggle and clear when exiting the mode
- propagate selection state to virtual and masonry layouts so each card renders checked/active styling

## Testing
- pnpm format:write
- pnpm lint:check *(fails: missing @eslint/js package in the workspace)*
- pnpm --filter @grim/desktop build *(fails: missing workspace dependencies such as react, tauri APIs, vite)*

------
https://chatgpt.com/codex/tasks/task_e_68d100865bdc832ea4974fcc71836885