### PR TITLE
feat(croquis): add start modal configuration

### DIFF
--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -1,0 +1,394 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { join } from '@tauri-apps/api/path';
+import { Button, Input, Modal, Switch } from '@tgim/ui';
+import { CroquisOption, CroquisStartResponse } from '@tgim/types/croquis';
+import { ipc } from '../../lib/ipc';
+import { toast } from 'react-toastify';
+
+type WindowPreset = {
+  label: string;
+  width: string | null;
+  height: string | null;
+};
+
+const WINDOW_PRESETS: WindowPreset[] = [
+  { label: 'Default', width: null, height: null },
+  { label: '1024×768', width: '1024', height: '768' },
+  { label: '1280×720', width: '1280', height: '720' },
+  { label: '1920×1080', width: '1920', height: '1080' },
+];
+
+const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
+  window: {
+    width: option.window?.width ?? null,
+    height: option.window?.height ?? null,
+  },
+  auto: {
+    isSkip: option.auto?.isSkip ?? false,
+  },
+  timer: {
+    max_time: option.timer?.max_time ?? 60,
+  },
+  isCapture: option.isCapture ?? false,
+  savePath: option.savePath ?? '',
+  isGray: option.isGray ?? false,
+  isShuffle: option.isShuffle ?? false,
+});
+
+export type CroquisStartModalConfirmPayload = {
+  response: CroquisStartResponse;
+  option: CroquisOption;
+  remember: boolean;
+};
+
+type CroquisStartModalProps = {
+  open: boolean;
+  option: CroquisOption;
+  moaId: string | null;
+  imageHashes: string[];
+  remember?: boolean;
+  onConfirm?: (payload: CroquisStartModalConfirmPayload) => void | Promise<void>;
+  onClose: () => void;
+};
+
+const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
+  open,
+  option,
+  moaId,
+  imageHashes,
+  remember = false,
+  onConfirm,
+  onClose,
+}) => {
+  const [localOption, setLocalOption] = useState<CroquisOption>(() =>
+    normaliseCroquisOption(option),
+  );
+  const [rememberSettings, setRememberSettings] = useState<boolean>(Boolean(remember));
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLocalOption(normaliseCroquisOption(option));
+    setRememberSettings(Boolean(remember));
+  }, [open, option, remember]);
+
+  useEffect(() => {
+    if (!open || !moaId) return;
+    if (localOption.savePath) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const moas = await ipc.moa.loadMoas();
+        const target = moas.find(moa => moa.moa_id === moaId);
+        if (!target) return;
+        const defaultPath = await join(target.path, 'croquis');
+        if (cancelled) return;
+        setLocalOption(prev => ({
+          ...prev,
+          savePath: defaultPath,
+        }));
+      } catch (error) {
+        console.error('[Croquis] Failed to resolve default save path', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, moaId, localOption.savePath]);
+
+  const selectedCount = imageHashes.length;
+
+  const windowWidth = localOption.window?.width ?? '';
+  const windowHeight = localOption.window?.height ?? '';
+
+  const skipMode = localOption.auto.isSkip ? 'auto' : 'manual';
+  const rememberMode = rememberSettings ? 'remember' : 'session';
+
+  const handleWindowPresetClick = useCallback((preset: WindowPreset) => {
+    setLocalOption(prev => ({
+      ...prev,
+      window: {
+        width: preset.width,
+        height: preset.height,
+      },
+    }));
+  }, []);
+
+  const handleWindowDimensionChange = useCallback((key: 'width' | 'height') => {
+    return (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      setLocalOption(prev => ({
+        ...prev,
+        window: {
+          ...prev.window,
+          [key]: value ? value : null,
+        },
+      }));
+    };
+  }, []);
+
+  const handleTimerChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = Number(event.target.value);
+    setLocalOption(prev => ({
+      ...prev,
+      timer: {
+        ...prev.timer,
+        maxTime: Number.isFinite(next) && next >= 0 ? next : 0,
+      },
+    }));
+  }, []);
+
+  const handleToggleOption = useCallback((key: 'isGray' | 'isCapture' | 'isShuffle') => {
+    setLocalOption(prev => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  }, []);
+
+  const handleSavePathChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setLocalOption(prev => ({
+      ...prev,
+      savePath: value,
+    }));
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    if (submitting) return;
+    if (!selectedCount) {
+      toast.error('Select at least one image to start Croquis.');
+      return;
+    }
+    if (!moaId) {
+      toast.error('Workspace information is not ready yet.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await ipc.croquis.startSession({
+        moaId,
+        imageHashes,
+        option: { ...localOption, auto: { isSkip: false } },
+        saveOption: rememberSettings,
+      });
+      await onConfirm?.({ response, option: localOption, remember: rememberSettings });
+      onClose();
+      return response;
+    } catch (error) {
+      console.error('[Croquis] Failed to start session', error);
+      toast.error('Failed to start Croquis. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [
+    imageHashes,
+    localOption,
+    moaId,
+    onClose,
+    onConfirm,
+    rememberSettings,
+    selectedCount,
+    submitting,
+  ]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <Modal onClose={handleCancel} dismissible>
+      <div className="flex w-[32rem] max-w-full flex-col gap-6 text-text">
+        <div>
+          <h2 className="text-lg font-semibold">Start Croquis session</h2>
+          <p className="mt-1 text-sm text-text-soft">
+            {selectedCount === 1
+              ? '1 image selected'
+              : `${selectedCount.toLocaleString()} images selected`}
+          </p>
+        </div>
+
+        <section className="space-y-3">
+          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+            Window size
+          </header>
+          <div className="flex flex-wrap gap-2">
+            {WINDOW_PRESETS.map(preset => {
+              const isActive =
+                (preset.width ?? '') === (localOption.window?.width ?? '') &&
+                (preset.height ?? '') === (localOption.window?.height ?? '');
+              return (
+                <Button
+                  key={preset.label}
+                  variant="toggle"
+                  active={isActive}
+                  onClick={() => handleWindowPresetClick(preset)}
+                >
+                  {preset.label}
+                </Button>
+              );
+            })}
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Width
+              </span>
+              <Input.Input
+                type="number"
+                min={0}
+                inputMode="numeric"
+                className="input-default"
+                value={windowWidth}
+                placeholder="e.g. 1280"
+                onChange={handleWindowDimensionChange('width')}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm">
+              <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Height
+              </span>
+              <Input.Input
+                type="number"
+                min={0}
+                inputMode="numeric"
+                className="input-default"
+                value={windowHeight}
+                placeholder="e.g. 720"
+                onChange={handleWindowDimensionChange('height')}
+              />
+            </label>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+            Auto skip
+          </header>
+          <Switch
+            current={skipMode}
+            onChanged={value =>
+              setLocalOption(prev => ({
+                ...prev,
+                auto: {
+                  ...prev.auto,
+                  skip: value === 'auto',
+                },
+              }))
+            }
+            options={[
+              { name: 'Auto skip breaks', value: 'auto' },
+              { name: 'Manual control', value: 'manual' },
+            ]}
+          />
+        </section>
+
+        <section className="space-y-3">
+          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+            Timer
+          </header>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+              Seconds per pose
+            </span>
+            <Input.Input
+              type="number"
+              min={5}
+              step={5}
+              inputMode="numeric"
+              className="input-default"
+              value={localOption.timer.max_time.toString()}
+              onChange={handleTimerChange}
+            />
+          </label>
+        </section>
+
+        <section className="space-y-3">
+          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+            Session options
+          </header>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="toggle"
+              active={localOption.isCapture}
+              onClick={() => handleToggleOption('isCapture')}
+            >
+              Capture reference
+            </Button>
+            <Button
+              type="button"
+              variant="toggle"
+              active={localOption.isGray}
+              onClick={() => handleToggleOption('isGray')}
+            >
+              Grayscale
+            </Button>
+            <Button
+              type="button"
+              variant="toggle"
+              active={localOption.isShuffle}
+              onClick={() => handleToggleOption('isShuffle')}
+            >
+              Shuffle order
+            </Button>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+            Saving
+          </header>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+              Save path
+            </span>
+            <Input.Input
+              type="text"
+              className="input-default"
+              value={localOption.savePath}
+              placeholder="Path for captured images"
+              onChange={handleSavePathChange}
+            />
+          </label>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-xs text-text-soft">
+              Remember these settings for this workspace?
+            </span>
+            <Switch
+              current={rememberMode}
+              onChanged={value => setRememberSettings(value === 'remember')}
+              options={[
+                { name: 'This session', value: 'session' },
+                { name: 'Remember', value: 'remember' },
+              ]}
+            />
+          </div>
+        </section>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleConfirm}
+            disabled={submitting || !selectedCount}
+          >
+            {submitting ? 'Starting…' : 'Start Croquis'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CroquisStartModal;

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -1,4 +1,3 @@
-import { listen } from '@tauri-apps/api/event';
 import { useMoa } from '@tgim/hooks/useMoa';
 import { useMultiSelect } from '@tgim/dnd/index';
 import { GridData, ImageItem } from '@tgim/types/grid';
@@ -11,6 +10,10 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import Masonry from 'react-masonry-css';
 import { FixedSizeGrid as WindowGrid, GridChildComponentProps } from 'react-window';
 import { Button } from '@tgim/ui';
+import { CroquisOption } from '@tgim/types/croquis';
+import CroquisStartModal, {
+  CroquisStartModalConfirmPayload,
+} from '../../../croquis/CroquisStartModal';
 
 /* ---------------------------------------------
  * Helper Icon Components (unchanged)
@@ -70,6 +73,16 @@ const SIZES: Size[] = ['small', 'medium', 'large'];
 const LAYOUTS: Layout[] = ['grid', 'masonry'];
 const MAX_ITEMS_PER_REQ = 100;
 const INITIAL_FETCH_COUNT = 50;
+
+const createDefaultCroquisOption = (): CroquisOption => ({
+  window: { width: null, height: null },
+  auto: { isSkip: true },
+  timer: { max_time: 1000 },
+  isCapture: false,
+  savePath: '',
+  isGray: false,
+  isShuffle: false,
+});
 
 // Debounce Hook (unchanged)
 function useDebouncedEffect(fn: () => void, deps: React.DependencyList, delay: number) {
@@ -186,6 +199,43 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     images.forEach(img => (map[img.hash] = img));
     return map;
   }, [images]);
+
+  const [croquisModalOpen, setCroquisModalOpen] = useState(false);
+  const [croquisOption, setCroquisOption] = useState<CroquisOption>(() =>
+    createDefaultCroquisOption(),
+  );
+  const [rememberCroquisOption, setRememberCroquisOption] = useState(false);
+
+  const selectedCount = selected.size;
+  const selectedHashes = useMemo(() => Array.from(selected), [selected]);
+
+  const handleStartCroquis = useCallback(() => {
+    if (selectedCount === 0) return;
+    if (!moaId) {
+      console.warn('Croquis start requested without a workspace id');
+      return;
+    }
+    setCroquisModalOpen(true);
+  }, [moaId, selectedCount]);
+
+  const handleCroquisModalClose = useCallback(() => {
+    setCroquisModalOpen(false);
+  }, []);
+
+  const handleCroquisConfirm = useCallback(
+    ({ option, remember }: CroquisStartModalConfirmPayload) => {
+      setCroquisOption(option);
+      setRememberCroquisOption(remember);
+      clearSelection();
+    },
+    [clearSelection],
+  );
+
+  useEffect(() => {
+    if (selectedCount === 0 && croquisModalOpen) {
+      setCroquisModalOpen(false);
+    }
+  }, [croquisModalOpen, selectedCount]);
 
   const { upsertThumb } = useThumbStore(
     useShallow(state => ({
@@ -312,8 +362,6 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     return '';
   }, [size, layout]);
 
-  const selectedCount = selected.size;
-
   const handleToggleSelectMode = useCallback(() => {
     setSelectMode(prev => {
       if (prev) {
@@ -323,28 +371,6 @@ const GridView: React.FC<Props> = ({ gridData }) => {
       return true;
     });
   }, [clearSelection]);
-
-  const handleStartCroquis = useCallback(() => {
-    console.log('Starting Croquis with selected items:', selected);
-    if (!moaId) return;
-    ipc.croquis.startSession({
-      imageHashes: Array.from(selected),
-      moaId: moaId,
-      option: {
-        window: {},
-        auto: {
-          isSkip: true,
-        },
-        timer: {
-          maxTime: 1000,
-        },
-        savePath: '',
-        isCapture: false,
-        isGray: false,
-        isShuffle: false,
-      },
-    });
-  }, [selected, moaId]);
 
   const handleBackgroundClick = useCallback(() => {
     clearSelection();
@@ -434,6 +460,15 @@ const GridView: React.FC<Props> = ({ gridData }) => {
           />
         )}
       </div>
+      <CroquisStartModal
+        open={croquisModalOpen && selectedCount > 0}
+        option={croquisOption}
+        remember={rememberCroquisOption}
+        imageHashes={selectedHashes}
+        moaId={moaId}
+        onConfirm={handleCroquisConfirm}
+        onClose={handleCroquisModalClose}
+      />
     </div>
   );
 };

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -8,7 +8,7 @@ export interface CroquisAutoOption {
 }
 
 export interface CroquisTimerOption {
-  maxTime: number;
+  max_time: number;
 }
 
 export interface CroquisOption {


### PR DESCRIPTION
## Summary
- add a CroquisStartModal component that lets users review croquis options, resolves a default save path, and launches the session via ipc
- integrate GridView with the new modal so selections open the dialog, state persists between runs, and selection clears on success

## Testing
- pnpm lint:check *(fails: missing @eslint/js in the container)*
- pnpm --filter @grim/desktop build *(fails: project dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d140c25e00832ea1f003b9fceb6210