### PR TITLE
Add workspace toggle for base thumbnail caching

### DIFF
--- a/apps/desktop/src-tauri/src/commands/file.rs
+++ b/apps/desktop/src-tauri/src/commands/file.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use crate::{
-    models::file::{FolderData, FolderPreview, ThumbRequest, ThumbResponse},
+    models::file::{
+        FileSettings, FileSettingsUpdate, FolderData, FolderPreview,
+        ThumbRequest, ThumbResponse,
+    },
     services::file_service::{
         self, collect_folder_preview, first_mount_folder, get_thumbs,
     },
@@ -45,6 +48,25 @@ pub async fn get_thumbnails(
         .map_err(|e| e.to_string())?;
 
     Ok(response)
+}
+
+#[tauri::command]
+/// Fetch the persisted file service settings for the workspace.
+pub async fn get_file_settings(moa_id: String) -> Result<FileSettings, String> {
+    file_service::settings::get_settings(&moa_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+/// Update and persist the file service settings for the workspace.
+pub async fn update_file_settings(
+    moa_id: String,
+    data: FileSettingsUpdate,
+) -> Result<FileSettings, String> {
+    file_service::settings::update_settings(&moa_id, data)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -42,6 +42,8 @@ fn main() {
             commands::moa::bootstrap_status,
             commands::graph::get_graph_one,
             commands::file::get_thumbnails,
+            commands::file::get_file_settings,
+            commands::file::update_file_settings,
             commands::file::preview_folder_import,
             commands::croquis::start_croquis_session,
             commands::croquis::load_croquis_session,

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -488,11 +488,40 @@ pub struct ThumbSpec {
     pub key: String,
 }
 
+fn default_true() -> bool {
+    true
+}
+
+/// Persisted workspace-specific file settings toggled from the renderer.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileSettings {
+    #[serde(default = "default_true")]
+    pub precache_base_thumbnails: bool,
+}
+
+impl Default for FileSettings {
+    fn default() -> Self {
+        Self { precache_base_thumbnails: true }
+    }
+}
+
+/// Partial update payload applied to the stored file settings.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileSettingsUpdate {
+    #[serde(default)]
+    pub precache_base_thumbnails: Option<bool>,
+}
+
 /// Request payload containing thumbnail requirements per file.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThumbReqInfo {
     pub xxhs: String, // ASCII-hex (will be normalized to lowercase)
     pub specs: Vec<ThumbSpec>,
+    #[serde(default)]
+    pub ensure_base: Option<bool>,
 }
 
 /// Wrapper representing the resolved thumbnail path on disk.
@@ -678,7 +707,10 @@ fn is_ascii_hex(s: &str) -> bool {
 
 /// Batch thumbnail request submitted from the frontend.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ThumbRequest {
+    #[serde(default)]
+    pub ensure_base: Option<bool>,
     pub items: Vec<ThumbReqInfo>,
 }
 

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -34,6 +34,7 @@ use crate::{
 
 use super::{
     job_queue::{enqueue_base_job, BaseThumbnailJob},
+    settings,
     utils::check_is_hidden,
 };
 
@@ -873,12 +874,28 @@ async fn upsert_file_entry(
     .await?;
 
     if file_info.file_exists && file_info.kind_guess == FileType::Image {
-        enqueue_base_job(BaseThumbnailJob {
-            moa_id: moa_id.to_string(),
-            xxhs: file_info.xxh3_64.clone(),
-            source_path: file_path.clone(),
-        })
-        .await;
+        let precache_enabled = match settings::is_base_precache_enabled(moa_id)
+            .await
+        {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(
+                    error = ?error,
+                    %moa_id,
+                    "Failed to load file settings; defaulting to base precache",
+                );
+                true
+            }
+        };
+
+        if precache_enabled {
+            enqueue_base_job(BaseThumbnailJob {
+                moa_id: moa_id.to_string(),
+                xxhs: file_info.xxh3_64.clone(),
+                source_path: file_path.clone(),
+            })
+            .await;
+        }
     }
     metrics.record_upsert_file(file_info.file_size, file_timer.elapsed());
 

--- a/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
@@ -56,6 +56,7 @@ pub struct ThumbnailJob {
     pub spec: ThumbSpec,
     pub out_path: PathBuf,
     pub priority: u8,
+    pub base_override: Option<bool>,
 }
 
 #[derive(Default)]

--- a/apps/desktop/src-tauri/src/services/file_service/mod.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/mod.rs
@@ -3,6 +3,7 @@
 pub mod folder;
 pub mod hash;
 pub mod job_queue;
+pub mod settings;
 pub mod thumbnail;
 pub mod utils;
 

--- a/apps/desktop/src-tauri/src/services/file_service/settings.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/settings.rs
@@ -1,0 +1,127 @@
+use std::{collections::HashMap, io::ErrorKind, path::PathBuf};
+
+use anyhow::{Context, Result};
+use once_cell::sync::Lazy;
+use tokio::{fs, sync::RwLock};
+
+use crate::{
+    bootstrap::PATH_MANAGER,
+    models::file::{FileSettings, FileSettingsUpdate},
+};
+
+const SETTINGS_DIR_NAME: &str = "settings";
+const SETTINGS_FILE_NAME: &str = "file.json";
+
+static SETTINGS_CACHE: Lazy<RwLock<HashMap<String, FileSettings>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
+
+async fn settings_paths(moa_id: &str) -> Result<(PathBuf, PathBuf)> {
+    let paths = PATH_MANAGER
+        .get_or_add(moa_id)
+        .await
+        .context("Failed to resolve workspace paths")?;
+
+    let settings_dir = paths.moa_dir.join(SETTINGS_DIR_NAME);
+    let file_path = settings_dir.join(SETTINGS_FILE_NAME);
+
+    Ok((settings_dir, file_path))
+}
+
+async fn load_from_disk(moa_id: &str) -> Result<FileSettings> {
+    let (_settings_dir, file_path) = settings_paths(moa_id).await?;
+
+    match fs::read(&file_path).await {
+        Ok(payload) => {
+            let settings =
+                serde_json::from_slice(&payload).with_context(|| {
+                    format!(
+                        "Failed to deserialize file settings at {}",
+                        file_path.display()
+                    )
+                })?;
+            Ok(settings)
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            Ok(FileSettings::default())
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!("Failed to read file settings from {}", file_path.display())
+        }),
+    }
+}
+
+async fn persist_to_disk(moa_id: &str, settings: &FileSettings) -> Result<()> {
+    let (settings_dir, file_path) = settings_paths(moa_id).await?;
+
+    fs::create_dir_all(&settings_dir).await.with_context(|| {
+        format!(
+            "Failed to create settings directory at {}",
+            settings_dir.display()
+        )
+    })?;
+
+    let payload = serde_json::to_vec_pretty(settings)
+        .context("Failed to serialise file settings payload")?;
+
+    fs::write(&file_path, payload).await.with_context(|| {
+        format!("Failed to write file settings to {}", file_path.display())
+    })?;
+
+    Ok(())
+}
+
+pub async fn get_settings(moa_id: &str) -> Result<FileSettings> {
+    if let Some(cached) = {
+        let cache = SETTINGS_CACHE.read().await;
+        cache.get(moa_id).cloned()
+    } {
+        return Ok(cached);
+    }
+
+    let settings = load_from_disk(moa_id).await?;
+
+    {
+        let mut cache = SETTINGS_CACHE.write().await;
+        cache.insert(moa_id.to_string(), settings.clone());
+    }
+
+    Ok(settings)
+}
+
+pub async fn update_settings(
+    moa_id: &str,
+    update: FileSettingsUpdate,
+) -> Result<FileSettings> {
+    let mut current = get_settings(moa_id).await?;
+
+    if let Some(value) = update.precache_base_thumbnails {
+        current.precache_base_thumbnails = value;
+    }
+
+    persist_to_disk(moa_id, &current).await?;
+
+    {
+        let mut cache = SETTINGS_CACHE.write().await;
+        cache.insert(moa_id.to_string(), current.clone());
+    }
+
+    Ok(current)
+}
+
+pub async fn set_settings(
+    moa_id: &str,
+    settings: FileSettings,
+) -> Result<FileSettings> {
+    persist_to_disk(moa_id, &settings).await?;
+
+    {
+        let mut cache = SETTINGS_CACHE.write().await;
+        cache.insert(moa_id.to_string(), settings.clone());
+    }
+
+    Ok(settings)
+}
+
+pub async fn is_base_precache_enabled(moa_id: &str) -> Result<bool> {
+    Ok(get_settings(moa_id).await?.precache_base_thumbnails)
+}

--- a/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
@@ -19,8 +19,9 @@ use tokio::{
 use tracing::warn;
 
 use crate::models::file::{
-    ImageFmt, ThumbBasePath, ThumbPath, ThumbRequest, ThumbResInfo,
-    ThumbResSpec, ThumbResponse, ThumbSpec, ThumbStatus, THUMB_BASE_WIDTH,
+    ImageFmt, ThumbBasePath, ThumbPath, ThumbReqInfo, ThumbRequest,
+    ThumbResInfo, ThumbResSpec, ThumbResponse, ThumbSpec, ThumbStatus,
+    THUMB_BASE_WIDTH,
 };
 
 use super::{
@@ -29,6 +30,7 @@ use super::{
         cancel_pending_base_job, enqueue_jobs, finish_base_job, finish_job,
         take_next_base_job, take_next_job, BaseThumbnailJob, ThumbnailJob,
     },
+    settings,
 };
 
 /// Version tag embedded in generated thumbnail paths.
@@ -167,19 +169,22 @@ pub async fn get_thumbs(
     moa_id: String,
     data: ThumbRequest,
 ) -> Result<ThumbResponse> {
+    let ThumbRequest { ensure_base: request_override, items } = data;
+
     let mut response = ThumbResponse { items: Vec::new() };
     let mut pending_jobs: Vec<ThumbnailJob> = Vec::new();
 
-    for item in data.items {
-        let specs = item.specs;
+    for item in items {
+        let ThumbReqInfo { xxhs, specs, ensure_base } = item;
         let mut res_specs: Vec<ThumbResSpec> = Vec::new();
+        let base_override = ensure_base.or(request_override);
 
         for spec in specs {
             let ThumbPath(thumb_path) = match ThumbPath::new(
                 app,
                 &moa_id,
                 spec.clone(),
-                item.xxhs.clone(),
+                xxhs.clone(),
                 SCHEMA_VERSION,
             )
             .await
@@ -210,11 +215,12 @@ pub async fn get_thumbs(
 
             pending_jobs.push(ThumbnailJob {
                 moa_id: moa_id.clone(),
-                xxhs: item.xxhs.clone(),
+                xxhs: xxhs.clone(),
                 thumb_key: spec.key.clone(),
                 spec: spec.clone(),
                 out_path: thumb_path,
                 priority: 0,
+                base_override,
             });
             res_specs.push(ThumbResSpec {
                 status: ThumbStatus::Miss,
@@ -225,7 +231,7 @@ pub async fn get_thumbs(
             });
         }
 
-        response.items.push(ThumbResInfo { xxhs: item.xxhs, specs: res_specs });
+        response.items.push(ThumbResInfo { xxhs, specs: res_specs });
     }
 
     enqueue_jobs(pending_jobs).await;
@@ -319,7 +325,22 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
         bail!("unsupported mime type for thumbnail generation");
     }
 
-    let (input_path, used_cache) =
+    let use_base_cache = match job.base_override {
+        Some(value) => value,
+        None => match settings::is_base_precache_enabled(&job.moa_id).await {
+            Ok(enabled) => enabled,
+            Err(error) => {
+                warn!(
+                    error = ?error,
+                    moa_id = %job.moa_id,
+                    "Failed to load file settings; defaulting to base precache",
+                );
+                true
+            }
+        },
+    };
+
+    let (input_path, used_cache) = if use_base_cache {
         match ensure_base_thumbnail(app, &job.moa_id, &job.xxhs, &source_path)
             .await
         {
@@ -338,7 +359,10 @@ async fn process_job(app: &AppHandle, job: ThumbnailJob) -> Result<()> {
                 );
                 (source_path.clone(), false)
             }
-        };
+        }
+    } else {
+        (source_path.clone(), false)
+    };
 
     let data = tokio::fs::read(&input_path).await.with_context(|| {
         format!("read source failed: {}", input_path.display())

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -4,7 +4,7 @@ import { GridData, ImageItem } from '@tgim/types/grid';
 import { ipc } from '../../../../lib/ipc';
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
-import { ResizeMode } from '@tgim/types/file';
+import { ResizeMode, ThumbReqInfo, ThumbRequest } from '@tgim/types/file';
 import { useShallow } from 'zustand/shallow';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import Masonry from 'react-masonry-css';
@@ -243,6 +243,10 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     })),
   );
 
+  const [precacheBaseThumbs, setPrecacheBaseThumbs] = useState(true);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [updatingSettings, setUpdatingSettings] = useState(false);
+
   const scrollRef = useRef<HTMLDivElement>(null);
   // @ts-expect-error.
   const { visible, observe, unobserve } = useVisibilityMap(scrollRef, 800);
@@ -258,6 +262,39 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     }
   }, [size]);
 
