### PR TITLE
feat: show thumbnails on graph nodes

### DIFF
--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -108,6 +108,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           label: data.file_name ?? 'file',
           size: nodeSize,
           type: type,
+          hash: data.xxh3_64,
         };
       } else if (node.kind == NodeKind.Folder && node.data['Folder']) {
         let data = node.data['Folder'];

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -1,12 +1,15 @@
 import usePanelsStore from '@tgim/stores/panelStore';
-import { Connection, GraphConnection, GraphData } from '@tgim/types/graph';
+import { Connection, GraphConnection, GraphData, GraphNode } from '@tgim/types/graph';
 import { NodeRenderer, clearNodeSpriteCaches, getGraphPalette } from '@tgim/ui/index';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
 import { useShallow } from 'zustand/shallow';
 import * as d3 from 'd3-force';
 import useThumbStore from '@tgim/stores/thumbStore';
 import { useMoa } from '@tgim/hooks/useMoa';
+import { ResizeMode } from '@tgim/types/file';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { useThumbnails } from '../../../../hooks';
 import { useTheme } from '../../../../theme/ThemeProvider';
 
 interface Props {
@@ -14,6 +17,8 @@ interface Props {
   rootNodeId: string;
   rootGraphNodeId: string;
 }
+
+const GRAPH_THUMB_SIZE = 64;
 
 const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -45,13 +50,6 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
       }
     };
   }, []);
-  const { upsertThumb, thumb } = useThumbStore(
-    useShallow(s => ({
-      upsertThumb: s.upsert,
-      thumb: s.byKey,
-    })),
-  );
-
   const nodesById = useMemo(() => {
     if (!graphData) return {};
     const nodesById = Object.fromEntries(graphData.nodes.map(node => [node.id, node]));
@@ -66,16 +64,9 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
     return nodesById;
   }, [graphData.nodes]);
   const { moaId } = useMoa(location);
-
-  useEffect(() => {
-    graphData.nodes.forEach(node => {
-      if (node.type == 'image' && !node.url) {
-      }
-    });
-  }, [moaId, graphData.nodes]);
+  const { ensureThumbnails, getThumbnailKey } = useThumbnails({ moaId });
 
   const GAP = 90;
-  const LEAF_OFFSET = 10;
 
   const getPrunedTree = () => {
     const visibleNodes = [];
@@ -96,6 +87,70 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
     return { nodes: visibleNodes, links: visibleLinks };
   };
   const [prunedTree, setPrunedTree] = useState(getPrunedTree());
+  const imageNodes = useMemo(
+    () => prunedTree.nodes.filter(node => node.type === 'image' && node.hash),
+    [prunedTree.nodes],
+  );
+  const imageNodesRef = useRef<GraphNode[]>([]);
+  useEffect(() => {
+    imageNodesRef.current = imageNodes;
+  }, [imageNodes]);
+
+  useEffect(() => {
+    if (imageNodes.length === 0) return;
+
+    const requests = imageNodes
+      .filter(
+        (node): node is GraphNode & { hash: string } =>
+          typeof node.hash === 'string' && node.hash.length > 0,
+      )
+      .map(node => {
+        const request = {
+          hash: node.hash,
+          width: GRAPH_THUMB_SIZE,
+          height: GRAPH_THUMB_SIZE,
+          dpr: 1 as const,
+          mode: ResizeMode.Original,
+        };
+        const key = getThumbnailKey(request);
+        if (node.thumbKey !== key) {
+          node.thumbKey = key;
+          node.url = undefined;
+        }
+        return { ...request, key };
+      });
+
+    if (requests.length === 0) return;
+
+    void ensureThumbnails(requests);
+  }, [ensureThumbnails, getThumbnailKey, imageNodes]);
+
+  useEffect(() => {
+    const unsubscribe = useThumbStore.subscribe(
+      state => state.byKey,
+      byKey => {
+        let changed = false;
+        imageNodesRef.current.forEach(node => {
+          const key = node.thumbKey;
+          if (!key) return;
+          const entry = byKey[key];
+          const nextUrl =
+            entry?.status === 'ready' && entry.url ? convertFileSrc(entry.url) : undefined;
+          if (node.url !== nextUrl) {
+            node.url = nextUrl;
+            changed = true;
+          }
+        });
+        if (changed) {
+          fgRef.current?.refresh();
+        }
+      },
+    );
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
 
   useEffect(() => {
     if (fgRef && fgRef.current) {
@@ -179,6 +234,8 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
               y: node.y || 0,
               size: node.size,
               label: node.label,
+              url: node.url,
+              thumbKey: node.thumbKey,
             },
             globalScale,
           );

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -141,9 +141,6 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
             changed = true;
           }
         });
