### PR TITLE
Add Croquis session backend and window scaffold

### DIFF
--- a/apps/desktop/src-tauri/src/app_launcher/croquis.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/croquis.rs
@@ -1,0 +1,65 @@
+use tauri::WebviewUrl;
+#[cfg(target_os = "macos")]
+use tauri_plugin_decorum::WebviewWindowExt;
+
+use crate::models::croquis::CroquisSession;
+
+/// Launch the Croquis window for the provided session, returning the window label.
+pub fn launch_croquis(
+    app: &tauri::AppHandle,
+    session: &CroquisSession,
+) -> Result<String, String> {
+    let uri = format!("croquis?session_id={}", session.session_id);
+
+    #[cfg(debug_assertions)]
+    let url = WebviewUrl::App(format!("index.html#{uri}").into());
+
+    #[cfg(not(debug_assertions))]
+    let url = WebviewUrl::App(format!("index.html#{uri}").into());
+
+    let window_label = format!("moa-croquis-{}", session.session_id);
+
+    let mut builder =
+        tauri::WebviewWindowBuilder::new(app, window_label.clone(), url)
+            .title("Croquis")
+            .resizable(true);
+
+    let width = parse_dimension(session.option.window.width.as_ref());
+    let height = parse_dimension(session.option.window.height.as_ref());
+
+    builder = match (width, height) {
+        (Some(w), Some(h)) => builder.inner_size(w, h),
+        _ => builder.inner_size(1024.0, 720.0),
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder.title_bar_style(tauri::TitleBarStyle::Overlay);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        builder = builder.decorations(false);
+    }
+
+    let window = builder.build().map_err(|err| err.to_string())?;
+
+    #[cfg(target_os = "macos")]
+    {
+        window.create_overlay_titlebar().map_err(|err| err.to_string())?;
+        window
+            .set_traffic_lights_inset(12.0, 16.0)
+            .and_then(|w| w.make_transparent())
+            .map_err(|err| err.to_string())?;
+    }
+
+    Ok(window_label)
+}
+
+fn parse_dimension(value: Option<&String>) -> Option<f64> {
+    let raw = value?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    raw.parse::<f64>().ok().filter(|v| *v > 0.0)
+}

--- a/apps/desktop/src-tauri/src/app_launcher/mod.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/mod.rs
@@ -1,4 +1,5 @@
 //! Helpers for launching the various Moa application windows.
 
+pub mod croquis;
 pub mod grim;
 pub mod moa;

--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,0 +1,25 @@
+use crate::{
+    models::croquis::{
+        CroquisSession, CroquisStartPayload, CroquisStartResponse,
+    },
+    services::croquis_service,
+};
+
+/// Ensure Croquis assets are ready and launch the dedicated Croquis window.
+#[tauri::command]
+pub async fn start_croquis_session(
+    app_handle: tauri::AppHandle,
+    payload: CroquisStartPayload,
+) -> Result<CroquisStartResponse, String> {
+    croquis_service::start_session(&app_handle, payload)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+/// Fetch a prepared Croquis session by identifier for the Croquis window.
+#[tauri::command]
+pub async fn load_croquis_session(
+    session_id: String,
+) -> Result<Option<CroquisSession>, String> {
+    Ok(croquis_service::load_session(&session_id).await)
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! Tauri command handlers exposed to the renderer process.
 
+pub mod croquis;
 pub mod file;
 pub mod graph;
 pub mod moa;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -43,6 +43,8 @@ fn main() {
             commands::graph::get_graph_one,
             commands::file::get_thumbnails,
             commands::file::preview_folder_import,
+            commands::croquis::start_croquis_session,
+            commands::croquis::load_croquis_session,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/models/croquis.rs
+++ b/apps/desktop/src-tauri/src/models/croquis.rs
@@ -1,0 +1,94 @@
+use serde::{Deserialize, Serialize};
+
+/// Window sizing preferences supplied by the renderer when launching Croquis.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisWindowOption {
+    #[serde(default)]
+    pub width: Option<String>,
+    #[serde(default)]
+    pub height: Option<String>,
+}
+
+/// Automatic behaviour toggles for the Croquis session.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisAutoOption {
+    #[serde(default)]
+    pub skip: bool,
+    #[serde(default)]
+    pub save: bool,
+    #[serde(default)]
+    pub capture: bool,
+}
+
+/// Timer configuration for the Croquis session.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisTimerOption {
+    #[serde(default)]
+    pub max_time: u32,
+}
+
+/// Aggregate Croquis options selected in the renderer.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisOption {
+    #[serde(default)]
+    pub window: CroquisWindowOption,
+    #[serde(default)]
+    pub auto: CroquisAutoOption,
+    #[serde(default)]
+    pub timer: CroquisTimerOption,
+    #[serde(default)]
+    pub capture: bool,
+    #[serde(default)]
+    pub save_path: String,
+    #[serde(default)]
+    pub save_folder: String,
+    #[serde(default)]
+    pub gray_option: bool,
+    #[serde(default)]
+    pub shuffle_option: bool,
+}
+
+/// Payload provided by the renderer to start a Croquis session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisStartPayload {
+    pub moa_id: String,
+    pub option: CroquisOption,
+    pub image_hashes: Vec<String>,
+    #[serde(default)]
+    pub save_option: bool,
+}
+
+/// Metadata describing an ensured Croquis base image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisSessionImage {
+    pub hash: String,
+    pub base_path: String,
+    pub base_width: u32,
+    pub base_height: u32,
+    pub source_path: String,
+}
+
+/// Persisted Croquis session information shared with the Croquis window.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisSession {
+    pub session_id: String,
+    pub moa_id: String,
+    pub option: CroquisOption,
+    pub images: Vec<CroquisSessionImage>,
+    pub created_at: String,
+}
+
+/// Response returned to the renderer once the Croquis window has been launched.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisStartResponse {
+    pub session_id: String,
+    pub window_label: String,
+}

