### PR TITLE
Implement croquis capture workflow

### DIFF
--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,7 +1,7 @@
 use crate::{
     models::croquis::{
-        CroquisOption, CroquisSession, CroquisStartPayload,
-        CroquisStartResponse,
+        CroquisCaptureRequest, CroquisCaptureResponse, CroquisOption,
+        CroquisSession, CroquisStartPayload, CroquisStartResponse,
     },
     services::croquis_service,
 };
@@ -31,4 +31,15 @@ pub async fn load_croquis_option(
     moa_id: String,
 ) -> Result<Option<CroquisOption>, String> {
     croquis_service::load_option(&moa_id).await.map_err(|err| err.to_string())
+}
+
+/// Persist a capture for the current Croquis session and link it to the source image.
+#[tauri::command]
+pub async fn capture_croquis_reference(
+    app_handle: tauri::AppHandle,
+    payload: CroquisCaptureRequest,
+) -> Result<CroquisCaptureResponse, String> {
+    croquis_service::capture_reference(&app_handle, payload)
+        .await
+        .map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/db/repository/file_repository.rs
+++ b/apps/desktop/src-tauri/src/db/repository/file_repository.rs
@@ -47,6 +47,29 @@ impl FileRepository {
         Ok(mount_id)
     }
 
+    /// Locate an existing virtual folder that is mounted to the provided real folder.
+    pub async fn find_virtual_folder_id_by_real_folder<'a, E>(
+        executor: &mut E,
+        real_folder_id: &str,
+    ) -> Result<Option<String>>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let virtual_node_id = sqlx::query_scalar!(
+            r#"
+                SELECT virtual_node_id AS "virtual_node_id!"
+                FROM virtual_folder_mount
+                WHERE real_folder_id = ?1
+                LIMIT 1
+            "#,
+            real_folder_id,
+        )
+        .fetch_optional(&mut *executor)
+        .await?;
+
+        Ok(virtual_node_id)
+    }
+
     /// Look up a real-folder identifier by normalized path components.
     pub async fn _find_folder_id<'a, E>(
         executor: &mut E,

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
             commands::croquis::start_croquis_session,
             commands::croquis::load_croquis_session,
             commands::croquis::load_croquis_option,
+            commands::croquis::capture_croquis_reference,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/models/connection.rs
+++ b/apps/desktop/src-tauri/src/models/connection.rs
@@ -22,6 +22,7 @@ pub enum RelationType {
     BelongToFolder,
     ParentFolder,
     ChildFolder,
+    CroquisReference,
 }
 
 /// Describes how edges are treated during graph traversal.

--- a/apps/desktop/src-tauri/src/models/croquis.rs
+++ b/apps/desktop/src-tauri/src/models/croquis.rs
@@ -85,3 +85,41 @@ pub struct CroquisStartResponse {
     pub session_id: String,
     pub window_label: String,
 }
+
+/// Selection rectangle expressed as normalised offsets relative to the base image.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureSelection {
+    pub left: f32,
+    pub top: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+/// Capture mode describing how the renderer derived the selection rectangle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CroquisCaptureMode {
+    Freeform,
+    Square,
+    Full,
+}
+
+/// Payload received from the renderer when the user saves a capture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureRequest {
+    pub session_id: String,
+    pub image_hash: String,
+    pub mode: CroquisCaptureMode,
+    pub selection: CroquisCaptureSelection,
+}
+
+/// Response returned once the capture has been persisted to disk and registered.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureResponse {
+    pub saved_path: String,
+    pub file_name: String,
+    pub node_id: String,
+}

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -1,22 +1,34 @@
-use std::{collections::HashMap, io::ErrorKind};
+use std::{collections::HashMap, io::Cursor, io::ErrorKind, path::PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use image::ImageOutputFormat;
 use once_cell::sync::Lazy;
-use tokio::{fs, sync::RwLock};
+use tokio::{fs, sync::RwLock, task};
 use tracing::warn;
 
 use crate::{
     app_launcher,
     bootstrap::PATH_MANAGER,
+    models::connection::RelationType,
     models::croquis::{
-        CroquisOption, CroquisSession, CroquisSessionImage,
-        CroquisStartPayload, CroquisStartResponse,
+        CroquisCaptureRequest, CroquisCaptureResponse, CroquisOption,
+        CroquisSession, CroquisSessionImage, CroquisStartPayload,
+        CroquisStartResponse,
     },
+    models::file::{FileInfo, FileType},
+    services::db::DB_MANAGER,
     services::file_service::{
         folder::fetch_one_file_path,
+        job_queue::{enqueue_base_job, BaseThumbnailJob},
         thumbnail::{ensure_base_thumbnail, BaseThumbInfo},
     },
-    utils::{date, identifier::get_unique_id},
+    services::storage_root,
+    utils::{date, identifier::get_unique_id, path_utils::normalize_path},
+};
+
+use crate::db::repository::{
+    connection_repository::ConnectionRepository,
+    file_repository::FileRepository, node_repository::NodeRepository,
 };
 
 /// In-memory registry of active Croquis sessions keyed by session identifier.
@@ -144,6 +156,248 @@ pub async fn load_option(moa_id: &str) -> Result<Option<CroquisOption>> {
             )
         }),
     }
