### PR TITLE
Group file tree leaves by type

### DIFF
--- a/apps/desktop/src/features/main/panel/FileTreePanel.tsx
+++ b/apps/desktop/src/features/main/panel/FileTreePanel.tsx
@@ -8,7 +8,7 @@ import {
   parseDropTarget,
 } from '@tgim/dnd/index';
 import { DndContext, DragOverlay, closestCenter } from '@dnd-kit/core';
-import { NodeList } from '@tgim/ui/index';
+import { NodeList, getVisibleNodeIds } from '@tgim/ui/index';
 import { File, Folder } from 'lucide-react';
 import useFileTreeStore from '@tgim/stores/fileTreeStore';
 import { useShallow } from 'zustand/shallow';
@@ -32,34 +32,6 @@ export const findNode = (tree: FileTreeData[], id: string): FileTreeData | null 
     }
   }
   return null;
-};
-
-// Returns a depth map used for indent rendering
-const buildDepthMap = (
-  tree: FileTreeData[],
-  depth = 0,
-  map: Map<string, number> = new Map<string, number>(),
-): Map<string, number> => {
-  for (const n of tree) {
-    map.set(n.id, depth);
-    if (n.children?.length) buildDepthMap(n.children, depth + 1, map);
-  }
-  return map;
-};
-
-// Returns visible id list based on expanded set
-const flattenVisible = (tree: FileTreeData[], expanded: Set<string>): string[] => {
-  const out: string[] = [];
-  const walk = (nodes: FileTreeData[]) => {
-    for (const n of nodes) {
-      out.push(n.id);
-      if (n.children?.length && expanded.has(n.id)) {
-        walk(n.children);
-      }
-    }
-  };
-  walk(tree);
-  return out;
 };
 
 type ImportContext = {
@@ -101,7 +73,7 @@ export const FileTree = () => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   // Multi-select (based on visible order)
-  const visibleOrder = useMemo(() => flattenVisible(treeData, expanded), [treeData, expanded]);
+  const visibleOrder = useMemo(() => getVisibleNodeIds(treeData, expanded), [treeData, expanded]);
   const {
     selected,
     setSelected,
@@ -137,7 +109,6 @@ export const FileTree = () => {
 
   // DnD sensors and depth map for rendering
   const sensors = useStandardSensors(4);
-  const depthMap = useMemo(() => buildDepthMap(treeData), [treeData]);
 
   const activeNode = activeId ? findNode(treeData, activeId) : null;
 
@@ -344,6 +315,7 @@ export const FileTree = () => {
       >
         <NodeList
           parentId="root"
+          depth={0}
           nodes={treeData}
           expandedSet={expanded}
           onToggle={id => {
@@ -354,7 +326,6 @@ export const FileTree = () => {
               return n;
             });
           }}
-          depthMap={depthMap}
           dragging={!!activeId}
           hoverId={hoverId}
           selectedSet={selected}

--- a/packages/stores/src/fileTreeStore.ts
+++ b/packages/stores/src/fileTreeStore.ts
@@ -180,6 +180,7 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
         icon: n.kind === 'folder' ? 'folder' : 'file',
         type: n.kind === 'folder' ? NodeKind.Folder : NodeKind.File,
         children: n.kind === 'folder' ? [] : undefined,
+        fileType: fileData?.kind,
       });
 
       incoming.set(n.id, 0);

--- a/packages/types/src/tree.ts
+++ b/packages/types/src/tree.ts
@@ -1,4 +1,5 @@
-import { NodeKind } from "./graph";
+import { NodeKind } from './graph';
+import { FileType } from './file';
 
 export interface FileTreeData {
   id: string;
@@ -6,4 +7,7 @@ export interface FileTreeData {
   icon?: string;
   children?: FileTreeData[];
   type: NodeKind;
+  fileType?: FileType;
+  isGroup?: boolean;
+  groupType?: FileType;
 }

--- a/packages/ui/src/FileTree.tsx
+++ b/packages/ui/src/FileTree.tsx
@@ -1,10 +1,111 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useDraggable, useDroppable } from '@dnd-kit/core';
 import { createContainerId, createFolderId, Droppable } from '@tgim/dnd/index';
-import { NodeKind, type FileTreeData } from '@tgim/types/index';
+import { FileType, NodeKind, type FileTreeData } from '@tgim/types/index';
 import { ChevronDown, ChevronRight, File, Folder, MoreVertical } from 'lucide-react';
 import cn from '@tgim/utils/cn';
 import Button from './Button';
+
+const LEAF_GROUP_THRESHOLD = 10;
+
+const FILE_TYPE_LABELS: Record<FileType, string> = {
+  [FileType.Image]: '이미지',
+  [FileType.Video]: '비디오',
+  [FileType.Document]: '문서',
+  [FileType.GraphicTool]: '그래픽',
+  [FileType.Audio]: '오디오',
+  [FileType.Archive]: '압축',
+  [FileType.Unknown]: '기타',
+};
+
+const formatFileTypeLabel = (fileType: FileType) =>
+  FILE_TYPE_LABELS[fileType] ?? fileType.charAt(0).toUpperCase() + fileType.slice(1);
+
+type GroupOptions = {
+  disableGrouping?: boolean;
+  threshold?: number;
+};
+
+const groupLeafNodes = (
+  parentId: string,
+  nodes: FileTreeData[],
+  options: GroupOptions = {},
+): FileTreeData[] => {
+  const { disableGrouping = false, threshold = LEAF_GROUP_THRESHOLD } = options;
+  if (disableGrouping || !nodes.length) return nodes;
+
+  const meta = new Map<FileType, { indices: number[]; nodes: FileTreeData[] }>();
+  const nodeTypes = nodes.map((node, index) => {
+    if (node.children?.length || !node.fileType) return null;
+    const entry = meta.get(node.fileType) ?? { indices: [], nodes: [] };
+    entry.indices.push(index);
+    entry.nodes.push(node);
+    meta.set(node.fileType, entry);
+    return node.fileType;
+  });
+
+  if (!meta.size) return nodes;
+
+  const handled = new Set<FileType>();
+  const result: FileTreeData[] = [];
+
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+    const fileType = nodeTypes[index];
+    if (!fileType) {
+      result.push(node);
+      continue;
+    }
+
+    const entry = meta.get(fileType);
+    if (!entry || entry.nodes.length < threshold) {
+      result.push(node);
+      continue;
+    }
+
+    if (handled.has(fileType)) {
+      continue;
+    }
+
+    handled.add(fileType);
+
+    const label = formatFileTypeLabel(fileType);
+    result.push({
+      id: `group:${parentId}:${fileType}`,
+      name: `${label} (${entry.nodes.length})`,
+      icon: 'folder',
+      type: NodeKind.Folder,
+      children: entry.nodes,
+      isGroup: true,
+      groupType: fileType,
+    });
+  }
+
+  return result;
+};
+
+export const getVisibleNodeIds = (
+  tree: FileTreeData[],
+  expanded: Set<string>,
+  options: { threshold?: number } = {},
+) => {
+  const { threshold } = options;
+  const ids: string[] = [];
+
+  const walk = (nodes: FileTreeData[], parentId: string, disableGrouping: boolean) => {
+    const grouped = groupLeafNodes(parentId, nodes, { disableGrouping, threshold });
+    for (const node of grouped) {
+      ids.push(node.id);
+      if (node.children?.length && expanded.has(node.id)) {
+        walk(node.children, node.id, disableGrouping || !!node.isGroup);
+      }
+    }
+  };
+
+  walk(tree, 'root', false);
+
+  return ids;
+};
 
 export const TreeNode: React.FC<{
   node: FileTreeData;
@@ -29,15 +130,16 @@ export const TreeNode: React.FC<{
 }) => {
   const isFolder = node.type === NodeKind.Folder;
   const isFile = node.type === NodeKind.File;
+  const isGroup = !!node.isGroup;
   const {
     attributes,
     listeners,
     setNodeRef: setDragRef,
     isDragging,
-  } = useDraggable({ id: node.id });
+  } = useDraggable({ id: node.id, disabled: isGroup });
   const { setNodeRef: setDropRef, isOver } = useDroppable({
     id: createFolderId(node.id),
-    disabled: !isFolder,
+    disabled: !isFolder || isGroup,
   });
   const setRefs = (el: HTMLElement | null) => {
     setDragRef(el);
@@ -58,9 +160,17 @@ export const TreeNode: React.FC<{
           isDragging ? 'is-dragging' : '',
         )}
         onClick={e => {
+          const hasModifier = e.shiftKey || e.metaKey || e.ctrlKey;
+
+          if (isGroup) {
+            e.stopPropagation();
+            if (!hasModifier) onToggle(node.id);
+            return;
+          }
+
           onSelect?.(e, node.id);
-          if (isFolder && !e.shiftKey && !e.metaKey && !e.ctrlKey) onToggle(node.id);
-          if (isFile && !e.shiftKey && !e.metaKey && !e.ctrlKey) openFile(node);
+          if (isFolder && !hasModifier) onToggle(node.id);
+          if (isFile && !hasModifier) openFile(node);
         }}
         {...attributes}
         {...listeners}
