### PR TITLE
Load Croquis start modal options from backend

### DIFF
--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,6 +1,7 @@
 use crate::{
     models::croquis::{
-        CroquisSession, CroquisStartPayload, CroquisStartResponse,
+        CroquisOption, CroquisSession, CroquisStartPayload,
+        CroquisStartResponse,
     },
     services::croquis_service,
 };
@@ -22,4 +23,12 @@ pub async fn load_croquis_session(
     session_id: String,
 ) -> Result<Option<CroquisSession>, String> {
     Ok(croquis_service::load_session(&session_id).await)
+}
+
+/// Load persisted Croquis options for the provided workspace if available.
+#[tauri::command]
+pub async fn load_croquis_option(
+    moa_id: String,
+) -> Result<Option<CroquisOption>, String> {
+    croquis_service::load_option(&moa_id).await.map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
             commands::file::preview_folder_import,
             commands::croquis::start_croquis_session,
             commands::croquis::load_croquis_session,
+            commands::croquis::load_croquis_option,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::ErrorKind};
 
 use anyhow::{anyhow, bail, Context, Result};
 use once_cell::sync::Lazy;
@@ -118,6 +118,32 @@ pub async fn start_session(
 pub async fn load_session(session_id: &str) -> Option<CroquisSession> {
     let sessions = CROQUIS_SESSIONS.read().await;
     sessions.get(session_id).cloned()
+}
+
+/// Load the persisted Croquis option payload from the workspace settings directory.
+pub async fn load_option(moa_id: &str) -> Result<Option<CroquisOption>> {
+    let paths = PATH_MANAGER
+        .get_or_add(moa_id)
+        .await
+        .context("Failed to resolve workspace paths")?;
+
+    let settings_dir = paths.moa_dir.join("settings");
+    let file_path = settings_dir.join("croquis.json");
+
+    match fs::read(&file_path).await {
+        Ok(payload) => {
+            let option = serde_json::from_slice(&payload)
+                .context("Failed to deserialise Croquis options")?;
+            Ok(Some(option))
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Failed to read Croquis options from {}",
+                file_path.display()
+            )
+        }),
+    }
 }
 
 /// Persist the Croquis option payload into the workspace `.moa/settings` folder.

--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { join } from '@tauri-apps/api/path';
 import { Button, Input, Modal, Switch } from '@tgim/ui';
 import { CroquisOption, CroquisStartResponse } from '@tgim/types/croquis';
@@ -28,7 +28,10 @@ const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
     isSkip: option.auto?.isSkip ?? false,
   },
   timer: {
-    max_time: option.timer?.max_time ?? 60,
+    max_time:
+      option.timer?.max_time ??
+      (option.timer as unknown as { maxTime?: number } | undefined)?.maxTime ??
+      60,
   },
   isCapture: option.isCapture ?? false,
   savePath: option.savePath ?? '',
@@ -66,12 +69,38 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   );
   const [rememberSettings, setRememberSettings] = useState<boolean>(Boolean(remember));
   const [submitting, setSubmitting] = useState(false);
+  const hasUserInteractedRef = useRef(false);
+  const markInteracted = useCallback(() => {
+    hasUserInteractedRef.current = true;
+  }, []);
 
   useEffect(() => {
     if (!open) return;
+    hasUserInteractedRef.current = false;
     setLocalOption(normaliseCroquisOption(option));
     setRememberSettings(Boolean(remember));
   }, [open, option, remember]);
+
+  useEffect(() => {
+    if (!open || !moaId) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const persistedOption = await ipc.croquis.loadOption(moaId);
+        if (cancelled || !persistedOption) return;
+        if (hasUserInteractedRef.current) return;
+        setLocalOption(normaliseCroquisOption(persistedOption));
+      } catch (error) {
+        console.error('[Croquis] Failed to load saved options', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, moaId]);
 
   useEffect(() => {
     if (!open || !moaId) return;
@@ -108,53 +137,78 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   const skipMode = localOption.auto.isSkip ? 'auto' : 'manual';
   const rememberMode = rememberSettings ? 'remember' : 'session';
 
-  const handleWindowPresetClick = useCallback((preset: WindowPreset) => {
-    setLocalOption(prev => ({
-      ...prev,
-      window: {
-        width: preset.width,
-        height: preset.height,
-      },
-    }));
-  }, []);
-
-  const handleWindowDimensionChange = useCallback((key: 'width' | 'height') => {
-    return (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
+  const handleWindowPresetClick = useCallback(
+    (preset: WindowPreset) => {
+      markInteracted();
       setLocalOption(prev => ({
         ...prev,
         window: {
-          ...prev.window,
-          [key]: value ? value : null,
+          width: preset.width,
+          height: preset.height,
         },
       }));
-    };
-  }, []);
+    },
+    [markInteracted],
+  );
 
-  const handleTimerChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const next = Number(event.target.value);
-    setLocalOption(prev => ({
-      ...prev,
-      timer: {
-        ...prev.timer,
-        maxTime: Number.isFinite(next) && next >= 0 ? next : 0,
-      },
-    }));
-  }, []);
+  const handleWindowDimensionChange = useCallback(
+    (key: 'width' | 'height') => {
+      return (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = event.target.value;
+        markInteracted();
+        setLocalOption(prev => ({
+          ...prev,
+          window: {
+            ...prev.window,
+            [key]: value ? value : null,
+          },
+        }));
+      };
+    },
+    [markInteracted],
+  );
 
-  const handleToggleOption = useCallback((key: 'isGray' | 'isCapture' | 'isShuffle') => {
-    setLocalOption(prev => ({
-      ...prev,
-      [key]: !prev[key],
-    }));
-  }, []);
+  const handleTimerChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = Number(event.target.value);
+      const safeValue = Number.isFinite(next) && next >= 0 ? next : 0;
+      markInteracted();
+      setLocalOption(prev => {
+        const timer = {
+          ...prev.timer,
+          max_time: safeValue,
+        } as typeof prev.timer & { maxTime?: number };
+        timer.maxTime = safeValue;
+        return {
+          ...prev,
+          timer,
+        };
+      });
+    },
+    [markInteracted],
+  );
 