+}
+
+/// Crop and persist a capture for the active session, linking it to the source image.
+pub async fn capture_reference(
+    _app_handle: &tauri::AppHandle,
+    payload: CroquisCaptureRequest,
+) -> Result<CroquisCaptureResponse> {
+    let CroquisCaptureRequest { session_id, image_hash, selection, mode: _ } =
+        payload;
+
+    let session = {
+        let sessions = CROQUIS_SESSIONS.read().await;
+        sessions.get(&session_id).cloned()
+    }
+    .ok_or_else(|| anyhow!("Croquis session not found for id {session_id}"))?;
+
+    let image = session
+        .images
+        .iter()
+        .find(|item| item.hash == image_hash)
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!("Croquis image not found for hash {image_hash}")
+        })?;
+
+    let save_dir_raw = session.option.save_path.trim();
+    if save_dir_raw.is_empty() {
+        bail!("Croquis capture path is not configured for this session");
+    }
+
+    let save_dir = PathBuf::from(save_dir_raw);
+    fs::create_dir_all(&save_dir).await.with_context(|| {
+        format!(
+            "Failed to create Croquis capture directory at {}",
+            save_dir.display()
+        )
+    })?;
+
+    let file_name = format!("croquis_{}.png", get_unique_id());
+    let file_path = save_dir.join(&file_name);
+
+    let base_width = image.base_width.max(1) as f32;
+    let base_height = image.base_height.max(1) as f32;
+    let source_path = PathBuf::from(&image.source_path);
+
+    let source_bytes = fs::read(&source_path).await.with_context(|| {
+        format!(
+            "Failed to read Croquis source image at {}",
+            source_path.display()
+        )
+    })?;
+
+    let selection_clone = selection.clone();
+    let (encoded, _dimensions) =
+        task::spawn_blocking(move || -> Result<(Vec<u8>, (u32, u32))> {
+            let image = image::load_from_memory(&source_bytes)
+                .context("Failed to decode source image for capture")?;
+            let (orig_w, orig_h) = image.dimensions();
+            if orig_w == 0 || orig_h == 0 {
+                bail!("Source image has invalid dimensions");
+            }
+
+            let clamp01 = |value: f32| value.clamp(0.0, 1.0);
+            let left = clamp01(selection_clone.left);
+            let top = clamp01(selection_clone.top);
+            let width = clamp01(selection_clone.width);
+            let height = clamp01(selection_clone.height);
+            if width <= f32::EPSILON || height <= f32::EPSILON {
+                bail!("Capture selection is too small");
+            }
+
+            let base_left = left * base_width;
+            let base_top = top * base_height;
+            let base_right = ((left + width).clamp(0.0, 1.0)) * base_width;
+            let base_bottom = ((top + height).clamp(0.0, 1.0)) * base_height;
+
+            let scale_x = orig_w as f32 / base_width;
+            let scale_y = orig_h as f32 / base_height;
+
+            let crop_left =
+                (base_left * scale_x).floor().clamp(0.0, (orig_w - 1) as f32);
+            let crop_top =
+                (base_top * scale_y).floor().clamp(0.0, (orig_h - 1) as f32);
+            let crop_right = (base_right * scale_x)
+                .ceil()
+                .clamp(crop_left + 1.0, orig_w as f32);
+            let crop_bottom = (base_bottom * scale_y)
+                .ceil()
+                .clamp(crop_top + 1.0, orig_h as f32);
+
+            let crop_width = (crop_right - crop_left).round().max(1.0) as u32;
+            let crop_height = (crop_bottom - crop_top).round().max(1.0) as u32;
+
+            let cropped = image.crop_imm(
+                crop_left as u32,
+                crop_top as u32,
+                crop_width,
+                crop_height,
+            );
+
+            let mut buffer = Vec::new();
+            cropped
+                .write_to(&mut Cursor::new(&mut buffer), ImageOutputFormat::Png)
+                .context("Failed to encode capture image as PNG")?;
+
+            Ok((buffer, (crop_width, crop_height)))
+        })
+        .await
+        .context("Croquis capture task failed")??;
+
+    fs::write(&file_path, &encoded).await.with_context(|| {
+        format!("Failed to write Croquis capture to {}", file_path.display())
+    })?;
+
+    let capture_result: Result<CroquisCaptureResponse> = async {
+        let normalized_dir = normalize_path(&save_dir);
+        let mut tx = DB_MANAGER.create_new_tx(&session.moa_id).await?;
+
+        let storage_info = storage_root::detect_storage_root(&normalized_dir)?;
+        let real_folder_id = storage_root::ensure_storage_root_and_real_folder(
+            &mut tx,
+            &storage_info,
+            &normalized_dir,
+        )
+        .await?;
+
+        let virtual_folder_id = if let Some(existing) =
+            FileRepository::find_virtual_folder_id_by_real_folder(
+                tx.as_mut(),
+                &real_folder_id,
+            )
+            .await?
+        {
+            existing
+        } else {
+            let folder_name = save_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|s| s.to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Croquis Captures".to_string());
+            let node = FileRepository::create_virtual_folder(
+                tx.as_mut(),
+                folder_name,
+                "root".to_string(),
+            )
+            .await?;
+            FileRepository::create_virtual_folder_mount(
+                tx.as_mut(),
+                node.id.clone(),
+                real_folder_id.clone(),
+            )
+            .await?;
+            node.id
+        };
+
+        let capture_file_name = file_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| anyhow!("Failed to resolve capture file name"))?
+            .to_string();
+
+        let file_info = FileInfo::new(
+            &file_path,
+            real_folder_id.clone(),
+            capture_file_name.clone(),
+        )
+        .await?;
+        let file_path_id =
+            FileRepository::insert_file_path(tx.as_mut(), &file_info).await?;
+        let file_content_id =
+            FileRepository::upsert_file_content(tx.as_mut(), &file_info)
+                .await?;
+        FileRepository::upsert_file_path_content_binding(
+            tx.as_mut(),
+            &file_path_id,
+            &file_content_id,
+        )
+        .await?;
+
+        NodeRepository::upsert_file_node(
+            tx.as_mut(),
+            virtual_folder_id.clone(),
+            file_content_id.clone(),
+        )
+        .await?;
+
+        if file_info.file_exists && file_info.kind_guess == FileType::Image {
+            enqueue_base_job(BaseThumbnailJob {
+                moa_id: session.moa_id.clone(),
+                xxhs: file_info.xxh3_64.clone(),
+                source_path: file_path.clone(),
+            })
+            .await;
+        }
+
+        let new_node_id = NodeRepository::fetch_node_id_by_fc_id(
+            tx.as_mut(),
+            file_content_id.clone(),
+        )
+        .await?
+        .ok_or_else(|| anyhow!("Failed to resolve capture node id"))?;
+
+        let original_content_id = FileRepository::find_file_content_id(
+            tx.as_mut(),
+            image.hash.clone(),
+        )
+        .await?
+        .ok_or_else(|| {
+            anyhow!("Original file metadata missing for capture source")
+        })?;
+        let original_node_id = NodeRepository::fetch_node_id_by_fc_id(
+            tx.as_mut(),
+            original_content_id,
+        )
+        .await?
+        .ok_or_else(|| anyhow!("Original node missing for capture source"))?;
+
+        ConnectionRepository::insert_connection(
+            tx.as_mut(),
+            original_node_id,
+            new_node_id.clone(),
+            RelationType::CroquisReference,
+            date::get_now_date(),
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        Ok(CroquisCaptureResponse {
+            saved_path: file_path.to_string_lossy().into_owned(),
+            file_name: capture_file_name,
+            node_id: new_node_id,
+        })
+    }
+    .await;
+
+    if capture_result.is_err() {
+        let _ = fs::remove_file(&file_path).await;
+    }
+
+    capture_result
 }
 
 /// Persist the Croquis option payload into the workspace `.moa/settings` folder.