-        if (changed) {
-          fgRef.current?.refresh();
-        }
       },
     );
 

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -1,12 +1,12 @@
 import { useMoa } from '@tgim/hooks/useMoa';
 import { useMultiSelect } from '@tgim/dnd/index';
 import { GridData, ImageItem } from '@tgim/types/grid';
-import { ipc } from '../../../../lib/ipc';
 import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
 import { ResizeMode } from '@tgim/types/file';
 import { useShallow } from 'zustand/shallow';
 import { convertFileSrc } from '@tauri-apps/api/core';
+import { useThumbnails } from '../../../../hooks';
 import Masonry from 'react-masonry-css';
 import { FixedSizeGrid as WindowGrid, GridChildComponentProps } from 'react-window';
 import { Button } from '@tgim/ui';
@@ -237,11 +237,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
     }
   }, [croquisModalOpen, selectedCount]);
 
-  const { upsertThumb } = useThumbStore(
-    useShallow(state => ({
-      upsertThumb: state.upsert,
-    })),
-  );
+  const { ensureThumbnails } = useThumbnails({ moaId, maxBatchSize: MAX_ITEMS_PER_REQ });
 
   const scrollRef = useRef<HTMLDivElement>(null);
   // @ts-expect-error.
@@ -264,50 +260,19 @@ const GridView: React.FC<Props> = ({ gridData }) => {
    * ------------------------------------------------- */
   const fetchThumbnails = useCallback(
     async (itemsToFetch: ImageItem[]) => {
-      if (moaId === null || itemsToFetch.length === 0) return;
+      if (itemsToFetch.length === 0) return;
 
-      const currentThumbs = useThumbStore.getState().byKey;
+      const requests = itemsToFetch.map(img => ({
+        hash: img.hash,
+        width: thumbSize,
+        height: thumbSize,
+        dpr: 1 as const,
+        mode: ResizeMode.Original,
+      }));
 
-      const toRequest = itemsToFetch
-        .map(img => {
-          const key = convertToThumbKey(img.hash, {
-            width: thumbSize,
-            height: thumbSize,
-            dpr: 1,
-            mode: ResizeMode.Original,
-          });
-          // Skip if already ready
-          if (currentThumbs[key]?.status === 'ready') return null;
-          return {
-            xxhs: img.hash,
-            specs: [
-              { width: thumbSize, height: thumbSize, dpr: 1, mode: ResizeMode.Original, key },
-            ],
-          };
-        })
-        .filter(Boolean) as any[];
-
-      if (toRequest.length === 0) return;
-
-      for (let i = 0; i < toRequest.length; i += MAX_ITEMS_PER_REQ) {
-        const chunk = toRequest.slice(i, i + MAX_ITEMS_PER_REQ);
-        try {
-          const responses = await ipc.file.getThumbnails(moaId, { items: chunk });
-          responses.items.forEach((item: any) => {
-            item.specs.forEach((spec: any) => {
-              upsertThumb(spec.thumb_key ?? spec.key, {
-                status: spec.status === 'hit' ? 'ready' : 'pending',
-                url: spec.status === 'hit' ? spec.url : undefined,
-                updatedAt: Date.now(),
-              });
-            });
-          });
-        } catch (error) {
-          console.error('Failed to fetch thumbnails:', error);
-        }
-      }
+      await ensureThumbnails(requests);
     },
-    [moaId, thumbSize, upsertThumb],
+    [ensureThumbnails, thumbSize],
   );
 
   // Stable ref to avoid stale closure

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useThumbnails';

--- a/apps/desktop/src/hooks/useThumbnails.ts
+++ b/apps/desktop/src/hooks/useThumbnails.ts
@@ -1,0 +1,139 @@
+import { useCallback } from 'react';
+import { ipc } from '../lib/ipc';
+import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
+import { ImageFmt, ResizeMode, ThumbSpec, ThumbStatus } from '@tgim/types/file';
+import { useShallow } from 'zustand/shallow';
+
+const DEFAULT_MAX_BATCH = 100;
+
+type Dpr = 1 | 2 | 3;
+
+export interface ThumbnailRequest {
+  hash: string;
+  width: number;
+  height: number;
+  dpr?: Dpr;
+  mode?: ResizeMode;
+  fmt?: ImageFmt;
+  key?: string;
+}
+
+interface UseThumbnailsOptions {
+  moaId: string | null;
+  maxBatchSize?: number;
+}
+
+export function useThumbnails({ moaId, maxBatchSize = DEFAULT_MAX_BATCH }: UseThumbnailsOptions) {
+  const { upsertThumb } = useThumbStore(
+    useShallow(state => ({
+      upsertThumb: state.upsert,
+    })),
+  );
+
+  const getThumbnailKey = useCallback(
+    ({ hash, width, height, dpr = 1, mode = ResizeMode.Original, key }: ThumbnailRequest) => {
+      return key ?? convertToThumbKey(hash, { width, height, dpr, mode });
+    },
+    [],
+  );
+
+  const ensureThumbnails = useCallback(
+    async (requests: ThumbnailRequest[]) => {
+      if (!moaId || requests.length === 0) {
+        return;
+      }
+
+      const grouped = new Map<string, ThumbSpec[]>();
+      const seenKeys = new Set<string>();
+
+      for (const request of requests) {
+        const { hash, width, height } = request;
+        if (!hash || width <= 0 || height <= 0) continue;
+
+        const descriptor: ThumbnailRequest = {
+          hash,
+          width,
+          height,
+          dpr: request.dpr ?? 1,
+          mode: request.mode ?? ResizeMode.Original,
+          fmt: request.fmt,
+          key: request.key,
+        };
+
+        const key = getThumbnailKey(descriptor);
+        if (seenKeys.has(key)) continue;
+        seenKeys.add(key);
+
+        const currentEntry = useThumbStore.getState().byKey[key];
+        if (currentEntry?.status === 'ready' && currentEntry.url) {
+          continue;
+        }
+
+        upsertThumb(key, { status: 'pending' });
+
+        const spec: ThumbSpec = {
+          width: descriptor.width,
+          height: descriptor.height,
+          key,
+        };
+        if (descriptor.dpr) spec.dpr = descriptor.dpr;
+        if (descriptor.mode) spec.mode = descriptor.mode;
+        if (descriptor.fmt) spec.fmt = descriptor.fmt;
+
+        const specs = grouped.get(hash) ?? [];
+        specs.push(spec);
+        grouped.set(hash, specs);
+      }
+
+      if (grouped.size === 0) return;
+
+      const payload = Array.from(grouped.entries()).map(([xxhs, specs]) => ({ xxhs, specs }));
+
+      for (let i = 0; i < payload.length; i += maxBatchSize) {
+        const chunk = payload.slice(i, i + maxBatchSize);
+        try {
+          const response = await ipc.file.getThumbnails(moaId, { items: chunk });
+          response.items.forEach(item => {
+            item.specs.forEach(spec => {
+              const key = spec.thumb_key ?? spec.key;
+              if (!key) return;
+
+              switch (spec.status) {
+                case ThumbStatus.Hit:
+                  upsertThumb(key, { status: 'ready', url: spec.url });
+                  break;
+                case ThumbStatus.Error:
+                  upsertThumb(key, { status: 'error', error: spec.error_msg });
+                  break;
+                default:
+                  upsertThumb(key, { status: 'pending' });
+                  break;
+              }
+            });
+          });
+        } catch (error) {
+          console.error('Failed to fetch thumbnails:', error);
+        }
+      }
+    },
+    [getThumbnailKey, maxBatchSize, moaId, upsertThumb],
+  );
+
+  const getThumbnailUrl = useCallback(
+    (request: ThumbnailRequest) => {
+      const key = getThumbnailKey(request);
+      const entry = useThumbStore.getState().byKey[key];
+      if (entry?.status === 'ready' && entry.url) {
+        return { key, url: entry.url };
+      }
+      return { key, url: undefined };
+    },
+    [getThumbnailKey],
+  );
+
+  return {
+    ensureThumbnails,
+    getThumbnailKey,
+    getThumbnailUrl,
+  };
+}

--- a/packages/stores/src/thumbStore.ts
+++ b/packages/stores/src/thumbStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import { subscribeWithSelector } from 'zustand/middleware';
 import { ThumbEntry, ThumbSpec } from '@tgim/types/file';
 
 /**
@@ -33,92 +34,94 @@ interface ThumbState {
 }
 
 export const useThumbStore = create<ThumbState>()(
-  immer((set, get) => ({
-    byKey: {},
-    byHash: {},
-    lru: [],
+  subscribeWithSelector(
+    immer((set, get) => ({
+      byKey: {},
+      byHash: {},
+      lru: [],
 
-    upsert: (key, patch) => {
-      const cur = get().byKey[key] ?? { status: 'pending', updatedAt: 0, v: 1 };
-      const prevUrl = cur.url;
-      const next = { ...cur, ...patch, updatedAt: Date.now() };
-      set(s => {
-        s.byKey[key] = next;
+      upsert: (key, patch) => {
+        const cur = get().byKey[key] ?? { status: 'pending', updatedAt: 0, v: 1 };
+        const prevUrl = cur.url;
+        const next = { ...cur, ...patch, updatedAt: Date.now() };
+        set(s => {
+          s.byKey[key] = next;
 
-        // Revoke previous blob URL if replaced to avoid leaks
-        // (safe-guard: don't revoke if same string)
-        if (prevUrl && prevUrl !== next.url && prevUrl.startsWith('blob:')) {
-          try {
-            URL.revokeObjectURL(prevUrl);
-          } catch {}
+          // Revoke previous blob URL if replaced to avoid leaks
+          // (safe-guard: don't revoke if same string)
+          if (prevUrl && prevUrl !== next.url && prevUrl.startsWith('blob:')) {
+            try {
+              URL.revokeObjectURL(prevUrl);
+            } catch {}
+          }
+        });
+        // Move to MRU only when entry becomes ready
+        if (next.status === 'ready') {
+          set(s => {
+            const lru = s.lru.filter(k => k !== key);
+            lru.push(key);
+            s.lru = lru;
+          });
         }
-      });
-      // Move to MRU only when entry becomes ready
-      if (next.status === 'ready') {
+      },
+
+      // Touch for read-access MRU update
+      touch: key => {
         set(s => {
           const lru = s.lru.filter(k => k !== key);
           lru.push(key);
           s.lru = lru;
         });
-      }
-    },
+      },
 
-    // Touch for read-access MRU update
-    touch: key => {
-      set(s => {
-        const lru = s.lru.filter(k => k !== key);
-        lru.push(key);
-        s.lru = lru;
-      });
-    },
+      attach: (hash, key) => {
+        set(s => {
+          const setForHash = s.byHash[hash] ?? [];
+          setForHash.push(key);
+          s.byHash[hash] = setForHash;
+        });
+      },
 
-    attach: (hash, key) => {
-      set(s => {
-        const setForHash = s.byHash[hash] ?? [];
-        setForHash.push(key);
-        s.byHash[hash] = setForHash;
-      });
-    },
+      evictLRU: max => {
+        const { lru, byKey } = get();
+        if (lru.length <= max) return;
 
-    evictLRU: max => {
-      const { lru, byKey } = get();
-      if (lru.length <= max) return;
+        const cut = lru.length - max;
+        const toEvict = lru.slice(0, cut);
+        const evictSet = new Set(toEvict); // lookups
 
-      const cut = lru.length - max;
-      const toEvict = lru.slice(0, cut);
-      const evictSet = new Set(toEvict); // lookups
-
-      // revoke Blob URLs for evicted keys
-      for (const k of toEvict) {
-        const e = byKey[k];
-        if (e?.url?.startsWith('blob:')) {
-          try {
-            URL.revokeObjectURL(e.url);
-          } catch {}
-        }
-      }
-
-      set(s => {
-        s.lru = s.lru.slice(cut);
-
-        for (const k of Object.keys(s.byKey)) {
-          if (evictSet.has(k)) {
-            const v = s.byKey[k];
-            if (v) s.byKey[k] = { ...v, url: undefined };
+        // revoke Blob URLs for evicted keys
+        for (const k of toEvict) {
+          const e = byKey[k];
+          if (e?.url?.startsWith('blob:')) {
+            try {
+              URL.revokeObjectURL(e.url);
+            } catch {}
           }
         }
-      });
-    },
 
-    getThumbPathByKey: key => {
-      const thumb = get().byKey[key];
-      if (thumb && thumb.status === 'ready') {
-        get().touch(key);
-        return thumb.url;
-      }
-      return undefined;
-    },
-  })),
+        set(s => {
+          s.lru = s.lru.slice(cut);
+
+          for (const k of Object.keys(s.byKey)) {
+            if (evictSet.has(k)) {
+              const v = s.byKey[k];
+              if (v) s.byKey[k] = { ...v, url: undefined };
+            }
+          }
+        });
+      },
+
+      getThumbPathByKey: key => {
+        const thumb = get().byKey[key];
+        if (thumb && thumb.status === 'ready') {
+          get().touch(key);
+          return thumb.url;
+        }
+        return undefined;
+      },
+    })),
+  ),
 );
 
 export const convertToThumbKey = (hash: string, spec: Partial<ThumbSpec>) => {

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -137,9 +137,7 @@ ensurePaletteObservers();
 const getGraphPaletteInternal = () => graphPalette;
 
 const colorParsingCtx =
-  typeof document !== 'undefined'
-    ? document.createElement('canvas').getContext('2d')
-    : null;
+  typeof document !== 'undefined' ? document.createElement('canvas').getContext('2d') : null;
 
 const normalizeColor = (value: string) => {
   if (!colorParsingCtx) return value;
@@ -352,8 +350,16 @@ function drawLabelCached(ctx: CanvasRenderingContext2D, node: NodeProp) {
 /** External images */
 // =========================
 
-function resolveImageSrc(_node: NodeProp): string | undefined {
-  // TODO: Implement project-specific mapping from node payload to URL
+function resolveImageSrc(node: NodeProp): string | undefined {
+  if (typeof node.url === 'string' && node.url.length > 0) {
+    return node.url;
+  }
+  if (typeof node.imageUrl === 'string' && node.imageUrl.length > 0) {
+    return node.imageUrl;
+  }
+  if (typeof node.src === 'string' && node.src.length > 0) {
+    return node.src;
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- add a shared `useThumbnails` hook to centralize thumbnail request batching and cache updates
- request 64px thumbnails for image nodes in the graph view and propagate the resolved URLs to the canvas renderer
- refactor the grid view to reuse the new hook and allow the node renderer to display supplied thumbnail URLs

## Testing
- pnpm format:write
- pnpm lint:check *(fails: missing @eslint/js because workspace dependencies cannot be installed in this environment)*
- pnpm --filter @grim/desktop build *(fails: workspace dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16fcec638832e8ff361386a313cdf