### PR TITLE
Make graph image nodes square

### DIFF
--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -64,7 +64,7 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
     return nodesById;
   }, [graphData.nodes]);
   const { moaId } = useMoa(location);
-  const { ensureThumbnails, getThumbnailKey } = useThumbnails({ moaId });
+  const { ensureThumbnails, getThumbnailKey, getThumbnailUrl } = useThumbnails({ moaId });
 
   const GAP = 90;
 
@@ -116,6 +116,12 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
         if (node.thumbKey !== key) {
           node.thumbKey = key;
           node.url = undefined;
+        }
+
+        const url = getThumbnailUrl(request).url;
+        if (url !== undefined) {
+          node.url = convertFileSrc(url);
+          node.key = getThumbnailKey(request);
         }
         return { ...request, key };
       });

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -244,6 +244,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
   const { visible, observe, unobserve } = useVisibilityMap(scrollRef, 800);
 
   const thumbSize = useMemo(() => {
+    if (layout == 'masonry') return 256;
     switch (size) {
       case 'small':
         return 96;
@@ -252,7 +253,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
       default:
         return 128;
     }
-  }, [size]);
+  }, [size, layout]);
 
   /* -------------------------------------------------
    * Thumbnail fetcher
@@ -265,14 +266,14 @@ const GridView: React.FC<Props> = ({ gridData }) => {
       const requests = itemsToFetch.map(img => ({
         hash: img.hash,
         width: thumbSize,
-        height: thumbSize,
+        height: layout == 'masonry' ? 0 : thumbSize,
         dpr: 1 as const,
         mode: ResizeMode.Original,
       }));
 
       await ensureThumbnails(requests);
     },
-    [ensureThumbnails, thumbSize],
+    [ensureThumbnails, thumbSize, layout],
   );
 
   // Stable ref to avoid stale closure
@@ -689,11 +690,11 @@ const ThumbCardComponent: React.FC<ThumbCardProps> = ({
     () =>
       convertToThumbKey(img.hash, {
         width: thumbSize,
-        height: thumbSize,
+        height: layout == 'masonry' ? 0 : thumbSize,
         dpr: 1,
         mode: ResizeMode.Original,
       }),
-    [img.hash, thumbSize],
+    [img.hash, thumbSize, layout],
   );
 
   const { entry } = useThumbStore(useShallow(state => ({ entry: state.byKey[key] })));

--- a/apps/desktop/src/hooks/index.ts
+++ b/apps/desktop/src/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useThumbnails';
+export * from '../../../../packages/hooks/src/useThumbnails';

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
+  "include": ["src", "../../packages/hooks/src/useThumbnails.ts"],
   "compilerOptions": {
     "outDir": "dist"
   }

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -27,6 +27,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@types/react": "^19.1.9"
+    "@types/react": "^19.1.9",
+    "zustand": "^5.0.8"
   }
 }

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,1 +1,2 @@
 export * from './useMoa';
+export * from './useThumbnails';

--- a/packages/hooks/src/useThumbnails.ts
+++ b/packages/hooks/src/useThumbnails.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { ipc } from '../lib/ipc';
+import { ipc } from '../../../apps/desktop/src/lib/ipc';
 import useThumbStore, { convertToThumbKey } from '@tgim/stores/thumbStore';
 import { ImageFmt, ResizeMode, ThumbSpec, ThumbStatus } from '@tgim/types/file';
 import { useShallow } from 'zustand/shallow';
@@ -48,7 +48,7 @@ export function useThumbnails({ moaId, maxBatchSize = DEFAULT_MAX_BATCH }: UseTh
 
       for (const request of requests) {
         const { hash, width, height } = request;
-        if (!hash || width <= 0 || height <= 0) continue;
+        if (!hash || width <= 0) continue;
 
         const descriptor: ThumbnailRequest = {
           hash,

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -664,18 +664,16 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
   const bg = node.bgColor ?? withAlpha(palette.imageBg, 0.9);
   const fg = node.fgColor ?? palette.imageBorder;
   const scaleB = bucketScale(globalScale);
-  const borderWidth = Math.max(1, 2 / Math.max(0.001, scaleB));
-  const radius = Math.min(12, side * 0.22);
-  const padding = Math.max(2, side * 0.08);
+  const radius = Math.max(2, baseSize * 0.18);
+  const padding = 0;
   const contentSize = Math.max(1, side - padding * 2);
   const clipRadius = Math.max(2, radius - padding * 0.5);
 
-  const backKey = `imgback|${side}|${radius}|${bg}|${fg}|${borderWidth}|${scaleB}`;
+  const backKey = `imgback|${side}|${radius}|${bg}|${fg}|${scaleB}`;
   const backplate = getOrCreateSprite(backKey, side, side, g => {
     roundRect(g, 0, 0, side, side, radius);
     g.fillStyle = bg;
     g.fill();
-    g.lineWidth = borderWidth;
     g.strokeStyle = fg;
     g.stroke();
   });

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -657,61 +657,75 @@ const documentRenderer: NodeRenderer = (ctx, node, globalScale) => {
 
 const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
   const r = getNodeRadius(node);
-  const w = r * 2.0 * 1.2;
-  const h = r * 2.0 * 1.0;
-  const radius = 8;
+  const baseSize = r * 2.0;
+  const side = baseSize * 1.2;
 
-  // backplate sprite
   const palette = getGraphPaletteInternal();
-  const bg = node.bgColor ?? palette.imageBg;
+  const bg = node.bgColor ?? withAlpha(palette.imageBg, 0.9);
   const fg = node.fgColor ?? palette.imageBorder;
   const scaleB = bucketScale(globalScale);
-  const backKey = `imgback|${w}|${h}|${radius}|${bg}|${fg}|${scaleB}`;
-  const backplate = getOrCreateSprite(backKey, w, h, g => {
-    g.globalAlpha = 0.95;
-    roundRect(g, 0, 0, w, h, radius);
+  const borderWidth = Math.max(1, 2 / Math.max(0.001, scaleB));
+  const radius = Math.min(12, side * 0.22);
+  const padding = Math.max(2, side * 0.08);
+  const contentSize = Math.max(1, side - padding * 2);
+  const clipRadius = Math.max(2, radius - padding * 0.5);
+
+  const backKey = `imgback|${side}|${radius}|${bg}|${fg}|${borderWidth}|${scaleB}`;
+  const backplate = getOrCreateSprite(backKey, side, side, g => {
+    roundRect(g, 0, 0, side, side, radius);
     g.fillStyle = bg;
     g.fill();
-    g.lineWidth = Math.max(1, 2 / Math.max(0.001, scaleB));
+    g.lineWidth = borderWidth;
     g.strokeStyle = fg;
     g.stroke();
   });
 
-  ctx.drawImage(backplate, node.x - w / 2, node.y - h / 2, w, h);
+  ctx.drawImage(backplate, node.x - side / 2, node.y - side / 2, side, side);
 
   const src = resolveImageSrc(node);
   let tile: HTMLCanvasElement | undefined;
-  if (src) tile = getMaskedImageTile(src, w - 4, h - 4, radius * 0.8);
+  if (src) tile = getMaskedImageTile(src, contentSize, contentSize, clipRadius);
 
   if (tile) {
-    ctx.drawImage(tile, node.x - (w - 4) / 2, node.y - (h - 4) / 2, w - 4, h - 4);
+    ctx.drawImage(
+      tile,
+      node.x - contentSize / 2,
+      node.y - contentSize / 2,
+      contentSize,
+      contentSize,
+    );
   } else {
-    // placeholder sprite
-    const phKey = `imgph|${w}|${h}|${radius}|${scaleB}`;
-    const placeholder = getOrCreateSprite(phKey, w, h, g => {
-      roundRect(g, 4, 4, w - 8, h - 8, 6);
+    const phKey = `imgph|${side}|${radius}|${padding}|${clipRadius}|${scaleB}`;
+    const placeholder = getOrCreateSprite(phKey, side, side, g => {
+      roundRect(g, padding, padding, contentSize, contentSize, clipRadius);
       g.strokeStyle = palette.placeholderStroke;
       g.lineWidth = Math.max(1, 1.5 / Math.max(0.001, scaleB));
       g.stroke();
 
       g.beginPath();
-      g.arc(w * 0.25, h * 0.32, Math.min(w, h) * 0.07, 0, Math.PI * 2);
+      g.arc(
+        padding + contentSize * 0.28,
+        padding + contentSize * 0.32,
+        contentSize * 0.12,
+        0,
+        Math.PI * 2,
+      );
       g.fillStyle = palette.placeholderAccent;
       g.fill();
 
       g.beginPath();
-      const baseY = h * 0.72;
-      g.moveTo(w * 0.12, baseY);
-      g.lineTo(w * 0.4, h * 0.45);
-      g.lineTo(w * 0.6, baseY);
-      g.lineTo(w * 0.48, baseY);
-      g.lineTo(w * 0.7, h * 0.55);
-      g.lineTo(w * 0.88, baseY);
+      const baseY = padding + contentSize * 0.78;
+      g.moveTo(padding + contentSize * 0.08, baseY);
+      g.lineTo(padding + contentSize * 0.35, padding + contentSize * 0.48);
+      g.lineTo(padding + contentSize * 0.55, baseY);
+      g.lineTo(padding + contentSize * 0.48, baseY);
+      g.lineTo(padding + contentSize * 0.72, padding + contentSize * 0.58);
+      g.lineTo(padding + contentSize * 0.92, baseY);
       g.closePath();
       g.fillStyle = palette.placeholderFill;
       g.fill();
     });
-    ctx.drawImage(placeholder, node.x - w / 2, node.y - h / 2, w, h);
+    ctx.drawImage(placeholder, node.x - side / 2, node.y - side / 2, side, side);
   }
 
   // drawLabelCached(ctx, node);


### PR DESCRIPTION
## Summary
- render graph image nodes using a square frame with consistent padding and border radius
- expand the thumbnail and placeholder layout so graph images are easier to see

## Testing
- pnpm format:write -- --log-level warn
- pnpm lint:check *(fails: cannot resolve @eslint/js because pnpm install is blocked by 403 from the npm registry)*
- pnpm --filter @grim/desktop build *(fails: missing workspace dependencies because pnpm install is blocked by the same registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d17e6615d8832eaf47b68acaa12830