### PR TITLE
Implement Croquis session window player

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -53,3 +53,7 @@ plist = "1.7.4"
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.3", features = ["Win32_Storage_FileSystem"] }
 winapi = "0.3.9"
+
+[features]
+macos-private-api = []
+

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -29,6 +29,7 @@
     "core:path:allow-resolve-directory",
     "core:webview:allow-internal-toggle-devtools",
     "dialog:default",
-    "decorum:allow-show-snap-overlay"
+    "decorum:allow-show-snap-overlay",
+    "core:window:allow-set-size"
   ]
 }

--- a/apps/desktop/src-tauri/src/app_launcher/croquis.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/croquis.rs
@@ -1,4 +1,4 @@
-use tauri::WebviewUrl;
+use tauri::{window::Color, WebviewUrl};
 #[cfg(target_os = "macos")]
 use tauri_plugin_decorum::WebviewWindowExt;
 
@@ -23,13 +23,16 @@ pub fn launch_croquis(
         tauri::WebviewWindowBuilder::new(app, window_label.clone(), url)
             .title("Croquis")
             .resizable(true)
-            .maximizable(false);
+            .maximizable(false)
+            .always_on_top(true)
+            .background_color(Color(0, 0, 0, 0));
 
     let width = parse_dimension(session.option.window.width.as_ref());
     let height = parse_dimension(session.option.window.height.as_ref());
 
     builder = match (width, height) {
         (Some(w), Some(h)) => builder.inner_size(w, h),
+        (Some(w), None) => builder.inner_size(w, 720.0),
         _ => builder.inner_size(1024.0, 720.0),
     };
 

--- a/apps/desktop/src-tauri/src/app_launcher/croquis.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/croquis.rs
@@ -12,7 +12,7 @@ pub fn launch_croquis(
     let uri = format!("croquis?session_id={}", session.session_id);
 
     #[cfg(debug_assertions)]
-    let url = WebviewUrl::App(format!("index.html#{uri}").into());
+    let url = WebviewUrl::App(format!("http://localhost:1420/#/{uri}").into());
 
     #[cfg(not(debug_assertions))]
     let url = WebviewUrl::App(format!("index.html#{uri}").into());
@@ -21,7 +21,7 @@ pub fn launch_croquis(
 
     let mut builder =
         tauri::WebviewWindowBuilder::new(app, window_label.clone(), url)
-            .title("Croquis")
+            .title("")
             .resizable(true)
             .maximizable(false)
             .always_on_top(true)

--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,6 +1,7 @@
 use crate::{
     models::croquis::{
-        CroquisSession, CroquisStartPayload, CroquisStartResponse,
+        CroquisOption, CroquisSession, CroquisStartPayload,
+        CroquisStartResponse,
     },
     services::croquis_service,
 };
@@ -22,4 +23,12 @@ pub async fn load_croquis_session(
     session_id: String,
 ) -> Result<Option<CroquisSession>, String> {
     Ok(croquis_service::load_session(&session_id).await)
+}
+
+/// Load persisted Croquis options for the provided workspace if available.
+#[tauri::command]
+pub async fn load_croquis_option(
+    moa_id: String,
+) -> Result<Option<CroquisOption>, String> {
+    croquis_service::load_option(&moa_id).await.map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
             commands::file::preview_folder_import,
             commands::croquis::start_croquis_session,
             commands::croquis::load_croquis_session,
+            commands::croquis::load_croquis_option,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::ErrorKind};
 
 use anyhow::{anyhow, bail, Context, Result};
 use once_cell::sync::Lazy;
@@ -118,6 +118,32 @@ pub async fn start_session(
 pub async fn load_session(session_id: &str) -> Option<CroquisSession> {
     let sessions = CROQUIS_SESSIONS.read().await;
     sessions.get(session_id).cloned()
+}
+
+/// Load the persisted Croquis option payload from the workspace settings directory.
+pub async fn load_option(moa_id: &str) -> Result<Option<CroquisOption>> {
+    let paths = PATH_MANAGER
+        .get_or_add(moa_id)
+        .await
+        .context("Failed to resolve workspace paths")?;
+
+    let settings_dir = paths.moa_dir.join("settings");
+    let file_path = settings_dir.join("croquis.json");
+
+    match fs::read(&file_path).await {
+        Ok(payload) => {
+            let option = serde_json::from_slice(&payload)
+                .context("Failed to deserialise Croquis options")?;
+            Ok(Some(option))
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "Failed to read Croquis options from {}",
+                file_path.display()
+            )
+        }),
+    }
 }
 
 /// Persist the Croquis option payload into the workspace `.moa/settings` folder.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -14,6 +14,7 @@
     "windows": [],
     "security": {
       "csp": null,
+      
       "assetProtocol": {
         "enable": true,
         "scope": [
@@ -46,3 +47,4 @@
     ]
   }
 }
+

--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -28,8 +28,8 @@ const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
     isSkip: option.auto?.isSkip ?? false,
   },
   timer: {
-    max_time:
-      option.timer?.max_time ??
+    maxTime:
+      option.timer?.maxTime ??
       (option.timer as unknown as { maxTime?: number } | undefined)?.maxTime ??
       60,
   },
@@ -176,7 +176,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
       setLocalOption(prev => {
         const timer = {
           ...prev.timer,
-          max_time: safeValue,
+          maxTime: safeValue,
         } as typeof prev.timer & { maxTime?: number };
         timer.maxTime = safeValue;
         return {
@@ -228,15 +228,15 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
     setSubmitting(true);
     try {
       const maxTimeValue =
-        localOption.timer.max_time ??
+        localOption.timer.maxTime ??
         (localOption.timer as unknown as { maxTime?: number }).maxTime ??
         60;
       const payloadOption = {
         ...localOption,
-        auto: { isSkip: false },
+        auto: { isSkip: skipMode === 'auto' },
         timer: {
           ...localOption.timer,
-          max_time: maxTimeValue,
+          maxTime: maxTimeValue,
         },
       } as CroquisOption & { timer: CroquisOption['timer'] & { maxTime?: number } };
       payloadOption.timer.maxTime = maxTimeValue;
@@ -348,7 +348,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
                 ...prev,
                 auto: {
                   ...prev.auto,
-                  skip: value === 'auto',
+                  isSkip: value === 'auto',
                 },
               }));
             }}