-  const handleSavePathChange = useCallback((value: string) => {
-    setLocalOption(prev => ({
-      ...prev,
-      savePath: value,
-    }));
-  }, []);
+  const handleToggleOption = useCallback(
+    (key: 'isGray' | 'isCapture' | 'isShuffle') => {
+      markInteracted();
+      setLocalOption(prev => ({
+        ...prev,
+        [key]: !prev[key],
+      }));
+    },
+    [markInteracted],
+  );
+
+  const handleSavePathChange = useCallback(
+    (value: string) => {
+      markInteracted();
+      setLocalOption(prev => ({
+        ...prev,
+        savePath: value,
+      }));
+    },
+    [markInteracted],
+  );
 
   const handleCancel = useCallback(() => {
     onClose();
@@ -173,10 +227,24 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
 
     setSubmitting(true);
     try {
+      const maxTimeValue =
+        localOption.timer.max_time ??
+        (localOption.timer as unknown as { maxTime?: number }).maxTime ??
+        60;
+      const payloadOption = {
+        ...localOption,
+        auto: { isSkip: false },
+        timer: {
+          ...localOption.timer,
+          max_time: maxTimeValue,
+        },
+      } as CroquisOption & { timer: CroquisOption['timer'] & { maxTime?: number } };
+      payloadOption.timer.maxTime = maxTimeValue;
+
       const response = await ipc.croquis.startSession({
         moaId,
         imageHashes,
-        option: { ...localOption, auto: { isSkip: false } },
+        option: payloadOption,
         saveOption: rememberSettings,
       });
       await onConfirm?.({ response, option: localOption, remember: rememberSettings });
@@ -274,15 +342,16 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
           </header>
           <Switch
             current={skipMode}
-            onChanged={value =>
+            onChanged={value => {
+              markInteracted();
               setLocalOption(prev => ({
                 ...prev,
                 auto: {
                   ...prev.auto,
                   skip: value === 'auto',
                 },
-              }))
-            }
+              }));
+            }}
             options={[
               { name: 'Auto skip breaks', value: 'auto' },
               { name: 'Manual control', value: 'manual' },

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -2,7 +2,12 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
 import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
-import { CroquisSession, CroquisStartPayload, CroquisStartResponse } from '@tgim/types/croquis';
+import {
+  CroquisOption,
+  CroquisSession,
+  CroquisStartPayload,
+  CroquisStartResponse,
+} from '@tgim/types/croquis';
 
 const appWindow = getCurrentWindow();
 
@@ -75,6 +80,10 @@ const croquisIpc = {
   loadSession: async (sessionId: string): Promise<CroquisSession | null> => {
     const response = await invoke('load_croquis_session', { sessionId });
     return (response as CroquisSession | null) ?? null;
+  },
+  loadOption: async (moaId: string): Promise<CroquisOption | null> => {
+    const response = await invoke('load_croquis_option', { moaId });
+    return (response as CroquisOption | null) ?? null;
   },
 };
 


### PR DESCRIPTION
## Summary
- add a croquis service helper and Tauri command to return any persisted Croquis option payload for a workspace
- expose the new IPC method and hydrate `CroquisStartModal` with backend data while preserving user edits and correct timer serialization

## Testing
- `pnpm format:write >/tmp/format.log`
- `pnpm lint:check` *(fails: missing @eslint/js because npm registry auth is unavailable in the sandbox)*
- `pnpm --filter @grim/desktop build` *(fails: many dependencies such as zustand are unavailable without npm install access in the sandbox)*
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: cargo cannot reach crates.io in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d155646954832e8294522898289a03