--- a/apps/desktop/src-tauri/src/models/mod.rs
+++ b/apps/desktop/src-tauri/src/models/mod.rs
@@ -1,6 +1,7 @@
 //! Core data models shared across services and commands.
 
 pub mod connection;
+pub mod croquis;
 pub mod file;
 pub mod graph;
 pub mod node;

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use anyhow::{anyhow, bail, Context, Result};
 use once_cell::sync::Lazy;
 use tokio::{fs, sync::RwLock};
+use tracing::warn;
 
 use crate::{
     app_launcher,
@@ -42,22 +43,41 @@ pub async fn start_session(
         Vec::with_capacity(image_hashes.len());
 
     for hash in &image_hashes {
-        let source_path = fetch_one_file_path(moa_id.clone(), hash.clone())
-            .await
-            .with_context(|| {
-                format!("Failed to resolve source path for hash {hash}")
-            })?;
+        let source_path = match fetch_one_file_path(
+            moa_id.clone(),
+            hash.clone(),
+        )
+        .await
+        {
+            Ok(path) => path,
+            Err(error) => {
+                warn!(
+                    error = ?error,
+                    %hash,
+                    "Failed to resolve source path for Croquis hash; skipping"
+                );
+                continue;
+            }
+        };
 
-        let BaseThumbInfo { path, width, height } = ensure_base_thumbnail(
+        let BaseThumbInfo { path, width, height } = match ensure_base_thumbnail(
             app_handle,
             &moa_id,
             hash,
             source_path.as_path(),
         )
         .await
-        .with_context(|| {
-            format!("Failed to ensure base thumbnail for hash {hash}")
-        })?;
+        {
+            Ok(info) => info,
+            Err(error) => {
+                warn!(
+                    error = ?error,
+                    %hash,
+                    "Failed to ensure base thumbnail for Croquis hash; skipping"
+                );
+                continue;
+            }
+        };
 
         images.push(CroquisSessionImage {
             hash: hash.clone(),
@@ -66,6 +86,10 @@ pub async fn start_session(
             base_height: height,
             source_path: source_path.to_string_lossy().into_owned(),
         });
+    }
+
+    if images.is_empty() {
+        bail!("None of the provided image hashes could be loaded for Croquis");
     }
 
     let session_id = get_unique_id();

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -1,0 +1,123 @@
+use std::collections::HashMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use once_cell::sync::Lazy;
+use tokio::{fs, sync::RwLock};
+
+use crate::{
+    app_launcher,
+    bootstrap::PATH_MANAGER,
+    models::croquis::{
+        CroquisOption, CroquisSession, CroquisSessionImage,
+        CroquisStartPayload, CroquisStartResponse,
+    },
+    services::file_service::{
+        folder::fetch_one_file_path,
+        thumbnail::{ensure_base_thumbnail, BaseThumbInfo},
+    },
+    utils::{date, identifier::get_unique_id},
+};
+
+/// In-memory registry of active Croquis sessions keyed by session identifier.
+static CROQUIS_SESSIONS: Lazy<RwLock<HashMap<String, CroquisSession>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+/// Launch a new Croquis session by ensuring base images and spawning the window.
+pub async fn start_session(
+    app_handle: &tauri::AppHandle,
+    payload: CroquisStartPayload,
+) -> Result<CroquisStartResponse> {
+    let CroquisStartPayload { moa_id, option, image_hashes, save_option } =
+        payload;
+
+    if image_hashes.is_empty() {
+        bail!("At least one image hash must be provided to start Croquis");
+    }
+
+    if save_option {
+        persist_option(&moa_id, &option).await?;
+    }
+
+    let mut images: Vec<CroquisSessionImage> =
+        Vec::with_capacity(image_hashes.len());
+
+    for hash in &image_hashes {
+        let source_path = fetch_one_file_path(moa_id.clone(), hash.clone())
+            .await
+            .with_context(|| {
+                format!("Failed to resolve source path for hash {hash}")
+            })?;
+
+        let BaseThumbInfo { path, width, height } = ensure_base_thumbnail(
+            app_handle,
+            &moa_id,
+            hash,
+            source_path.as_path(),
+        )
+        .await
+        .with_context(|| {
+            format!("Failed to ensure base thumbnail for hash {hash}")
+        })?;
+
+        images.push(CroquisSessionImage {
+            hash: hash.clone(),
+            base_path: path.as_path().to_string_lossy().into_owned(),
+            base_width: width,
+            base_height: height,
+            source_path: source_path.to_string_lossy().into_owned(),
+        });
+    }
+
+    let session_id = get_unique_id();
+    let created_at = date::get_now_date();
+    let session = CroquisSession {
+        session_id: session_id.clone(),
+        moa_id: moa_id.clone(),
+        option: option.clone(),
+        images,
+        created_at,
+    };
+
+    let window_label =
+        app_launcher::croquis::launch_croquis(app_handle, &session)
+            .map_err(|err| anyhow!(err))?;
+
+    {
+        let mut sessions = CROQUIS_SESSIONS.write().await;
+        sessions.insert(session_id.clone(), session);
+    }
+
+    Ok(CroquisStartResponse { session_id, window_label })
+}
+
+/// Fetch a previously created Croquis session by identifier.
+pub async fn load_session(session_id: &str) -> Option<CroquisSession> {
+    let sessions = CROQUIS_SESSIONS.read().await;
+    sessions.get(session_id).cloned()
+}
+
+/// Persist the Croquis option payload into the workspace `.moa/settings` folder.
+async fn persist_option(moa_id: &str, option: &CroquisOption) -> Result<()> {
+    let paths = PATH_MANAGER
+        .get_or_add(moa_id)
+        .await
+        .context("Failed to resolve workspace paths")?;
+
+    let settings_dir = paths.moa_dir.join("settings");
+    fs::create_dir_all(&settings_dir).await.with_context(|| {
+        format!(
+            "Failed to create settings directory at {}",
+            settings_dir.display()
+        )
+    })?;
+
+    let file_path = settings_dir.join("croquis.json");
+    let payload = serde_json::to_vec_pretty(option)
+        .context("Failed to serialise Croquis options")?;
+
+    fs::write(&file_path, payload).await.with_context(|| {
+        format!("Failed to write Croquis options to {}", file_path.display())
+    })?;
+
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/services/mod.rs
+++ b/apps/desktop/src-tauri/src/services/mod.rs
@@ -1,6 +1,7 @@
 //! Backend services that power the desktop application.
 
 pub mod bootstrap_service;
+pub mod croquis_service;
 pub mod db;
 pub mod file_service;
 pub mod graph_service;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { HashRouter, Routes, Route } from 'react-router-dom';
 import Moa from './features/moa/Moa';
 import './i18n';
 import Main from './features/main/Main';
+import CroquisWindow from './features/croquis/CroquisWindow';
 
 // Desktop entry point that keeps routing hash-based for Tauri compatibility.
 const App: React.FC = () => {
@@ -12,6 +13,7 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/moa/*" element={<Main />} />
           <Route path="/create-moa/*" element={<Moa />} />
+          <Route path="/croquis/*" element={<CroquisWindow />} />
         </Routes>
       </HashRouter>
     </div>

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { ipc } from '../../lib/ipc';
+import { CroquisSession } from '@tgim/types/croquis';
+
+const CroquisWindow: React.FC = () => {
+  const [params] = useSearchParams();
+  const [session, setSession] = useState<CroquisSession | null>(null);
+
+  useEffect(() => {
+    console.log('[Croquis] window mounted');
+  }, []);
+
+  useEffect(() => {
+    const sessionId = params.get('session_id');
+    if (!sessionId) {
+      console.warn('[Croquis] Missing session_id query parameter');
+      return;
+    }
+
+    void (async () => {
+      try {
+        const data = await ipc.croquis.loadSession(sessionId);
+        if (!data) {
+          console.warn('[Croquis] No session found for id', sessionId);
+          return;
+        }
+        setSession(data);
+        console.log('[Croquis] session hydrated', data);
+      } catch (error) {
+        console.error('[Croquis] Failed to load Croquis session', error);
+      }
+    })();
+  }, [params]);
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full bg-surface text-text">
+      <p className="text-base font-semibold">Croquis window bootstrap</p>
+      {session ? (
+        <pre className="mt-4 max-w-xl whitespace-pre-wrap break-all text-left text-xs text-text-muted">
+          {JSON.stringify(
+            {
+              sessionId: session.sessionId,
+              images: session.images.length,
+            },
+            null,
+            2,
+          )}
+        </pre>
+      ) : (
+        <p className="mt-2 text-sm text-text-muted">Waiting for Croquis data...</p>
+      )}
+    </div>
+  );
+};
+
+export default CroquisWindow;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -2,6 +2,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
 import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
+import { CroquisSession, CroquisStartPayload, CroquisStartResponse } from '@tgim/types/croquis';
 
 const appWindow = getCurrentWindow();
 
@@ -66,9 +67,21 @@ const fileIpc = {
   },
 };
 
+const croquisIpc = {
+  startSession: async (payload: CroquisStartPayload): Promise<CroquisStartResponse> => {
+    const response = await invoke('start_croquis_session', { payload });
+    return response as CroquisStartResponse;
+  },
+  loadSession: async (sessionId: string): Promise<CroquisSession | null> => {
+    const response = await invoke('load_croquis_session', { sessionId });
+    return (response as CroquisSession | null) ?? null;
+  },
+};
+
 export const ipc = {
   windowController: windowControllerIpc,
   moa: moaIpc,
   graph: graphIpc,
   file: fileIpc,
+  croquis: croquisIpc,
 };

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -1,0 +1,53 @@
+export interface CroquisWindowOption {
+  width?: string | null;
+  height?: string | null;
+}
+
+export interface CroquisAutoOption {
+  skip: boolean;
+  save: boolean;
+  capture: boolean;
+}
+
+export interface CroquisTimerOption {
+  maxTime: number;
+}
+
+export interface CroquisOption {
+  window: CroquisWindowOption;
+  auto: CroquisAutoOption;
+  timer: CroquisTimerOption;
+  capture: boolean;
+  savePath: string;
+  saveFolder: string;
+  grayOption: boolean;
+  shuffleOption: boolean;
+}
+
+export interface CroquisStartPayload {
+  moaId: string;
+  option: CroquisOption;
+  imageHashes: string[];
+  saveOption?: boolean;
+}
+
+export interface CroquisSessionImage {
+  hash: string;
+  basePath: string;
+  baseWidth: number;
+  baseHeight: number;
+  sourcePath: string;
+}
+
+export interface CroquisSession {
+  sessionId: string;
+  moaId: string;
+  option: CroquisOption;
+  images: CroquisSessionImage[];
+  createdAt: string;
+}
+
+export interface CroquisStartResponse {
+  sessionId: string;
+  windowLabel: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,3 +3,4 @@ export * from './panel';
 export * from './graph';
 export * from './grid';
 export * from './file';
+export * from './croquis';


### PR DESCRIPTION
## Summary
- add Croquis models, service, and commands to prepare base images, persist options, and open a dedicated window
- register a Croquis app launcher and React route with a bootstrap component that logs loaded session data
- expose Croquis IPC endpoints and shared TypeScript types for renderer integration

## Testing
- pnpm format:write
- pnpm lint:check *(fails: missing @eslint/js package in environment)*
- pnpm --filter @grim/desktop build *(fails: workspace dependencies missing in environment)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: crates.io access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d101db9eb4832eaf797b5e1bbc77d3