@@ -373,7 +373,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
               step={5}
               inputMode="numeric"
               className="input-default"
-              value={localOption.timer.max_time.toString()}
+              value={localOption.timer.maxTime.toString()}
               onChange={handleTimerChange}
             />
           </label>

--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -3,6 +3,8 @@ import { join } from '@tauri-apps/api/path';
 import { Button, Input, Modal, Switch } from '@tgim/ui';
 import { CroquisOption, CroquisStartResponse } from '@tgim/types/croquis';
 import { ipc } from '../../lib/ipc';
+import { open as pickerOpen } from '@tauri-apps/plugin-dialog';
+
 import { toast } from 'react-toastify';
 
 type WindowPreset = {
@@ -12,10 +14,9 @@ type WindowPreset = {
 };
 
 const WINDOW_PRESETS: WindowPreset[] = [
-  { label: 'Default', width: null, height: null },
-  { label: '1024×768', width: '1024', height: '768' },
-  { label: '1280×720', width: '1280', height: '720' },
-  { label: '1920×1080', width: '1920', height: '1080' },
+  { label: 'Custom', width: null, height: null },
+  { label: '256xauto', width: '256', height: '0' },
+  { label: '512xauto', width: '512', height: '0' },
 ];
 
 const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
@@ -148,8 +149,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
     }));
   }, []);
 