+  useEffect(() => {
+    if (!moaId) {
+      setPrecacheBaseThumbs(true);
+      setSettingsLoaded(false);
+      setUpdatingSettings(false);
+      return;
+    }
+
+    let cancelled = false;
+    setSettingsLoaded(false);
+    setUpdatingSettings(false);
+
+    void (async () => {
+      try {
+        const settings = await ipc.file.getSettings(moaId);
+        if (!cancelled) {
+          setPrecacheBaseThumbs(settings.precacheBaseThumbnails);
+          setSettingsLoaded(true);
+        }
+      } catch (error) {
+        console.error('Failed to load workspace file settings', error);
+        if (!cancelled) {
+          setPrecacheBaseThumbs(true);
+          setSettingsLoaded(true);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [moaId]);
+
   /* -------------------------------------------------
    * Thumbnail fetcher
    * NOTE: Prevent duplicate work by checking store.
@@ -267,35 +304,55 @@ const GridView: React.FC<Props> = ({ gridData }) => {
       if (moaId === null || itemsToFetch.length === 0) return;
 
       const currentThumbs = useThumbStore.getState().byKey;
+      const basePreference = settingsLoaded ? precacheBaseThumbs : undefined;
 
-      const toRequest = itemsToFetch
-        .map(img => {
-          const key = convertToThumbKey(img.hash, {
-            width: thumbSize,
-            height: thumbSize,
-            dpr: 1,
-            mode: ResizeMode.Original,
-          });
-          // Skip if already ready
-          if (currentThumbs[key]?.status === 'ready') return null;
-          return {
-            xxhs: img.hash,
-            specs: [
-              { width: thumbSize, height: thumbSize, dpr: 1, mode: ResizeMode.Original, key },
-            ],
-          };
-        })
-        .filter(Boolean) as any[];
+      const toRequest = itemsToFetch.reduce<ThumbReqInfo[]>((acc, img) => {
+        const key = convertToThumbKey(img.hash, {
+          width: thumbSize,
+          height: thumbSize,
+          dpr: 1,
+          mode: ResizeMode.Original,
+        });
+
+        if (currentThumbs[key]?.status === 'ready') {
+          return acc;
+        }
+
+        const request: ThumbReqInfo = {
+          xxhs: img.hash,
+          specs: [
+            {
+              width: thumbSize,
+              height: thumbSize,
+              dpr: 1,
+              mode: ResizeMode.Original,
+              key,
+            },
+          ],
+        };
+
+        if (basePreference !== undefined) {
+          request.ensureBase = basePreference;
+        }
+
+        acc.push(request);
+        return acc;
+      }, []);
 
       if (toRequest.length === 0) return;
 
       for (let i = 0; i < toRequest.length; i += MAX_ITEMS_PER_REQ) {
         const chunk = toRequest.slice(i, i + MAX_ITEMS_PER_REQ);
         try {
-          const responses = await ipc.file.getThumbnails(moaId, { items: chunk });
-          responses.items.forEach((item: any) => {
-            item.specs.forEach((spec: any) => {
-              upsertThumb(spec.thumb_key ?? spec.key, {
+          const payload: ThumbRequest = { items: chunk };
+          if (basePreference !== undefined) {
+            payload.ensureBase = basePreference;
+          }
+
+          const responses = await ipc.file.getThumbnails(moaId, payload);
+          responses.items.forEach(item => {
+            item.specs.forEach(spec => {
+              upsertThumb(spec.thumb_key, {
                 status: spec.status === 'hit' ? 'ready' : 'pending',
                 url: spec.status === 'hit' ? spec.url : undefined,
                 updatedAt: Date.now(),
@@ -307,7 +364,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
         }
       }
     },
-    [moaId, thumbSize, upsertThumb],
+    [moaId, thumbSize, upsertThumb, precacheBaseThumbs, settingsLoaded],
   );
 
   // Stable ref to avoid stale closure
@@ -372,6 +429,28 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     });
   }, [clearSelection]);
 
+  const handleToggleBaseCache = useCallback(async () => {
+    if (!moaId || !settingsLoaded || updatingSettings) {
+      return;
+    }
+
+    const previous = precacheBaseThumbs;
+    const next = !previous;
+    setPrecacheBaseThumbs(next);
+    setUpdatingSettings(true);
+
+    try {
+      await ipc.file.updateSettings(moaId, {
+        precacheBaseThumbnails: next,
+      });
+    } catch (error) {
+      console.error('Failed to update base thumbnail cache setting', error);
+      setPrecacheBaseThumbs(previous);
+    } finally {
+      setUpdatingSettings(false);
+    }
+  }, [moaId, precacheBaseThumbs, settingsLoaded, updatingSettings]);
+
   const handleBackgroundClick = useCallback(() => {
     clearSelection();
   }, [clearSelection]);
@@ -411,6 +490,18 @@ const GridView: React.FC<Props> = ({ gridData }) => {
                 {l === 'grid' ? <GridIcon /> : <MasonryIcon />}
               </Button>
             ))}
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-text-soft uppercase tracking-wide">Base cache</span>
+            <Button
+              variant="toggle"
+              active={precacheBaseThumbs}
+              onClick={handleToggleBaseCache}
+              disabled={!settingsLoaded || updatingSettings}
+              className="px-3"
+            >
+              {precacheBaseThumbs ? 'On' : 'Off'}
+            </Button>
           </div>
         </div>
         <Button

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -1,7 +1,14 @@
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
-import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
+import {
+  CreateFolderPayload,
+  FileSettings,
+  FolderPreview,
+  ThumbRequest,
+  ThumbResponse,
+  UpdateFileSettingsPayload,
+} from '@tgim/types/file';
 import {
   CroquisOption,
   CroquisSession,
@@ -65,6 +72,14 @@ const fileIpc = {
   getThumbnails: async (moaId: string, data: ThumbRequest) => {
     const response = await invoke('get_thumbnails', { data, moaId });
     return response as ThumbResponse;
+  },
+  getSettings: async (moaId: string) => {
+    const response = await invoke('get_file_settings', { moaId });
+    return response as FileSettings;
+  },
+  updateSettings: async (moaId: string, data: UpdateFileSettingsPayload) => {
+    const response = await invoke('update_file_settings', { moaId, data });
+    return response as FileSettings;
   },
   previewFolderImport: async (path: string): Promise<FolderPreview> => {
     const response = await invoke('preview_folder_import', { path });

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -18,6 +18,14 @@ export type ThumbEntry = {
   updatedAt: number;
 };
 
+export interface FileSettings {
+  precacheBaseThumbnails: boolean;
+}
+
+export interface UpdateFileSettingsPayload {
+  precacheBaseThumbnails?: boolean;
+}
+
 /** Resize behavior for thumbnails. */
 export enum ResizeMode {
   Upscale = 'upscale',
@@ -51,10 +59,12 @@ export interface ThumbSpec {
 export interface ThumbReqInfo {
   xxhs: string; // hex lowercase preferred
   specs: ThumbSpec[];
+  ensureBase?: boolean;
 }
 
 export interface ThumbRequest {
   items: ThumbReqInfo[];
+  ensureBase?: boolean;
 }
 
 export interface ThumbResSpec {


### PR DESCRIPTION
## Summary
- add persistent file-service settings for controlling base thumbnail caching
- respect the setting when queuing and processing base thumbnail work on the backend
- expose renderer IPC for the setting and add a UI toggle that scopes thumbnail requests accordingly

## Testing
- pnpm format:write
- pnpm lint:check *(fails: missing npm dependencies in the container)*
- pnpm --filter @grim/desktop build *(fails: missing npm dependencies in the container)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: registry access blocked in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d170329008832e96661664dcc6ddd3