--- a/apps/desktop/src-tauri/src/services/integrity.rs
+++ b/apps/desktop/src-tauri/src/services/integrity.rs
@@ -140,6 +140,20 @@ pub async fn seed_initial_data(pool: &Pool<Sqlite>) -> Result<()> {
         }
     }
 
+    // Ensure Croquis capture relation exists for upgraded databases.
+    sqlx::query!(
+        r#"INSERT OR IGNORE INTO connection_kind_rule
+               (id, kind, default_level, editable, description)
+               VALUES (?1, ?2, ?3, ?4, ?5);"#,
+        get_unique_id(),
+        RelationType::CroquisReference,
+        3,
+        0,
+        "Image -> Croquis capture",
+    )
+    .execute(&mut *tx)
+    .await?;
+
     // Seed one root folder node if none exists
     let (has_root,): (i64,) =
         sqlx::query_as(r#"SELECT COUNT(*) FROM node WHERE kind = 'folder';"#)

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -3,8 +3,27 @@ import { useSearchParams } from 'react-router-dom';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { getCurrentWindow, LogicalSize } from '@tauri-apps/api/window';
 import { Button } from '@tgim/ui';
-import { CroquisSession, CroquisSessionImage } from '@tgim/types/croquis';
-import { Pause, Play, SkipBack, SkipForward, Camera } from 'lucide-react';
+import {
+  CroquisCaptureMode,
+  CroquisCaptureSelection,
+  CroquisSession,
+  CroquisSessionImage,
+} from '@tgim/types/croquis';
+import {
+  Pause,
+  Play,
+  SkipBack,
+  SkipForward,
+  Camera,
+  Check,
+  X,
+  Square,
+  Maximize2,
+  Crop,
+  Undo2,
+  Loader2,
+} from 'lucide-react';
+import { toast } from 'react-toastify';
 import { ipc } from '../../lib/ipc';
 
 const shuffleImages = (images: CroquisSessionImage[]): CroquisSessionImage[] => {
@@ -24,6 +43,27 @@ const formatTime = (seconds: number): string => {
   return `${minutes.toString().padStart(2, '0')}:${remainder.toString().padStart(2, '0')}`;
 };
 
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const MIN_SELECTION_PX = 12;
+
+interface CaptureLayout {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+type CapturePhase = 'selecting' | 'preview';
+
+interface CaptureContext {
+  phase: CapturePhase;
+  mode: CroquisCaptureMode;
+  selection: CroquisCaptureSelection | null;
+  image: CroquisSessionImage;
+  layout: CaptureLayout;
+}
+
 const CroquisWindow: React.FC = () => {
   const [params] = useSearchParams();
   const [session, setSession] = useState<CroquisSession | null>(null);
@@ -31,12 +71,25 @@ const CroquisWindow: React.FC = () => {
   const [elapsedMs, setElapsedMs] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
-  const [isHover, setIsHover] = useState(false); // UI visible only on hover
+  const [isHover, setIsHover] = useState(false);
 
-  const imgRef = useRef<HTMLImageElement | null>(null); // reference to current <img>
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const stageRef = useRef<HTMLDivElement | null>(null);
   const rafRef = useRef<number | null>(null);
   const elapsedRef = useRef(0);
   const startTimestampRef = useRef<number | null>(null);
+
+  const [capture, setCapture] = useState<CaptureContext | null>(null);
+  const captureRef = useRef<CaptureContext | null>(null);
+  const captureStageRectRef = useRef<DOMRect | null>(null);
+  const capturePointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const captureActiveRef = useRef(false);
+  const [capturePreviewUrl, setCapturePreviewUrl] = useState<string | null>(null);
+  const [savingCapture, setSavingCapture] = useState(false);
+
+  useEffect(() => {
+    captureRef.current = capture;
+  }, [capture]);
 
   useEffect(() => {
     console.log('[Croquis] window mounted');
@@ -88,21 +141,6 @@ const CroquisWindow: React.FC = () => {
     setCurrentIndex(prev => (imageList.length ? Math.min(prev, imageList.length - 1) : 0));
   }, [imageList]);
 
-  // Re-apply size when image loads or index changes
-  // useEffect(() => {
-  //   const el = imgRef.current;
-  //   if (!el) return;
-
-  //   const handle = () => void applyWindowSizeToImage();
-  //   if (el.complete) handle();
-  //   el.addEventListener('load', handle);
-  //   el.addEventListener('error', handle);
-  //   return () => {
-  //     el.removeEventListener('load', handle);
-  //     el.removeEventListener('error', handle);
-  //   };
-  // }, [applyWindowSizeToImage, currentIndex]);
-
   const [isInitHeight, setIsInitHeight] = useState(false);
   useEffect(() => {
     (async () => {
@@ -126,9 +164,8 @@ const CroquisWindow: React.FC = () => {
         console.error('[Croquis] Failed to apply window size to image', error);
       }
     })();
-  }, [imageList, imgRef.current, option]);
+  }, [imageList, imgRef.current, option, isInitHeight]);
 
-  // --- Timer logic ---
   const maxTimeSecondsRaw = option?.timer?.maxTime ?? 0;
   const maxTimeSeconds = Number.isFinite(maxTimeSecondsRaw) ? Math.max(0, maxTimeSecondsRaw) : 0;
   const maxTimeMs = maxTimeSeconds > 0 ? maxTimeSeconds * 1000 : 0;
@@ -212,38 +249,323 @@ const CroquisWindow: React.FC = () => {
 
   const hasPrev = currentIndex > 0;
   const hasNext = imageList.length > 0 && currentIndex < imageList.length - 1;
+  const transportDisabled = Boolean(capture);
 
   const handlePrev = useCallback(() => {
-    if (!hasPrev) return;
+    if (!hasPrev || transportDisabled) return;
     setCurrentIndex(prev => Math.max(0, prev - 1));
-  }, [hasPrev]);
+  }, [hasPrev, transportDisabled]);
 
   const handleNext = useCallback(() => {
-    if (!hasNext) return;
+    if (!hasNext || transportDisabled) return;
     setCurrentIndex(prev => Math.min(imageList.length - 1, prev + 1));
-  }, [hasNext, imageList.length]);
+  }, [hasNext, imageList.length, transportDisabled]);
 
-  const handleCapture = useCallback(() => {
-    window.alert('Capture requested. (Not implemented yet)');
+  const handleCaptureCancel = useCallback(() => {
+    captureActiveRef.current = false;
+    capturePointerStartRef.current = null;
+    setCapture(null);
+    setCapturePreviewUrl(null);
   }, []);
 
-  const elapsedSeconds =
-    maxTimeSeconds > 0 ? Math.min(maxTimeSeconds, elapsedMs / 1000) : elapsedMs / 1000;
+  const handleCaptureRetake = useCallback(() => {
+    captureActiveRef.current = false;
+    capturePointerStartRef.current = null;
+    setCapture(prev => (prev ? { ...prev, phase: 'selecting', selection: null } : prev));
+    setCapturePreviewUrl(null);
+  }, []);
+
+  const ensureLayout = useCallback((): CaptureLayout | null => {
+    const stageRect = stageRef.current?.getBoundingClientRect();
+    const imageRect = imgRef.current?.getBoundingClientRect();
+    if (!stageRect || !imageRect) return null;
+    captureStageRectRef.current = stageRect;
+    return {
+      left: imageRect.left - stageRect.left,
+      top: imageRect.top - stageRect.top,
+      width: imageRect.width,
+      height: imageRect.height,
+    };
+  }, []);
+
+  const handleCaptureStart = useCallback(() => {
+    if (!currentImage || !isCaptureEnabled || !session) return;
+    const layout = ensureLayout();
+    if (!layout || layout.width <= 0 || layout.height <= 0) {
+      toast.error('Image layout is not ready yet. Please try again.');
+      return;
+    }
+    pauseTimer();
+    setCapture({
+      phase: 'selecting',
+      mode: 'freeform',
+      selection: null,
+      image: currentImage,
+      layout,
+    });
+  }, [currentImage, ensureLayout, isCaptureEnabled, pauseTimer, session]);
+
+  useEffect(() => {
+    if (!capture) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleCaptureCancel();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [capture, handleCaptureCancel]);
+
+  useEffect(() => {
+    if (capture && currentImage && capture.image.hash !== currentImage.hash) {
+      handleCaptureCancel();
+    }
+  }, [capture, currentImage, handleCaptureCancel]);
+
+  const updateSelection = useCallback((next: { x: number; y: number }) => {
+    const state = captureRef.current;
+    const start = capturePointerStartRef.current;
+    if (!state || !start) return;
+    const layout = state.layout;
+    const startX = clamp(start.x, 0, layout.width);
+    const startY = clamp(start.y, 0, layout.height);
+    const currentX = clamp(next.x, 0, layout.width);
+    const currentY = clamp(next.y, 0, layout.height);
+
+    let leftPx = Math.min(startX, currentX);
+    let topPx = Math.min(startY, currentY);
+    let widthPx = Math.abs(currentX - startX);
+    let heightPx = Math.abs(currentY - startY);
+
+    if (state.mode === 'square') {
+      const size = Math.min(widthPx, heightPx);
+      if (size > 0) {
+        const centerX = leftPx + widthPx / 2;
+        const centerY = topPx + heightPx / 2;
+        widthPx = size;
+        heightPx = size;
+        leftPx = clamp(centerX - size / 2, 0, layout.width - size);
+        topPx = clamp(centerY - size / 2, 0, layout.height - size);
+      }
+    }
+
+    widthPx = clamp(widthPx, 0, layout.width - leftPx);
+    heightPx = clamp(heightPx, 0, layout.height - topPx);
+
+    const selection: CroquisCaptureSelection = {
+      left: layout.width > 0 ? clamp(leftPx / layout.width, 0, 1) : 0,
+      top: layout.height > 0 ? clamp(topPx / layout.height, 0, 1) : 0,
+      width: layout.width > 0 ? clamp(widthPx / layout.width, 0, 1) : 0,
+      height: layout.height > 0 ? clamp(heightPx / layout.height, 0, 1) : 0,
+    };
+
+    setCapture(prev => (prev ? { ...prev, selection } : prev));
+  }, []);
+
+  const handleCapturePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const state = captureRef.current;
+    if (!state || state.phase !== 'selecting') return;
+    const stageRect = captureStageRectRef.current ?? stageRef.current?.getBoundingClientRect();
+    const layout = state.layout;
+    if (!stageRect || layout.width <= 0 || layout.height <= 0) return;
+
+    captureStageRectRef.current = stageRect;
+
+    const stageX = event.clientX - stageRect.left;
+    const stageY = event.clientY - stageRect.top;
+    const localX = stageX - layout.left;
+    const localY = stageY - layout.top;
+    if (localX < 0 || localY < 0 || localX > layout.width || localY > layout.height) return;
+
+    captureActiveRef.current = true;
+    capturePointerStartRef.current = { x: localX, y: localY };
+    setCapture(prev => (prev ? { ...prev, selection: null } : prev));
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+    event.stopPropagation();
+  }, []);
+
+  const handleCapturePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!captureActiveRef.current) return;
+      const state = captureRef.current;
+      if (!state || state.phase !== 'selecting') return;
+      const stageRect = captureStageRectRef.current ?? stageRef.current?.getBoundingClientRect();
+      const layout = state.layout;
+      if (!stageRect || layout.width <= 0 || layout.height <= 0) return;
+
+      const stageX = event.clientX - stageRect.left;
+      const stageY = event.clientY - stageRect.top;
+      const next = {
+        x: stageX - layout.left,
+        y: stageY - layout.top,
+      };
+      updateSelection(next);
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [updateSelection],
+  );
+
+  const finaliseSelection = useCallback(() => {
+    const state = captureRef.current;
+    if (!state || !state.selection) {
+      setCapture(prev => (prev ? { ...prev, selection: null } : prev));
+      return;
+    }
+    const layout = state.layout;
+    const widthPx = state.selection.width * layout.width;
+    const heightPx = state.selection.height * layout.height;
+    if (widthPx < MIN_SELECTION_PX || heightPx < MIN_SELECTION_PX) {
+      toast.info('Selection is too small. Try selecting a larger area.');
+      setCapture(prev => (prev ? { ...prev, selection: null } : prev));
+      return;
+    }
+    setCapture(prev => (prev ? { ...prev, phase: 'preview' } : prev));
+  }, []);
+
+  const handleCapturePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!captureActiveRef.current) return;
+      captureActiveRef.current = false;
+      capturePointerStartRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      finaliseSelection();
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [finaliseSelection],
+  );
+
+  const handleCapturePointerCancel = useCallback(() => {
+    if (!captureActiveRef.current) return;
+    captureActiveRef.current = false;
+    capturePointerStartRef.current = null;
+  }, []);
+
+  const handleCaptureModeChange = useCallback((mode: CroquisCaptureMode) => {
+    setCapture(prev => (prev ? { ...prev, mode, selection: null } : prev));
+    capturePointerStartRef.current = null;
+    captureActiveRef.current = false;
+  }, []);
+
+  const handleCaptureFullImage = useCallback(() => {
+    const state = captureRef.current;
+    if (!state) return;
+    setCapture(prev =>
+      prev
+        ? {
+            ...prev,
+            mode: 'full',
+            phase: 'preview',
+            selection: { left: 0, top: 0, width: 1, height: 1 },
+          }
+        : prev,
+    );
+  }, []);
+
+  useEffect(() => {
+    const state = captureRef.current;
+    if (!state || state.phase !== 'preview' || !state.selection) {
+      setCapturePreviewUrl(null);
+      return;
+    }
+    const previewSource = convertFileSrc(state.image.basePath);
+    let cancelled = false;
+    const image = new Image();
+    image.onload = () => {
+      if (cancelled) return;
+      const canvas = document.createElement('canvas');
+      const sx = state.selection.left * image.naturalWidth;
+      const sy = state.selection.top * image.naturalHeight;
+      const sw = state.selection.width * image.naturalWidth;
+      const sh = state.selection.height * image.naturalHeight;
+      const width = Math.max(1, Math.round(sw));
+      const height = Math.max(1, Math.round(sh));
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+      ctx.drawImage(image, sx, sy, sw, sh, 0, 0, width, height);
+      const url = canvas.toDataURL('image/png');
+      setCapturePreviewUrl(url);
+    };
+    image.onerror = () => {
+      if (!cancelled) {
+        console.warn('[Croquis] Failed to prepare capture preview');
+        setCapturePreviewUrl(null);
+      }
+    };
+    image.src = previewSource;
+    return () => {
+      cancelled = true;
+    };
+  }, [capture]);
+
+  const handleCaptureConfirm = useCallback(async () => {
+    const state = captureRef.current;
+    if (!state || !state.selection || !session) return;
+    if (!session.sessionId) {
+      toast.error('Croquis session is not ready yet.');
+      return;
+    }
+    setSavingCapture(true);
+    try {
+      await ipc.croquis.capture({
+        sessionId: session.sessionId,
+        imageHash: state.image.hash,
+        mode: state.mode,
+        selection: state.selection,
+      });
+      toast.success('Capture saved to workspace.');
+      handleCaptureCancel();
+    } catch (error) {
+      console.error('[Croquis] Failed to save capture', error);
+      toast.error('Failed to save capture. Please try again.');
+    } finally {
+      setSavingCapture(false);
+    }
+  }, [handleCaptureCancel, session]);
+
   const progress = useMemo(
     () => (maxTimeMs > 0 ? Math.min(elapsedMs / maxTimeMs, 1) : 0),
     [elapsedMs, maxTimeMs],
   );
   const isCritical = timerExpired || progress >= 0.9;
 