@@ -90,16 +200,18 @@ export const TreeNode: React.FC<{
           {node.name}
         </span>
 
-        <Button
-          variant="icon"
-          aria-label="More actions"
-          onClick={e => {
-            e.stopPropagation();
-            onClickOption?.(node);
-          }}
-        >
-          <MoreVertical className="icon" />
-        </Button>
+        {!isGroup ? (
+          <Button
+            variant="icon"
+            aria-label="More actions"
+            onClick={e => {
+              e.stopPropagation();
+              onClickOption?.(node);
+            }}
+          >
+            <MoreVertical className="icon" />
+          </Button>
+        ) : null}
       </div>
     </li>
   );
@@ -107,34 +219,43 @@ export const TreeNode: React.FC<{
 
 export const NodeList: React.FC<{
   parentId: string;
+  depth: number;
   nodes: FileTreeData[];
   expandedSet: Set<string>;
   onToggle: (id: string) => void;
-  depthMap: Map<string, number>;
   dragging: boolean;
   hoverId: string | null;
   selectedSet: Set<string>;
   onSelect: (e: React.MouseEvent, id: string) => void;
   onClickOption?: (node: FileTreeData | undefined) => void;
   openFile: (node: FileTreeData) => void;
+  disableGrouping?: boolean;
 }> = ({
   parentId,
+  depth,
   nodes,
   expandedSet,
   onToggle,
-  depthMap,
   dragging,
   hoverId,
   selectedSet,
   onSelect,
   onClickOption,
   openFile,
+  disableGrouping = false,
 }) => {
-  const orderedNodes = [...nodes].sort((a, b) => {
-    const aHas = a.children == null ? 0 : 1;
-    const bHas = b.children == null ? 0 : 1;
-    return bHas - aHas;
-  });
+  const displayNodes = useMemo(
+    () => groupLeafNodes(parentId, nodes, { disableGrouping }),
+    [parentId, nodes, disableGrouping],
+  );
+
+  const orderedNodes = useMemo(() => {
+    return [...displayNodes].sort((a, b) => {
+      const aHas = a.children == null ? 0 : 1;
+      const bHas = b.children == null ? 0 : 1;
+      return bHas - aHas;
+    });
+  }, [displayNodes]);
 
   return (
     <Droppable
@@ -142,7 +263,6 @@ export const NodeList: React.FC<{
       dragging={dragging}
       render={() =>
         orderedNodes.map(node => {
-          const depth = depthMap.get(node.id) ?? 0;
           const expanded = expandedSet.has(node.id);
           const selected = selectedSet.has(node.id);
 
@@ -162,16 +282,17 @@ export const NodeList: React.FC<{
               {node.children?.length && expanded ? (
                 <NodeList
                   parentId={node.id}
+                  depth={depth + 1}
                   nodes={node.children}
                   expandedSet={expandedSet}
                   onToggle={onToggle}
-                  depthMap={depthMap}
                   dragging={dragging}
                   hoverId={hoverId}
                   selectedSet={selectedSet}
                   onSelect={onSelect}
                   openFile={openFile}
                   onClickOption={onClickOption}
+                  disableGrouping={node.isGroup}
                 />
               ) : null}
             </React.Fragment>


### PR DESCRIPTION
## Summary
- attach file type metadata to file tree nodes so the renderer can distinguish leaf kinds
- group leaf nodes with the same file type into virtual folders that expand on click and skip selection/dragging
- update the desktop file tree panel to use the new visible-id helper and depth handling for grouped nodes

## Testing
- `pnpm format:write`
- `pnpm lint:check` *(fails: missing @eslint/js in workspace)*
- `pnpm --filter @grim/desktop build` *(fails: dependencies not installed; npm registry blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68d1701405dc832eb7980d0d92fbb024