### PR TITLE
Sync file tree selection with panels

### DIFF
--- a/apps/desktop/src/features/main/panel/Container.tsx
+++ b/apps/desktop/src/features/main/panel/Container.tsx
@@ -1,6 +1,6 @@
 import { usePanelsStore } from '@tgim/stores/index';
+import useFileTreeStore from '@tgim/stores/fileTreeStore';
 import { Tab } from '@tgim/ui/index';
-import { useShallow } from 'zustand/shallow';
 import { useCallback, useEffect } from 'react';
 import Panels from './Panel';
 
@@ -13,17 +13,62 @@ const PanelContainer: React.FC<Props> = ({ containerId }) => {
   const setActivePanel = usePanelsStore(state => state.setActivePanel);
   const panelEntities = usePanelsStore(state => state.panelEntities);
 
+  const syncSelectedNode = useCallback(
+    (panelId: string | null | undefined) => {
+      const { treeData, setSelectedNode, ensureVisible } = useFileTreeStore.getState();
+
+      if (!panelId) {
+        setSelectedNode(null);
+        return;
+      }
+
+      const panel = panelEntities[panelId];
+      if (!panel || panel.nodeId == null) {
+        setSelectedNode(null);
+        return;
+      }
+
+      const nodeId = String(panel.nodeId);
+
+      if (!treeData.length) {
+        setSelectedNode(nodeId);
+        return;
+      }
+
+      const ancestors = ensureVisible(nodeId);
+      if (!ancestors) {
+        setSelectedNode(null);
+        return;
+      }
+
+      setSelectedNode(nodeId);
+    },
+    [panelEntities],
+  );
+
   const parsePanel = useCallback(
     (panelIds: string[]) => {
       return panelIds.map(panelId => {
         const panel = panelEntities[panelId];
         return {
-          panelId: panel.id,
-          name: panel.name,
+          panelId: panel?.id ?? panelId,
+          name: panel?.name ?? 'Untitled',
         };
       });
     },
     [panelEntities],
+  );
+
+  useEffect(() => {
+    syncSelectedNode(focusedPanelId);
+  }, [focusedPanelId, syncSelectedNode]);
+
+  const handleSelectTab = useCallback(
+    (id: string) => {
+      setActivePanel(id);
+      syncSelectedNode(id);
+    },
+    [setActivePanel, syncSelectedNode],
   );
 
   return (
@@ -32,7 +77,7 @@ const PanelContainer: React.FC<Props> = ({ containerId }) => {
         containerId={containerId}
         selectedTabId={focusedPanelId}
         tabs={parsePanel(panels)}
-        onSelectTab={id => setActivePanel(id)}
+        onSelectTab={handleSelectTab}
       />
       <div className="flex-grow overflow-hidden">
         {panels.map(panel => (

--- a/apps/desktop/src/features/main/panel/FileTreePanel.tsx
+++ b/apps/desktop/src/features/main/panel/FileTreePanel.tsx
@@ -1,5 +1,5 @@
 import { FileTreeData } from '@tgim/types/index';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useHoverOpen,
   useMultiSelect,
@@ -73,10 +73,13 @@ export const FileTree = () => {
   const [isFolderModal, setIsFolderModal] = useState(false);
 
   // Select only what we need from the store (shallow compare to reduce re-renders)
-  const { treeData, onMove } = useFileTreeStore(
+  const { treeData, onMove, selectedNodeId, setSelectedNode, ensureVisible } = useFileTreeStore(
     useShallow(s => ({
       treeData: s.treeData,
       onMove: s.onMove,
+      selectedNodeId: s.selectedNodeId,
+      setSelectedNode: s.setSelectedNode,
+      ensureVisible: s.ensureVisible,
     })),
   );
 
@@ -99,7 +102,29 @@ export const FileTree = () => {
 
   // Multi-select (based on visible order)
   const visibleOrder = useMemo(() => flattenVisible(treeData, expanded), [treeData, expanded]);
-  const { selected, onItemClick, clearSelection, onDragStartSelect } = useMultiSelect(visibleOrder);
+  const {
+    selected,
+    setSelected,
+    setAnchorId,
+    onItemClick,
+    clearSelection: clearLocalSelection,
+    onDragStartSelect,
+  } = useMultiSelect(visibleOrder);
+
+  const skipSelectedSync = useRef(false);
+
+  const updateSelectedNode = useCallback(
+    (id: string | null) => {
+      skipSelectedSync.current = true;
+      setSelectedNode(id);
+    },
+    [setSelectedNode],
+  );
+
+  const handleClearSelection = useCallback(() => {
+    clearLocalSelection();
+    updateSelectedNode(null);
+  }, [clearLocalSelection, updateSelectedNode]);
 
   // Hover-to-open folder while dragging
   const { hoverId, onDragOverHoverOpen, resetHoverOpen } = useHoverOpen(
@@ -127,6 +152,52 @@ export const FileTree = () => {
   const [importProgress, setImportProgress] = useState<FolderImportProgressEvent | null>(null);
   const [importModalOpen, setImportModalOpen] = useState(false);
   const importContextRef = useRef<ImportContext | null>(null);
+
+  useEffect(() => {
+    if (skipSelectedSync.current) {
+      skipSelectedSync.current = false;
+      return;
+    }
+
+    if (!selectedNodeId) {
+      clearLocalSelection();
+      return;
+    }
+
+    setSelected(prev => {
+      if (prev.size === 1 && prev.has(selectedNodeId)) return prev;
+      return new Set([selectedNodeId]);
+    });
+    setAnchorId(selectedNodeId);
+  }, [selectedNodeId, clearLocalSelection, setAnchorId, setSelected]);
+
+  useEffect(() => {
+    if (!selectedNodeId) return;
+
+    const ancestors = ensureVisible(selectedNodeId);
+    if (!ancestors?.length) return;
+
+    setExpanded(prev => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const ancestorId of ancestors) {
+        if (!next.has(ancestorId)) {
+          next.add(ancestorId);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [selectedNodeId, ensureVisible, treeData]);
+
+  useEffect(() => {
+    if (!selectedNodeId) return;
+    if (!treeData.length) return;
+
+    if (!findNode(treeData, selectedNodeId)) {
+      updateSelectedNode(null);
+    }
+  }, [treeData, selectedNodeId, updateSelectedNode]);
 
   useEffect(() => {
     importContextRef.current = importContext;
@@ -191,7 +262,7 @@ export const FileTree = () => {
   };
 
   return (
-    <div className="w-full h-full text-sidebar-text" onClick={clearSelection}>
+    <div className="w-full h-full text-sidebar-text" onClick={handleClearSelection}>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -199,6 +270,7 @@ export const FileTree = () => {
           const id = String(active.id);
           setActiveId(id);
           onDragStartSelect(id);
+          updateSelectedNode(id);
         }}
         onDragCancel={() => {
           setActiveId(null);
@@ -246,8 +318,10 @@ export const FileTree = () => {
           selectedSet={selected}
           onSelect={(e: React.MouseEvent, id: string) => {
             onItemClick(e, id);
+            updateSelectedNode(id);
           }}
           openFile={(node: FileTreeData) => {
+            updateSelectedNode(node.id);
             openFile({
               nodeId: node.id,
               name: node.name,

--- a/apps/desktop/src/features/main/panel/FileTreePanel.tsx
+++ b/apps/desktop/src/features/main/panel/FileTreePanel.tsx
@@ -112,10 +112,13 @@ export const FileTree = () => {
   } = useMultiSelect(visibleOrder);
 
   const skipSelectedSync = useRef(false);
+  const manualSelection = useRef(false);
+  const pendingScrollId = useRef<string | null>(null);
 
   const updateSelectedNode = useCallback(
     (id: string | null) => {
       skipSelectedSync.current = true;
+      manualSelection.current = id !== null;
       setSelectedNode(id);
     },
     [setSelectedNode],
@@ -172,10 +175,25 @@ export const FileTree = () => {
   }, [selectedNodeId, clearLocalSelection, setAnchorId, setSelected]);
 
   useEffect(() => {
-    if (!selectedNodeId) return;
+    if (!selectedNodeId) {
+      manualSelection.current = false;
+      pendingScrollId.current = null;
+      return;
+    }
 
-    const ancestors = ensureVisible(selectedNodeId);
-    if (!ancestors?.length) return;
+    if (manualSelection.current) {
+      manualSelection.current = false;
+      pendingScrollId.current = null;
+      return;
+    }
+
+    const node = findNode(treeData, selectedNodeId);
+    if (!node) {
+      pendingScrollId.current = selectedNodeId;
+      return;
+    }
+
+    const ancestors = ensureVisible(selectedNodeId) ?? [];
 
     setExpanded(prev => {
       let changed = false;
@@ -186,9 +204,33 @@ export const FileTree = () => {
           changed = true;
         }
       }
+
+      if (node.children && !next.has(node.id)) {
+        next.add(node.id);
+        changed = true;
+      }
+
       return changed ? next : prev;
     });
+
+    pendingScrollId.current = selectedNodeId;
   }, [selectedNodeId, ensureVisible, treeData]);
+
+  useEffect(() => {
+    const targetId = pendingScrollId.current;
+    if (!targetId || targetId !== selectedNodeId) return;
+
+    const escapeId =
+      typeof window !== 'undefined' && window.CSS?.escape
+        ? window.CSS.escape(targetId)
+        : targetId.replace(/["\\]/g, '\\$&');
+
+    const element = document.querySelector<HTMLElement>(`[data-node-id="${escapeId}"]`);
+    if (!element) return;
+
+    pendingScrollId.current = null;
+    element.scrollIntoView({ block: 'nearest' });
+  }, [expanded, treeData, selectedNodeId]);
 
   useEffect(() => {
     if (!selectedNodeId) return;

--- a/packages/stores/src/fileTreeStore.ts
+++ b/packages/stores/src/fileTreeStore.ts
@@ -14,6 +14,10 @@ interface FileTreeState {
   setTreeData: (data: FileTreeData[]) => void;
   convertToTreeData: (data: GraphResponse) => FileTreeData[];
 
+  selectedNodeId: string | null;
+  setSelectedNode: (id: string | null) => void;
+  ensureVisible: (id: string) => string[] | null;
+
   // move nodes into a parent (append)
   onMove: (args: { dragIds: string[]; parentId: string; index?: number }) => void;
 }
@@ -78,6 +82,19 @@ const removeNode = (
   return { removed, next };
 };
 
+// Path from root to id (inclusive) or null when not found
+const findPathToNode = (tree: FileTreeData[], id: string, path: string[] = []): string[] | null => {
+  for (const node of tree) {
+    const nextPath = [...path, node.id];
+    if (node.id === id) return nextPath;
+    if (node.children?.length) {
+      const found = findPathToNode(node.children, id, nextPath);
+      if (found) return found;
+    }
+  }
+  return null;
+};
+
 // Insert `node` under `parentId` (append). Special parentId "root" means top-level.
 const insertNode = (tree: FileTreeData[], parentId: string, node: FileTreeData): FileTreeData[] => {
   if (parentId === 'root') return [...tree, node];
@@ -130,7 +147,23 @@ const batchMoveIntoParent = (tree: FileTreeData[], ids: string[], targetParent: 
 
 const useFileTreeStore = create<FileTreeState>((set, get) => ({
   treeData: [],
-  setTreeData: data => set({ treeData: data }),
+  setTreeData: data =>
+    set(state => {
+      const next: Partial<FileTreeState> = { treeData: data };
+      if (state.selectedNodeId && !findNode(data, state.selectedNodeId)) {
+        next.selectedNodeId = null;
+      }
+      return next;
+    }),
+
+  selectedNodeId: null,
+  setSelectedNode: id => set({ selectedNodeId: id }),
+  ensureVisible: id => {
+    if (!id) return null;
+    const path = findPathToNode(get().treeData, id);
+    if (!path) return null;
+    return path.slice(0, -1);
+  },
 
   convertToTreeData: data => {
     const { nodes, connections } = data;

--- a/packages/ui/src/FileTree.tsx
+++ b/packages/ui/src/FileTree.tsx
@@ -49,7 +49,7 @@ export const TreeNode: React.FC<{
   const indentStyle = { ['--depth' as any]: depth } as React.CSSProperties;
 
   return (
-    <li ref={setRefs} className="tree-node">
+    <li ref={setRefs} className="tree-node" data-node-id={node.id}>
       <div
         className={cn(
           'tree-row',


### PR DESCRIPTION
## Summary
- add selected node tracking and helper utilities to the file tree store to keep the highlighted node in sync with available tree data
- update the file tree panel to drive its selection from the shared store, auto-expand ancestors, and clear stale selections when nodes disappear
- sync panel tab activation with the file tree store so selecting a tab highlights (or clears) the matching node in the tree

## Testing
- pnpm prettier --write packages/stores/src/fileTreeStore.ts apps/desktop/src/features/main/panel/FileTreePanel.tsx apps/desktop/src/features/main/panel/Container.tsx
- pnpm lint:check *(fails: missing dependencies in the offline environment)*
- pnpm --filter @grim/desktop build *(fails: missing dependencies in the offline environment)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: unable to reach crates.io from the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11595e1e0832ea0a57888b3fc9206