-  const handleSavePathChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
+  const handleSavePathChange = useCallback((value: string) => {
     setLocalOption(prev => ({
       ...prev,
       savePath: value,
@@ -346,7 +346,14 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
           <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
             Saving
           </header>
-          <label className="flex flex-col gap-1 text-sm">
+          <label
+            className="flex flex-col gap-1 text-sm"
+            onClick={async () => {
+              const result = await pickerOpen({ directory: true });
+              if (!result) return;
+              handleSavePathChange(result);
+            }}
+          >
             <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
               Save path
             </span>
@@ -355,7 +362,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
               className="input-default"
               value={localOption.savePath}
               placeholder="Path for captured images"
-              onChange={handleSavePathChange}
+              readOnly
             />
           </label>
           <div className="flex items-center justify-between gap-3">

--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { join } from '@tauri-apps/api/path';
 import { Button, Input, Modal, Switch } from '@tgim/ui';
 import { CroquisOption, CroquisStartResponse } from '@tgim/types/croquis';
@@ -28,7 +28,10 @@ const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
     isSkip: option.auto?.isSkip ?? false,
   },
   timer: {
-    max_time: option.timer?.max_time ?? 60,
+    max_time:
+      option.timer?.max_time ??
+      (option.timer as unknown as { maxTime?: number } | undefined)?.maxTime ??
+      60,
   },
   isCapture: option.isCapture ?? false,
   savePath: option.savePath ?? '',
@@ -66,12 +69,38 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   );
   const [rememberSettings, setRememberSettings] = useState<boolean>(Boolean(remember));
   const [submitting, setSubmitting] = useState(false);
+  const hasUserInteractedRef = useRef(false);
+  const markInteracted = useCallback(() => {
+    hasUserInteractedRef.current = true;
+  }, []);
 
   useEffect(() => {
     if (!open) return;
+    hasUserInteractedRef.current = false;
     setLocalOption(normaliseCroquisOption(option));
     setRememberSettings(Boolean(remember));
   }, [open, option, remember]);
+
+  useEffect(() => {
+    if (!open || !moaId) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const persistedOption = await ipc.croquis.loadOption(moaId);
+        if (cancelled || !persistedOption) return;
+        if (hasUserInteractedRef.current) return;
+        setLocalOption(normaliseCroquisOption(persistedOption));
+      } catch (error) {
+        console.error('[Croquis] Failed to load saved options', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, moaId]);
 
   useEffect(() => {
     if (!open || !moaId) return;
@@ -108,53 +137,78 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   const skipMode = localOption.auto.isSkip ? 'auto' : 'manual';
   const rememberMode = rememberSettings ? 'remember' : 'session';
 
-  const handleWindowPresetClick = useCallback((preset: WindowPreset) => {
-    setLocalOption(prev => ({
-      ...prev,
-      window: {
-        width: preset.width,
-        height: preset.height,
-      },
-    }));
-  }, []);
-
-  const handleWindowDimensionChange = useCallback((key: 'width' | 'height') => {
-    return (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
+  const handleWindowPresetClick = useCallback(
+    (preset: WindowPreset) => {
+      markInteracted();
       setLocalOption(prev => ({
         ...prev,
         window: {
-          ...prev.window,
-          [key]: value ? value : null,
+          width: preset.width,
+          height: preset.height,
         },
       }));
-    };
-  }, []);
+    },
+    [markInteracted],
+  );
 
-  const handleTimerChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const next = Number(event.target.value);
-    setLocalOption(prev => ({
-      ...prev,
-      timer: {
-        ...prev.timer,
-        maxTime: Number.isFinite(next) && next >= 0 ? next : 0,
-      },
-    }));
-  }, []);
+  const handleWindowDimensionChange = useCallback(
+    (key: 'width' | 'height') => {
+      return (event: React.ChangeEvent<HTMLInputElement>) => {
+        const value = event.target.value;
+        markInteracted();
+        setLocalOption(prev => ({
+          ...prev,
+          window: {
+            ...prev.window,
+            [key]: value ? value : null,
+          },
+        }));
+      };
+    },
+    [markInteracted],
+  );
 
-  const handleToggleOption = useCallback((key: 'isGray' | 'isCapture' | 'isShuffle') => {
-    setLocalOption(prev => ({
-      ...prev,
-      [key]: !prev[key],
-    }));
-  }, []);
+  const handleTimerChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = Number(event.target.value);
+      const safeValue = Number.isFinite(next) && next >= 0 ? next : 0;
+      markInteracted();
+      setLocalOption(prev => {
+        const timer = {
+          ...prev.timer,
+          max_time: safeValue,
+        } as typeof prev.timer & { maxTime?: number };
+        timer.maxTime = safeValue;
+        return {
+          ...prev,
+          timer,
+        };
+      });
+    },
+    [markInteracted],
+  );
 
-  const handleSavePathChange = useCallback((value: string) => {
-    setLocalOption(prev => ({
-      ...prev,
-      savePath: value,
-    }));
-  }, []);
+  const handleToggleOption = useCallback(
+    (key: 'isGray' | 'isCapture' | 'isShuffle') => {
+      markInteracted();
+      setLocalOption(prev => ({
+        ...prev,
+        [key]: !prev[key],
+      }));
+    },
+    [markInteracted],
+  );
+
+  const handleSavePathChange = useCallback(
+    (value: string) => {
+      markInteracted();
+      setLocalOption(prev => ({
+        ...prev,
+        savePath: value,
+      }));
+    },
+    [markInteracted],
+  );
 
   const handleCancel = useCallback(() => {
     onClose();
@@ -173,10 +227,24 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
 
     setSubmitting(true);
     try {
+      const maxTimeValue =
+        localOption.timer.max_time ??
+        (localOption.timer as unknown as { maxTime?: number }).maxTime ??
+        60;
+      const payloadOption = {
+        ...localOption,
+        auto: { isSkip: false },
+        timer: {
+          ...localOption.timer,
+          max_time: maxTimeValue,
+        },
+      } as CroquisOption & { timer: CroquisOption['timer'] & { maxTime?: number } };
+      payloadOption.timer.maxTime = maxTimeValue;
+
       const response = await ipc.croquis.startSession({
         moaId,
         imageHashes,
-        option: { ...localOption, auto: { isSkip: false } },
+        option: payloadOption,
         saveOption: rememberSettings,
       });
       await onConfirm?.({ response, option: localOption, remember: rememberSettings });
@@ -274,15 +342,16 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
           </header>
           <Switch
             current={skipMode}
-            onChanged={value =>
+            onChanged={value => {
+              markInteracted();
               setLocalOption(prev => ({
                 ...prev,
                 auto: {
                   ...prev.auto,
                   skip: value === 'auto',
                 },
-              }))
-            }
+              }));
+            }}
             options={[
               { name: 'Auto skip breaks', value: 'auto' },
               { name: 'Manual control', value: 'manual' },

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -4,7 +4,7 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
 import { Button } from '@tgim/ui';
 import { CroquisSession, CroquisSessionImage } from '@tgim/types/croquis';
-import { Minus, Pause, Play, SkipBack, SkipForward, Camera, X } from 'lucide-react';
+import { Pause, Play, SkipBack, SkipForward, Camera } from 'lucide-react';
 import { ipc } from '../../lib/ipc';
 
 const shuffleImages = (images: CroquisSessionImage[]): CroquisSessionImage[] => {
@@ -17,9 +17,7 @@ const shuffleImages = (images: CroquisSessionImage[]): CroquisSessionImage[] => 
 };
 
 const formatTime = (seconds: number): string => {
-  if (!Number.isFinite(seconds) || seconds < 0) {
-    return '00:00';
-  }
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00';
   const totalSeconds = Math.max(0, Math.floor(seconds));
   const minutes = Math.floor(totalSeconds / 60);
   const remainder = totalSeconds % 60;
@@ -33,7 +31,9 @@ const CroquisWindow: React.FC = () => {
   const [elapsedMs, setElapsedMs] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
+  const [isHover, setIsHover] = useState(false); // UI visible only on hover
 
+  const imgRef = useRef<HTMLImageElement | null>(null); // reference to current <img>
   const rafRef = useRef<number | null>(null);
   const elapsedRef = useRef(0);
   const startTimestampRef = useRef<number | null>(null);
@@ -51,7 +51,6 @@ const CroquisWindow: React.FC = () => {
     }
 
     let cancelled = false;
-
     void (async () => {
       try {
         const data = await ipc.croquis.loadSession(sessionId);
@@ -78,53 +77,59 @@ const CroquisWindow: React.FC = () => {
   const isGray = option?.isGray ?? false;
 
   const imageList = useMemo(() => {
-    if (!session) {
-      return [];
-    }
+    if (!session) return [];
     const base = session.images ?? [];
-    if (!base.length) {
-      return [];
-    }
-    if (session.option?.isShuffle) {
-      return shuffleImages(base);
-    }
+    if (!base.length) return [];
+    if (session.option?.isShuffle) return shuffleImages(base);
     return [...base];
   }, [session]);
 
   useEffect(() => {
-    setCurrentIndex(prev => {
-      if (!imageList.length) {
-        return 0;
-      }
-      return Math.min(prev, imageList.length - 1);
-    });
+    setCurrentIndex(prev => (imageList.length ? Math.min(prev, imageList.length - 1) : 0));
   }, [imageList]);
 
-  useEffect(() => {
-    if (!session) return;
-    const { width, height } = session.option.window ?? {};
-    const parsedWidth = width ? Number(width) : NaN;
-    const parsedHeight = height ? Number(height) : NaN;
-    const hasWidth = Number.isFinite(parsedWidth) && parsedWidth > 0;
-    const hasHeight = Number.isFinite(parsedHeight) && parsedHeight > 0;
-    if (!hasWidth && !hasHeight) {
-      return;
-    }
+  // Re-apply size when image loads or index changes
+  // useEffect(() => {
+  //   const el = imgRef.current;
+  //   if (!el) return;
 
-    void (async () => {
+  //   const handle = () => void applyWindowSizeToImage();
+  //   if (el.complete) handle();
+  //   el.addEventListener('load', handle);
+  //   el.addEventListener('error', handle);
+  //   return () => {
+  //     el.removeEventListener('load', handle);
+  //     el.removeEventListener('error', handle);
+  //   };
+  // }, [applyWindowSizeToImage, currentIndex]);
+
+  const [isInitHeight, setIsInitHeight] = useState(false);
+  useEffect(() => {
+    (async () => {
+      if (isInitHeight) return;
+      const el = imgRef.current;
+      if (!el) return;
+
+      const naturalH = el.naturalHeight || el.height;
+      const naturalW = el.naturalWidth || el.width;
+      if (!naturalH) return;
+
       try {
         const windowRef = getCurrentWindow();
-        const currentSize = await windowRef.outerSize();
-        const nextWidth = hasWidth ? parsedWidth : currentSize.width;
-        const nextHeight = hasHeight ? parsedHeight : currentSize.height;
-        await windowRef.setSize(new LogicalSize(nextWidth, nextHeight));
+
+        const fixedWidth = Number(option?.window.width!);
+        const desiredHeight = Math.max(1, (Math.round(naturalH) * fixedWidth) / naturalW);
+
+        await windowRef.setSize(new LogicalSize(fixedWidth, desiredHeight));
+        setIsInitHeight(true);
       } catch (error) {
-        console.error('[Croquis] Failed to apply window size option', error);
+        console.error('[Croquis] Failed to apply window size to image', error);
       }
     })();
-  }, [session]);
+  }, [imageList, imgRef.current, option]);
 
-  const maxTimeSecondsRaw = option?.timer?.max_time ?? 0;
+  // --- Timer logic ---
+  const maxTimeSecondsRaw = option?.timer?.maxTime ?? 0;
   const maxTimeSeconds = Number.isFinite(maxTimeSecondsRaw) ? Math.max(0, maxTimeSecondsRaw) : 0;
   const maxTimeMs = maxTimeSeconds > 0 ? maxTimeSeconds * 1000 : 0;
 
@@ -132,12 +137,7 @@ const CroquisWindow: React.FC = () => {
     setIsPlaying(false);
     setTimerExpired(true);
     if (autoSkip && imageList.length > 0) {
-      setCurrentIndex(prev => {
-        if (prev >= imageList.length - 1) {
-          return prev;
-        }
-        return prev + 1;
-      });
+      setCurrentIndex(prev => (prev >= imageList.length - 1 ? prev : prev + 1));
     }
   }, [autoSkip, imageList.length]);
 
@@ -146,7 +146,6 @@ const CroquisWindow: React.FC = () => {
       if (startTimestampRef.current === null) {
         startTimestampRef.current = timestamp - elapsedRef.current;
       }
-
       const nextElapsed = timestamp - startTimestampRef.current;
       elapsedRef.current = nextElapsed;
       if (maxTimeMs > 0 && nextElapsed >= maxTimeMs) {
@@ -157,7 +156,6 @@ const CroquisWindow: React.FC = () => {
         handleTimerComplete();
         return;
       }
-
       setElapsedMs(nextElapsed);
       rafRef.current = requestAnimationFrame(updateLoop);
     },
@@ -177,9 +175,7 @@ const CroquisWindow: React.FC = () => {
   }, []);
 
   const startTimer = useCallback(() => {
-    if (rafRef.current !== null) {
-      return;
-    }
+    if (rafRef.current !== null) return;
     setTimerExpired(false);
     setIsPlaying(true);
     startTimestampRef.current = null;
@@ -196,20 +192,17 @@ const CroquisWindow: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!session || !imageList.length) {
-      return;
-    }
+    if (!session || !imageList.length) return;
     resetTimer();
     startTimer();
   }, [session, imageList, currentIndex, resetTimer, startTimer]);
 
-  useEffect(() => {
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-      }
-    };
-  }, []);
+  useEffect(
+    () => () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
 
   const currentImage = imageList[currentIndex] ?? null;
   const currentImageSrc = useMemo(
@@ -236,138 +229,108 @@ const CroquisWindow: React.FC = () => {
 
   const elapsedSeconds =
     maxTimeSeconds > 0 ? Math.min(maxTimeSeconds, elapsedMs / 1000) : elapsedMs / 1000;
-  const progress = maxTimeMs > 0 ? Math.min(elapsedMs / maxTimeMs, 1) : 0;
+  const progress = useMemo(
+    () => (maxTimeMs > 0 ? Math.min(elapsedMs / maxTimeMs, 1) : 0),
+    [elapsedMs, maxTimeMs],
+  );
   const isCritical = timerExpired || progress >= 0.9;
 
   return (
-    <div className="flex h-full flex-col bg-surface text-text">
-      <header
-        className="flex h-8 items-center justify-between border-b border-border bg-shell-base/80 px-3 text-text backdrop-blur"
-        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+    <div className="flex h-full w-full flex-col text-text">
+      {/* Stage area */}
+      <main
+        className="relative flex h-full w-full flex-1 select-none bg-transparent flex-col"
+        onMouseEnter={() => setIsHover(true)}
+        onMouseLeave={() => setIsHover(false)}
       >
-        <div className="text-sm font-semibold uppercase tracking-wide text-text-soft">
-          Croquis Session
-        </div>
-        <div
-          className="flex items-center"
-          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-        >
-          <Button
-            type="button"
-            variant="titlebar"
-            onClick={() => ipc.windowController.minimize()}
-            aria-label="Minimize window"
-            className="flex items-center justify-center text-icon-main hover:text-icon-hover-main"
-          >
-            <Minus className="size-4" />
-          </Button>
-          <Button
-            type="button"
-            variant="titlebar"
-            onClick={() => ipc.windowController.close()}
-            aria-label="Close window"
-            className="flex items-center justify-center text-icon-main hover:text-icon-hover-main"
-          >
-            <X className="size-4" />
-          </Button>
-        </div>
-      </header>
-
-      <main className="flex flex-1 flex-col gap-4 p-6">
-        <div className="flex items-center justify-between text-sm text-text-soft">
-          <span>
-            {imageList.length > 0
-              ? `Image ${currentIndex + 1} / ${imageList.length}`
-              : 'Loading images...'}
-          </span>
-          <span>{option?.auto?.isSkip ? 'Auto skip mode' : 'Manual mode'}</span>
-        </div>
-
-        <div className="flex flex-1 items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted shadow-inner">
+        <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
           {currentImage && currentImageSrc ? (
             <img
               key={currentImage.hash}
+              ref={imgRef}
               src={currentImageSrc}
               alt={currentImage.hash}
-              className="max-h-full max-w-full object-contain"
+              className="h-full w-full object-contain"
               style={{ filter: isGray ? 'grayscale(100%)' : 'none' }}
             />
           ) : (
             <div className="text-sm text-text-soft">Waiting for Croquis data...</div>
           )}
         </div>
-
-        <div className="flex flex-wrap items-center justify-center gap-3">
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={handlePrev}
-            disabled={!hasPrev}
-            className="flex items-center gap-2"
-          >
-            <SkipBack className="size-4" />
-            Prev
-          </Button>
-          {isPlaying ? (
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={pauseTimer}
-              className="flex items-center gap-2"
-            >
-              <Pause className="size-4" />
-              Pause
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              variant="primary"
-              onClick={startTimer}
-              className="flex items-center gap-2"
-            >
-              <Play className="size-4" />
-              Start
-            </Button>
-          )}
-          {!autoSkip && (
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleNext}
-              disabled={!hasNext}
-              className="flex items-center gap-2"
-            >
-              <SkipForward className="size-4" />
-              Next
-            </Button>
-          )}
-          {!autoSkip && isCaptureEnabled && (
-            <Button
-              type="button"
-              variant="secondary"
-              onClick={handleCapture}
-              className="flex items-center gap-2"
-            >
-              <Camera className="size-4" />
-              Capture
-            </Button>
-          )}
+        <div className="pointer-events-none flex w-full items-center justify-center">
+          <div className="w-full max-w-[720px]">
+            <div className="h-1 w-full overflow-hidden rounded-full bg-surface-muted">
+              <div
+                className={`h-full ${isCritical ? 'bg-red-500' : 'bg-accent'}`}
+                style={{ width: `${Math.min(100, Math.max(0, progress * 100))}%` }}
+              />
+            </div>
+          </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-between text-xs text-text-soft">
-            <span>
-              {formatTime(elapsedSeconds)} / {formatTime(maxTimeSeconds)}
-            </span>
-            {maxTimeMs > 0 && <span>{Math.round(progress * 100)}%</span>}
-          </div>
-          <div className="h-2 w-full overflow-hidden rounded-full bg-surface-muted">
-            <div
-              className={`h-full transition-[width,background-color] ${
-                isCritical ? 'bg-red-500' : 'bg-accent'
-              }`}
-              style={{ width: `${Math.min(100, Math.max(0, progress * 100))}%` }}
-            />
+        {/* Absolute overlay controls (show on hover only) */}
+        <div
+          className={`pointer-events-none absolute inset-0 flex flex-col items-center justify-between p-4 transition-opacity duration-200 ${
+            isHover ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          {/* Bottom transport controls */}
+          <div
+            className="absolute pointer-events-none flex w-full items-end justify-center"
+            style={{ bottom: 10 }}
+          >
+            <div className="pointer-events-auto flex items-center gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handlePrev}
+                disabled={!hasPrev}
+                className="flex items-center gap-2"
+              >
+                <SkipBack className="size-4" />
+              </Button>
+
+              {isPlaying ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={pauseTimer}
+                  className="flex items-center gap-2"
+                >
+                  <Pause className="size-4" />
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={startTimer}
+                  className="flex items-center gap-2"
+                >
+                  <Play className="size-4" />
+                </Button>
+              )}
+
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleNext}
+                disabled={!hasNext}
+                className="flex items-center gap-2"
+              >
+                <SkipForward className="size-4" />
+              </Button>
+
+              {!autoSkip && isCaptureEnabled && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleCapture}
+                  className="flex items-center gap-2"
+                >
+                  <Camera className="size-4" />
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </main>

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -9,6 +9,7 @@ const CroquisWindow: React.FC = () => {
 
   useEffect(() => {
     console.log('[Croquis] window mounted');
+    document.body.style.backgroundColor = 'transparent';
   }, []);
 
   useEffect(() => {
@@ -34,7 +35,7 @@ const CroquisWindow: React.FC = () => {
   }, [params]);
 
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full bg-surface text-text">
+    <div className="flex flex-col items-center justify-center w-full h-full text-text">
       <p className="text-base font-semibold">Croquis window bootstrap</p>
       {session ? (
         <pre className="mt-4 max-w-xl whitespace-pre-wrap break-all text-left text-xs text-text-muted">

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -1,11 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
+import { Button } from '@tgim/ui';
+import { CroquisSession, CroquisSessionImage } from '@tgim/types/croquis';
+import { Minus, Pause, Play, SkipBack, SkipForward, Camera, X } from 'lucide-react';
 import { ipc } from '../../lib/ipc';
-import { CroquisSession } from '@tgim/types/croquis';
+
+const shuffleImages = (images: CroquisSessionImage[]): CroquisSessionImage[] => {
+  const next = [...images];
+  for (let i = next.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [next[i], next[j]] = [next[j], next[i]];
+  }
+  return next;
+};
+
+const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return '00:00';
+  }
+  const totalSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(totalSeconds / 60);
+  const remainder = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
+};
 
 const CroquisWindow: React.FC = () => {
   const [params] = useSearchParams();
   const [session, setSession] = useState<CroquisSession | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [timerExpired, setTimerExpired] = useState(false);
+
+  const rafRef = useRef<number | null>(null);
+  const elapsedRef = useRef(0);
+  const startTimestampRef = useRef<number | null>(null);
 
   useEffect(() => {
     console.log('[Croquis] window mounted');
@@ -18,6 +49,8 @@ const CroquisWindow: React.FC = () => {
       return;
     }
 
+    let cancelled = false;
+
     void (async () => {
       try {
         const data = await ipc.croquis.loadSession(sessionId);
@@ -25,31 +58,318 @@ const CroquisWindow: React.FC = () => {
           console.warn('[Croquis] No session found for id', sessionId);
           return;
         }
+        if (cancelled) return;
         setSession(data);
         console.log('[Croquis] session hydrated', data);
       } catch (error) {
         console.error('[Croquis] Failed to load Croquis session', error);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [params]);
 
+  const option = session?.option;
+  const autoSkip = option?.auto?.isSkip ?? false;
+  const isCaptureEnabled = option?.isCapture ?? false;
+  const isGray = option?.isGray ?? false;
+
+  const imageList = useMemo(() => {
+    if (!session) {
+      return [];
+    }
+    const base = session.images ?? [];
+    if (!base.length) {
+      return [];
+    }
+    if (session.option?.isShuffle) {
+      return shuffleImages(base);
+    }
+    return [...base];
+  }, [session]);
+
+  useEffect(() => {
+    setCurrentIndex(prev => {
+      if (!imageList.length) {
+        return 0;
+      }
+      return Math.min(prev, imageList.length - 1);
+    });
+  }, [imageList]);
+
+  useEffect(() => {
+    if (!session) return;
+    const { width, height } = session.option.window ?? {};
+    const parsedWidth = width ? Number(width) : NaN;
+    const parsedHeight = height ? Number(height) : NaN;
+    const hasWidth = Number.isFinite(parsedWidth) && parsedWidth > 0;
+    const hasHeight = Number.isFinite(parsedHeight) && parsedHeight > 0;
+    if (!hasWidth && !hasHeight) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const windowRef = getCurrentWindow();
+        const currentSize = await windowRef.outerSize();
+        const nextWidth = hasWidth ? parsedWidth : currentSize.width;
+        const nextHeight = hasHeight ? parsedHeight : currentSize.height;
+        await windowRef.setSize(new LogicalSize(nextWidth, nextHeight));
+      } catch (error) {
+        console.error('[Croquis] Failed to apply window size option', error);
+      }
+    })();
+  }, [session]);
+
+  const maxTimeSecondsRaw = option?.timer?.max_time ?? 0;
+  const maxTimeSeconds = Number.isFinite(maxTimeSecondsRaw) ? Math.max(0, maxTimeSecondsRaw) : 0;
+  const maxTimeMs = maxTimeSeconds > 0 ? maxTimeSeconds * 1000 : 0;
+
+  const handleTimerComplete = useCallback(() => {
+    setIsPlaying(false);
+    setTimerExpired(true);
+    if (autoSkip && imageList.length > 0) {
+      setCurrentIndex(prev => {
+        if (prev >= imageList.length - 1) {
+          return prev;
+        }
+        return prev + 1;
+      });
+    }
+  }, [autoSkip, imageList.length]);
+
+  const updateLoop = useCallback(
+    (timestamp: number) => {
+      if (startTimestampRef.current === null) {
+        startTimestampRef.current = timestamp - elapsedRef.current;
+      }
+
+      const nextElapsed = timestamp - startTimestampRef.current;
+      elapsedRef.current = nextElapsed;
+      if (maxTimeMs > 0 && nextElapsed >= maxTimeMs) {
+        setElapsedMs(maxTimeMs);
+        elapsedRef.current = maxTimeMs;
+        startTimestampRef.current = null;
+        rafRef.current = null;
+        handleTimerComplete();
+        return;
+      }
+
+      setElapsedMs(nextElapsed);
+      rafRef.current = requestAnimationFrame(updateLoop);
+    },
+    [handleTimerComplete, maxTimeMs],
+  );
+
+  const resetTimer = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    elapsedRef.current = 0;
+    startTimestampRef.current = null;
+    setElapsedMs(0);
+    setIsPlaying(false);
+    setTimerExpired(false);
+  }, []);
+
+  const startTimer = useCallback(() => {
+    if (rafRef.current !== null) {
+      return;
+    }
+    setTimerExpired(false);
+    setIsPlaying(true);
+    startTimestampRef.current = null;
+    rafRef.current = requestAnimationFrame(updateLoop);
+  }, [updateLoop]);
+
+  const pauseTimer = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    startTimestampRef.current = null;
+    setIsPlaying(false);
+  }, []);
+
+  useEffect(() => {
+    if (!session || !imageList.length) {
+      return;
+    }
+    resetTimer();
+    startTimer();
+  }, [session, imageList, currentIndex, resetTimer, startTimer]);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const currentImage = imageList[currentIndex] ?? null;
+  const currentImageSrc = useMemo(
+    () => (currentImage ? convertFileSrc(currentImage.basePath) : null),
+    [currentImage],
+  );
+
+  const hasPrev = currentIndex > 0;
+  const hasNext = imageList.length > 0 && currentIndex < imageList.length - 1;
+
+  const handlePrev = useCallback(() => {
+    if (!hasPrev) return;
+    setCurrentIndex(prev => Math.max(0, prev - 1));
+  }, [hasPrev]);
+
+  const handleNext = useCallback(() => {
+    if (!hasNext) return;
+    setCurrentIndex(prev => Math.min(imageList.length - 1, prev + 1));
+  }, [hasNext, imageList.length]);
+
+  const handleCapture = useCallback(() => {
+    window.alert('Capture requested. (Not implemented yet)');
+  }, []);
+
+  const elapsedSeconds =
+    maxTimeSeconds > 0 ? Math.min(maxTimeSeconds, elapsedMs / 1000) : elapsedMs / 1000;
+  const progress = maxTimeMs > 0 ? Math.min(elapsedMs / maxTimeMs, 1) : 0;
+  const isCritical = timerExpired || progress >= 0.9;
+
   return (
-    <div className="flex flex-col items-center justify-center w-full h-full bg-surface text-text">
-      <p className="text-base font-semibold">Croquis window bootstrap</p>
-      {session ? (
-        <pre className="mt-4 max-w-xl whitespace-pre-wrap break-all text-left text-xs text-text-muted">
-          {JSON.stringify(
-            {
-              sessionId: session.sessionId,
-              images: session.images.length,
-            },
-            null,
-            2,
+    <div className="flex h-full flex-col bg-surface text-text">
+      <header
+        className="flex h-8 items-center justify-between border-b border-border bg-shell-base/80 px-3 text-text backdrop-blur"
+        style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      >
+        <div className="text-sm font-semibold uppercase tracking-wide text-text-soft">
+          Croquis Session
+        </div>
+        <div
+          className="flex items-center"
+          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+        >
+          <Button
+            type="button"
+            variant="titlebar"
+            onClick={() => ipc.windowController.minimize()}
+            aria-label="Minimize window"
+            className="flex items-center justify-center text-icon-main hover:text-icon-hover-main"
+          >
+            <Minus className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="titlebar"
+            onClick={() => ipc.windowController.close()}
+            aria-label="Close window"
+            className="flex items-center justify-center text-icon-main hover:text-icon-hover-main"
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </header>
+
+      <main className="flex flex-1 flex-col gap-4 p-6">
+        <div className="flex items-center justify-between text-sm text-text-soft">
+          <span>
+            {imageList.length > 0
+              ? `Image ${currentIndex + 1} / ${imageList.length}`
+              : 'Loading images...'}
+          </span>
+          <span>{option?.auto?.isSkip ? 'Auto skip mode' : 'Manual mode'}</span>
+        </div>
+
+        <div className="flex flex-1 items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted shadow-inner">
+          {currentImage && currentImageSrc ? (
+            <img
+              key={currentImage.hash}
+              src={currentImageSrc}
+              alt={currentImage.hash}
+              className="max-h-full max-w-full object-contain"
+              style={{ filter: isGray ? 'grayscale(100%)' : 'none' }}
+            />
+          ) : (
+            <div className="text-sm text-text-soft">Waiting for Croquis data...</div>
           )}
-        </pre>
-      ) : (
-        <p className="mt-2 text-sm text-text-muted">Waiting for Croquis data...</p>
-      )}
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handlePrev}
+            disabled={!hasPrev}
+            className="flex items-center gap-2"
+          >
+            <SkipBack className="size-4" />
+            Prev
+          </Button>
+          {isPlaying ? (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={pauseTimer}
+              className="flex items-center gap-2"
+            >
+              <Pause className="size-4" />
+              Pause
+            </Button>
+          ) : (
+            <Button
+              type="button"
+              variant="primary"
+              onClick={startTimer}
+              className="flex items-center gap-2"
+            >
+              <Play className="size-4" />
+              Start
+            </Button>
+          )}
+          {!autoSkip && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleNext}
+              disabled={!hasNext}
+              className="flex items-center gap-2"
+            >
+              <SkipForward className="size-4" />
+              Next
+            </Button>
+          )}
+          {!autoSkip && isCaptureEnabled && (
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleCapture}
+              className="flex items-center gap-2"
+            >
+              <Camera className="size-4" />
+              Capture
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between text-xs text-text-soft">
+            <span>
+              {formatTime(elapsedSeconds)} / {formatTime(maxTimeSeconds)}
+            </span>
+            {maxTimeMs > 0 && <span>{Math.round(progress * 100)}%</span>}
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-surface-muted">
+            <div
+              className={`h-full transition-[width,background-color] ${
+                isCritical ? 'bg-red-500' : 'bg-accent'
+              }`}
+              style={{ width: `${Math.min(100, Math.max(0, progress * 100))}%` }}
+            />
+          </div>
+        </div>
+      </main>
     </div>
   );
 };

--- a/apps/desktop/src/features/main/Main.tsx
+++ b/apps/desktop/src/features/main/Main.tsx
@@ -166,18 +166,15 @@ const Main: React.FC = () => {
 
     let unlisten: (() => void) | undefined;
     const initListener = async () => {
-      unlisten = await listen<{ items: ThumbResSpec[] }>(
-        'thumbnails://created',
-        event => {
-          event.payload.items.forEach(item => {
-            upsertThumb(item.thumb_key, {
-              status: 'ready',
-              url: item.url,
-              updatedAt: Date.now(),
-            });
+      unlisten = await listen<{ items: ThumbResSpec[] }>('thumbnails://created', event => {
+        event.payload.items.forEach(item => {
+          upsertThumb(item.thumb_key, {
+            status: 'ready',
+            url: item.url,
+            updatedAt: Date.now(),
           });
-        },
-      );
+        });
+      });
     };
 
     void initListener();
@@ -208,12 +205,9 @@ const Main: React.FC = () => {
     void load();
 
     const initListener = async () => {
-      unlisten = await listen<AppProgressEvent>(
-        `bootstrap://progress/${moaId}`,
-        event => {
-          setProgressQueue(prev => [...prev, event.payload]);
-        },
-      );
+      unlisten = await listen<AppProgressEvent>(`bootstrap://progress/${moaId}`, event => {
+        setProgressQueue(prev => [...prev, event.payload]);
+      });
     };
 
     void initListener();
@@ -239,7 +233,10 @@ const Main: React.FC = () => {
   }, []);
 
   return (
-    <div className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden" data-theme={theme}>
+    <div
+      className="flex flex-col w-full h-full bg-shell-base text-text overflow-hidden"
+      data-theme={theme}
+    >
       {!isMac && (
         <div className="fixed w-full top-0 z-50">
           <TitleBar />

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -77,7 +77,7 @@ const INITIAL_FETCH_COUNT = 50;
 const createDefaultCroquisOption = (): CroquisOption => ({
   window: { width: null, height: null },
   auto: { isSkip: true },
-  timer: { max_time: 1000 },
+  timer: { maxTime: 1000 },
   isCapture: false,
   savePath: '',
   isGray: false,

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -14,8 +14,14 @@ body,
 
 body {
   margin: 0;
-  font-family: 'Pretendard Variable', 'Inter', 'Segoe UI', system-ui, -apple-system,
-    BlinkMacSystemFont, sans-serif;
+  font-family:
+    'Pretendard Variable',
+    'Inter',
+    'Segoe UI',
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
   background-color: var(--ds-shell-surface);
   color: var(--ds-text-primary);
   -webkit-font-smoothing: antialiased;

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -2,7 +2,12 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
 import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
-import { CroquisSession, CroquisStartPayload, CroquisStartResponse } from '@tgim/types/croquis';
+import {
+  CroquisOption,
+  CroquisSession,
+  CroquisStartPayload,
+  CroquisStartResponse,
+} from '@tgim/types/croquis';
 
 const appWindow = getCurrentWindow();
 
@@ -75,6 +80,10 @@ const croquisIpc = {
   loadSession: async (sessionId: string): Promise<CroquisSession | null> => {
     const response = await invoke('load_croquis_session', { sessionId });
     return (response as CroquisSession | null) ?? null;
+  },
+  loadOption: async (moaId: string): Promise<CroquisOption | null> => {
+    const response = await invoke('load_croquis_option', { moaId });
+    return (response as CroquisOption | null) ?? null;
   },
 };
 

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -8,7 +8,7 @@ export interface CroquisAutoOption {
 }
 
 export interface CroquisTimerOption {
-  max_time: number;
+  maxTime: number;
 }
 
 export interface CroquisOption {


### PR DESCRIPTION
## Summary
- load Croquis sessions in the window, apply shuffle and window sizing options, and manage timer playback with auto-skip support
- build the session UI with start/pause controls, prev/next handling when skip is disabled, and an optional capture button stub
- show the active image with grayscale support and display a timer progress bar that turns red near completion

## Testing
- pnpm format:write
- pnpm lint:check *(fails: missing @eslint/js because dependencies cannot be installed in the environment)*
- pnpm --filter @grim/desktop build *(fails: project dependencies are unavailable after the registry denied @tauri-apps/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68d1567bdfe4832e91dbdd9a063f1d8f