+  const captureSelection = capture?.selection ?? null;
+  const captureLayout = capture?.layout ?? null;
+  const selectionPx = useMemo(() => {
+    if (!captureSelection || !captureLayout) return null;
+    return {
+      left: captureLayout.left + captureSelection.left * captureLayout.width,
+      top: captureLayout.top + captureSelection.top * captureLayout.height,
+      width: captureSelection.width * captureLayout.width,
+      height: captureSelection.height * captureLayout.height,
+    };
+  }, [captureSelection, captureLayout]);
+
+  const selectionDisplay = useMemo(() => {
+    if (!captureSelection || !capture?.image) return null;
+    const width = Math.round(captureSelection.width * capture.image.baseWidth);
+    const height = Math.round(captureSelection.height * capture.image.baseHeight);
+    return `${width} × ${height}`;
+  }, [captureSelection, capture?.image]);
+
   return (
     <div className="flex h-full w-full flex-col text-text">
-      {/* Stage area */}
       <main
         className="relative flex h-full w-full flex-1 select-none bg-transparent flex-col"
         onMouseEnter={() => setIsHover(true)}
         onMouseLeave={() => setIsHover(false)}
       >
-        <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+        <div
+          ref={stageRef}
+          className="relative flex h-full w-full items-center justify-center overflow-hidden"
+        >
           {currentImage && currentImageSrc ? (
             <img
               key={currentImage.hash}
@@ -256,7 +578,168 @@ const CroquisWindow: React.FC = () => {
           ) : (
             <div className="text-sm text-text-soft">Waiting for Croquis data...</div>
           )}
+
+          {capture && (
+            <div className="absolute inset-0 z-30 flex flex-col">
+              <div
+                className="relative flex-1"
+                style={{ cursor: capture.phase === 'selecting' ? 'crosshair' : 'default' }}
+                onPointerDown={capture.phase === 'selecting' ? handleCapturePointerDown : undefined}
+                onPointerMove={capture.phase === 'selecting' ? handleCapturePointerMove : undefined}
+                onPointerUp={capture.phase === 'selecting' ? handleCapturePointerUp : undefined}
+                onPointerLeave={capture.phase === 'selecting' ? handleCapturePointerUp : undefined}
+                onPointerCancel={
+                  capture.phase === 'selecting' ? handleCapturePointerCancel : undefined
+                }
+              >
+                <div className="absolute inset-0 bg-black/50" style={{ pointerEvents: 'none' }} />
+                {captureLayout && (
+                  <div
+                    className="absolute"
+                    style={{
+                      left: captureLayout.left,
+                      top: captureLayout.top,
+                      width: captureLayout.width,
+                      height: captureLayout.height,
+                      pointerEvents: 'none',
+                    }}
+                  />
+                )}
+                {selectionPx && (
+                  <div
+                    className="absolute rounded-sm border-2 border-accent/90"
+                    style={{
+                      left: selectionPx.left,
+                      top: selectionPx.top,
+                      width: selectionPx.width,
+                      height: selectionPx.height,
+                      boxShadow: '0 0 0 9999px rgba(0,0,0,0.55)',
+                    }}
+                  >
+                    {selectionDisplay && (
+                      <div className="absolute right-2 top-2 rounded bg-black/70 px-2 py-1 text-xs font-medium text-white">
+                        {selectionDisplay}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-end p-6">
+                <div className="pointer-events-auto w-full max-w-[520px]">
+                  {capture.phase === 'selecting' ? (
+                    <div className="rounded-lg bg-surface/90 p-4 text-sm shadow-lg backdrop-blur">
+                      <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-soft">
+                        Choose capture area
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant={capture.mode === 'freeform' ? 'primary' : 'secondary'}
+                          onClick={() => handleCaptureModeChange('freeform')}
+                          className="flex items-center gap-2"
+                        >
+                          <Crop className="size-4" />
+                          Freeform
+                        </Button>
+                        <Button
+                          type="button"
+                          variant={capture.mode === 'square' ? 'primary' : 'secondary'}
+                          onClick={() => handleCaptureModeChange('square')}
+                          className="flex items-center gap-2"
+                        >
+                          <Square className="size-4" />
+                          Square
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          onClick={handleCaptureFullImage}
+                          className="flex items-center gap-2"
+                        >
+                          <Maximize2 className="size-4" />
+                          Full image
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={handleCaptureCancel}
+                          className="ml-auto flex items-center gap-2"
+                        >
+                          <X className="size-4" />
+                          Cancel
+                        </Button>
+                      </div>
+                      <p className="mt-3 text-xs text-text-soft">
+                        Drag across the reference to define the capture. Use the buttons above for
+                        quick presets.
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="rounded-lg bg-surface/95 p-4 text-sm shadow-xl backdrop-blur">
+                      <div className="mb-3 text-xs font-semibold uppercase tracking-wide text-text-soft">
+                        Preview capture
+                      </div>
+                      <div className="flex flex-col gap-3">
+                        <div className="flex h-48 w-full items-center justify-center overflow-hidden rounded border border-surface-muted bg-surface-muted/30">
+                          {capturePreviewUrl ? (
+                            <img
+                              src={capturePreviewUrl}
+                              alt="Capture preview"
+                              className="max-h-full max-w-full object-contain"
+                            />
+                          ) : (
+                            <div className="flex items-center gap-2 text-xs text-text-soft">
+                              <Loader2 className="size-4 animate-spin" /> Preparing preview…
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="primary"
+                            onClick={handleCaptureConfirm}
+                            disabled={savingCapture}
+                            className="flex items-center gap-2"
+                          >
+                            {savingCapture ? (
+                              <>
+                                <Loader2 className="size-4 animate-spin" /> Saving…
+                              </>
+                            ) : (
+                              <>
+                                <Check className="size-4" /> Save capture
+                              </>
+                            )}
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={handleCaptureRetake}
+                            disabled={savingCapture}
+                            className="flex items-center gap-2"
+                          >
+                            <Undo2 className="size-4" /> Retake
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={handleCaptureCancel}
+                            disabled={savingCapture}
+                            className="ml-auto flex items-center gap-2"
+                          >
+                            <X className="size-4" /> Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
+
         <div className="pointer-events-none flex w-full items-center justify-center">
           <div className="w-full max-w-[720px]">
             <div className="h-1 w-full overflow-hidden rounded-full bg-surface-muted">
@@ -268,13 +751,11 @@ const CroquisWindow: React.FC = () => {
           </div>
         </div>
 
-        {/* Absolute overlay controls (show on hover only) */}
         <div
           className={`pointer-events-none absolute inset-0 flex flex-col items-center justify-between p-4 transition-opacity duration-200 ${
-            isHover ? 'opacity-100' : 'opacity-0'
+            capture ? 'opacity-0' : isHover ? 'opacity-100' : 'opacity-0'
           }`}
         >
-          {/* Bottom transport controls */}
           <div
             className="absolute pointer-events-none flex w-full items-end justify-center"
             style={{ bottom: 10 }}
@@ -284,7 +765,7 @@ const CroquisWindow: React.FC = () => {
                 type="button"
                 variant="secondary"
                 onClick={handlePrev}
-                disabled={!hasPrev}
+                disabled={!hasPrev || transportDisabled}
                 className="flex items-center gap-2"
               >
                 <SkipBack className="size-4" />
@@ -295,6 +776,7 @@ const CroquisWindow: React.FC = () => {
                   type="button"
                   variant="secondary"
                   onClick={pauseTimer}
+                  disabled={transportDisabled}
                   className="flex items-center gap-2"
                 >
                   <Pause className="size-4" />
@@ -304,6 +786,7 @@ const CroquisWindow: React.FC = () => {
                   type="button"
                   variant="primary"
                   onClick={startTimer}
+                  disabled={transportDisabled}
                   className="flex items-center gap-2"
                 >
                   <Play className="size-4" />
@@ -314,7 +797,7 @@ const CroquisWindow: React.FC = () => {
                 type="button"
                 variant="secondary"
                 onClick={handleNext}
-                disabled={!hasNext}
+                disabled={!hasNext || transportDisabled}
                 className="flex items-center gap-2"
               >
                 <SkipForward className="size-4" />
@@ -324,7 +807,8 @@ const CroquisWindow: React.FC = () => {
                 <Button
                   type="button"
                   variant="secondary"
-                  onClick={handleCapture}
+                  onClick={handleCaptureStart}
+                  disabled={transportDisabled || !currentImage}
                   className="flex items-center gap-2"
                 >
                   <Camera className="size-4" />

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -3,6 +3,8 @@ import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
 import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
 import {
+  CroquisCaptureRequest,
+  CroquisCaptureResponse,
   CroquisOption,
   CroquisSession,
   CroquisStartPayload,
@@ -84,6 +86,10 @@ const croquisIpc = {
   loadOption: async (moaId: string): Promise<CroquisOption | null> => {
     const response = await invoke('load_croquis_option', { moaId });
     return (response as CroquisOption | null) ?? null;
+  },
+  capture: async (payload: CroquisCaptureRequest): Promise<CroquisCaptureResponse> => {
+    const response = await invoke('capture_croquis_reference', { payload });
+    return response as CroquisCaptureResponse;
   },
 };
 

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -48,3 +48,25 @@ export interface CroquisStartResponse {
   sessionId: string;
   windowLabel: string;
 }
+
+export type CroquisCaptureMode = 'freeform' | 'square' | 'full';
+
+export interface CroquisCaptureSelection {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface CroquisCaptureRequest {
+  sessionId: string;
+  imageHash: string;
+  mode: CroquisCaptureMode;
+  selection: CroquisCaptureSelection;
+}
+
+export interface CroquisCaptureResponse {
+  savedPath: string;
+  fileName: string;
+  nodeId: string;
+}

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -83,4 +83,5 @@ export enum RelationType {
   BelongToFolder = 'belongtofolder',
   ParentFolder = 'parentfolder',
   ChildFolder = 'childfolder',
+  CroquisReference = 'croquisreference',
 }


### PR DESCRIPTION
## Summary
- add a capture workflow to the Croquis window including selection modes, preview, and confirmation wiring to the IPC bridge
- define capture request/response payloads and register a new Croquis reference relation across shared TypeScript and Rust models
- implement the backend capture pipeline that crops the source image, saves it into the selected folder, and links the new node back to the original asset

## Testing
- `pnpm format:write --log-level warn`
- `pnpm lint:check` *(fails: workspace dependencies are not installed in the offline container)*
- `pnpm --filter @grim/desktop build` *(fails: workspace dependencies are not installed in the offline container)*
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings` *(fails: container cannot reach crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d16f5dad0c832e9671df1ffe7e065b