### PR TITLE
feat: add Croquis capture overlay and backend pipeline

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ fast_image_resize = "5.3.0"
 log = "0.4.28"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+screenshots = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.7.4"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["moa-main", "moa-create", "moa-croquis"],
+  "windows": ["moa-main", "moa-create", "moa-croquis", "moa-croquis-capture"],
   "permissions": [
     "core:default",
     "os:default",

--- a/apps/desktop/src-tauri/src/app_launcher/croquis.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/croquis.rs
@@ -67,3 +67,41 @@ fn parse_dimension(value: Option<&String>) -> Option<f64> {
     }
     raw.parse::<f64>().ok().filter(|v| *v > 0.0)
 }
+
+/// Launch the transparent capture overlay used to select screen regions.
+pub fn launch_croquis_capture(
+    app: &tauri::AppHandle,
+    capture_id: &str,
+) -> Result<String, String> {
+    let uri = format!("croquis-capture?capture_id={capture_id}");
+
+    #[cfg(debug_assertions)]
+    let url = WebviewUrl::App(format!("http://localhost:1420/#/{uri}").into());
+
+    #[cfg(not(debug_assertions))]
+    let url = WebviewUrl::App(format!("index.html#{uri}").into());
+
+    let window_label = "moa-croquis-capture".to_string();
+
+    if let Some(existing) = app.get_webview_window(&window_label) {
+        let _ = existing.close();
+    }
+
+    let builder =
+        tauri::WebviewWindowBuilder::new(app, window_label.clone(), url)
+            .title("")
+            .decorations(false)
+            .resizable(false)
+            .maximizable(false)
+            .always_on_top(true)
+            .fullscreen(true)
+            .background_color(Color(0, 0, 0, 0));
+
+    builder
+        .build()
+        .map_err(|err| err.to_string())?
+        .set_focus()
+        .map_err(|err| err.to_string())?;
+
+    Ok(window_label)
+}

--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,7 +1,9 @@
 use crate::{
     models::croquis::{
-        CroquisOption, CroquisSession, CroquisStartPayload,
-        CroquisStartResponse,
+        CroquisCaptureConfirmResponse, CroquisCaptureContext,
+        CroquisCapturePreview, CroquisCapturePreviewPayload,
+        CroquisCaptureStartPayload, CroquisCaptureStartResponse, CroquisOption,
+        CroquisSession, CroquisStartPayload, CroquisStartResponse,
     },
     services::croquis_service,
 };
@@ -31,4 +33,56 @@ pub async fn load_croquis_option(
     moa_id: String,
 ) -> Result<Option<CroquisOption>, String> {
     croquis_service::load_option(&moa_id).await.map_err(|err| err.to_string())
+}
+
+/// Initiate the capture overlay for the active Croquis session.
+#[tauri::command]
+pub async fn start_croquis_capture(
+    app_handle: tauri::AppHandle,
+    payload: CroquisCaptureStartPayload,
+) -> Result<CroquisCaptureStartResponse, String> {
+    croquis_service::start_capture(&app_handle, payload)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+/// Fetch the active capture context used by the overlay window.
+#[tauri::command]
+pub async fn load_croquis_capture_context(
+    capture_id: String,
+) -> Result<Option<CroquisCaptureContext>, String> {
+    Ok(croquis_service::load_capture_context(&capture_id).await)
+}
+
+/// Capture a preview image for the provided selection rectangle.
+#[tauri::command]
+pub async fn render_croquis_capture_preview(
+    app_handle: tauri::AppHandle,
+    payload: CroquisCapturePreviewPayload,
+) -> Result<CroquisCapturePreview, String> {
+    croquis_service::render_capture_preview(&app_handle, payload)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+/// Finalise the capture by saving the preview to disk and ingesting it.
+#[tauri::command]
+pub async fn confirm_croquis_capture(
+    app_handle: tauri::AppHandle,
+    capture_id: String,
+) -> Result<CroquisCaptureConfirmResponse, String> {
+    croquis_service::confirm_capture(&app_handle, &capture_id)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+/// Cancel the active capture flow and close the overlay window.
+#[tauri::command]
+pub async fn cancel_croquis_capture(
+    app_handle: tauri::AppHandle,
+    capture_id: String,
+) -> Result<(), String> {
+    croquis_service::cancel_capture(&app_handle, &capture_id)
+        .await
+        .map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -46,6 +46,11 @@ fn main() {
             commands::croquis::start_croquis_session,
             commands::croquis::load_croquis_session,
             commands::croquis::load_croquis_option,
+            commands::croquis::start_croquis_capture,
+            commands::croquis::load_croquis_capture_context,
+            commands::croquis::render_croquis_capture_preview,
+            commands::croquis::confirm_croquis_capture,
+            commands::croquis::cancel_croquis_capture,
         ])
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_decorum::init())

--- a/apps/desktop/src-tauri/src/models/connection.rs
+++ b/apps/desktop/src-tauri/src/models/connection.rs
@@ -22,6 +22,7 @@ pub enum RelationType {
     BelongToFolder,
     ParentFolder,
     ChildFolder,
+    CroquisReference,
 }
 
 /// Describes how edges are treated during graph traversal.

--- a/apps/desktop/src-tauri/src/models/croquis.rs
+++ b/apps/desktop/src-tauri/src/models/croquis.rs
@@ -85,3 +85,67 @@ pub struct CroquisStartResponse {
     pub session_id: String,
     pub window_label: String,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureStartPayload {
+    pub session_id: String,
+    pub image_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureStartResponse {
+    pub capture_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureContext {
+    pub capture_id: String,
+    pub session_id: String,
+    pub image_hash: String,
+    pub moa_id: String,
+    pub save_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureRect {
+    pub x: u32,
+    pub y: u32,
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureMonitor {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub scale_factor: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCapturePreviewPayload {
+    pub capture_id: String,
+    pub rect: CroquisCaptureRect,
+    pub monitor: CroquisCaptureMonitor,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCapturePreview {
+    pub preview_path: String,
+    pub rect: CroquisCaptureRect,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisCaptureConfirmResponse {
+    pub file_path: String,
+    pub file_name: String,
+}

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -1,27 +1,57 @@
-use std::{collections::HashMap, io::ErrorKind};
+use std::{collections::HashMap, io::ErrorKind, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, bail, Context, Result};
+use image::{ColorType, ImageFormat};
 use once_cell::sync::Lazy;
-use tokio::{fs, sync::RwLock};
+use screenshots::Screen;
+use tauri::Manager;
+use tokio::{fs, sync::RwLock, time::sleep};
 use tracing::warn;
 
 use crate::{
     app_launcher,
     bootstrap::PATH_MANAGER,
-    models::croquis::{
-        CroquisOption, CroquisSession, CroquisSessionImage,
-        CroquisStartPayload, CroquisStartResponse,
+    db::repository::{
+        connection_repository::ConnectionRepository,
+        file_repository::FileRepository, node_repository::NodeRepository,
     },
+    models::connection::RelationType,
+    models::croquis::{
+        CroquisCaptureConfirmResponse, CroquisCaptureContext,
+        CroquisCaptureMonitor, CroquisCapturePreview,
+        CroquisCapturePreviewPayload, CroquisCaptureRect,
+        CroquisCaptureStartPayload, CroquisCaptureStartResponse, CroquisOption,
+        CroquisSession, CroquisSessionImage, CroquisStartPayload,
+        CroquisStartResponse,
+    },
+    models::file::{FileInfo, FileType},
     services::file_service::{
         folder::fetch_one_file_path,
+        job_queue::{enqueue_base_job, BaseThumbnailJob},
         thumbnail::{ensure_base_thumbnail, BaseThumbInfo},
     },
-    utils::{date, identifier::get_unique_id},
+    services::{db::DB_MANAGER, storage_root},
+    utils::{date, identifier::get_unique_id, path_utils::normalize_path},
 };
 
 /// In-memory registry of active Croquis sessions keyed by session identifier.
 static CROQUIS_SESSIONS: Lazy<RwLock<HashMap<String, CroquisSession>>> =
     Lazy::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Debug, Clone)]
+struct CroquisCaptureState {
+    capture_id: String,
+    session_id: String,
+    image_hash: String,
+    moa_id: String,
+    save_dir: PathBuf,
+    window_label: String,
+    preview_path: Option<PathBuf>,
+}
+
+/// Currently active capture request (only one supported at a time).
+static ACTIVE_CAPTURE: Lazy<RwLock<Option<CroquisCaptureState>>> =
+    Lazy::new(|| RwLock::new(None));
 
 /// Launch a new Croquis session by ensuring base images and spawning the window.
 pub async fn start_session(
@@ -168,6 +198,387 @@ async fn persist_option(moa_id: &str, option: &CroquisOption) -> Result<()> {
     fs::write(&file_path, payload).await.with_context(|| {
         format!("Failed to write Croquis options to {}", file_path.display())
     })?;
+
+    Ok(())
+}
+
+/// Begin a capture flow by launching the overlay window for the current Croquis session.
+pub async fn start_capture(
+    app_handle: &tauri::AppHandle,
+    payload: CroquisCaptureStartPayload,
+) -> Result<CroquisCaptureStartResponse> {
+    let CroquisCaptureStartPayload { session_id, image_hash } = payload;
+
+    let session = {
+        let sessions = CROQUIS_SESSIONS.read().await;
+        sessions
+            .get(&session_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("Croquis session not found for capture"))?
+    };
+
+    if session.option.save_path.trim().is_empty() {
+        bail!("Croquis capture save path is not configured");
+    }
+
+    let save_dir = PathBuf::from(session.option.save_path.trim());
+    fs::create_dir_all(&save_dir).await.with_context(|| {
+        format!("Failed to create capture directory at {}", save_dir.display())
+    })?;
+
+    let Some(_target_image) =
+        session.images.iter().find(|img| img.hash == image_hash)
+    else {
+        bail!("Requested image hash is not part of the Croquis session");
+    };
+
+    {
+        let active = ACTIVE_CAPTURE.read().await;
+        if active.is_some() {
+            bail!("Another capture is currently in progress");
+        }
+    }
+
+    let capture_id = get_unique_id();
+    let window_label =
+        app_launcher::croquis::launch_croquis_capture(app_handle, &capture_id)
+            .map_err(|err| anyhow!(err))?;
+
+    {
+        let mut guard = ACTIVE_CAPTURE.write().await;
+        *guard = Some(CroquisCaptureState {
+            capture_id: capture_id.clone(),
+            session_id: session_id.clone(),
+            image_hash: image_hash.clone(),
+            moa_id: session.moa_id.clone(),
+            save_dir: save_dir.clone(),
+            window_label,
+            preview_path: None,
+        });
+    }
+
+    Ok(CroquisCaptureStartResponse { capture_id })
+}
+
+/// Load the active capture context for the overlay window.
+pub async fn load_capture_context(
+    capture_id: &str,
+) -> Option<CroquisCaptureContext> {
+    let guard = ACTIVE_CAPTURE.read().await;
+    let state = guard.as_ref()?;
+    if state.capture_id != capture_id {
+        return None;
+    }
+
+    Some(CroquisCaptureContext {
+        capture_id: state.capture_id.clone(),
+        session_id: state.session_id.clone(),
+        image_hash: state.image_hash.clone(),
+        moa_id: state.moa_id.clone(),
+        save_path: state.save_dir.to_string_lossy().into_owned(),
+    })
+}
+
+/// Render a preview for the selected screen region by capturing and cropping the display.
+pub async fn render_capture_preview(
+    app_handle: &tauri::AppHandle,
+    payload: CroquisCapturePreviewPayload,
+) -> Result<CroquisCapturePreview> {
+    let CroquisCapturePreviewPayload { capture_id, rect, monitor } = payload;
+
+    if rect.width == 0 || rect.height == 0 {
+        bail!("Capture rectangle must be greater than zero");
+    }
+
+    let (state_snapshot, previous_preview) = {
+        let guard = ACTIVE_CAPTURE.read().await;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("No active capture session"))?;
+        if state.capture_id != capture_id {
+            bail!("Capture session does not match active request");
+        }
+        (state.clone(), state.preview_path.clone())
+    };
+
+    let paths = PATH_MANAGER
+        .get_or_add(&state_snapshot.moa_id)
+        .await
+        .context("Failed to resolve workspace paths for capture")?;
+    let preview_dir = paths.cached_dir.join("croquis").join("captures");
+    fs::create_dir_all(&preview_dir).await.with_context(|| {
+        format!(
+            "Failed to create capture preview directory at {}",
+            preview_dir.display()
+        )
+    })?;
+
+    if let Some(prev) = previous_preview {
+        let _ = fs::remove_file(prev).await;
+    }
+
+    let preview_path = preview_dir.join(format!("{}_preview.png", capture_id));
+
+    if let Some(window) =
+        app_handle.get_webview_window(&state_snapshot.window_label)
+    {
+        let _ = window.hide();
+        // Give the compositor a moment to remove the overlay from the screen before capturing.
+        sleep(Duration::from_millis(120)).await;
+    }
+
+    let monitor_clone = monitor;
+    let rect_clone = rect;
+    let out_path = preview_path.clone();
+
+    tauri::async_runtime::spawn_blocking(move || -> Result<()> {
+        capture_region(&monitor_clone, &rect_clone, &out_path)
+    })
+    .await
+    .map_err(|err| anyhow!("Capture task join error: {err}"))??;
+
+    if let Some(window) =
+        app_handle.get_webview_window(&state_snapshot.window_label)
+    {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+
+    {
+        let mut guard = ACTIVE_CAPTURE.write().await;
+        if let Some(state) = guard.as_mut() {
+            if state.capture_id == capture_id {
+                state.preview_path = Some(preview_path.clone());
+            }
+        }
+    }
+
+    Ok(CroquisCapturePreview {
+        preview_path: preview_path.to_string_lossy().into_owned(),
+        rect,
+    })
+}
+
+/// Finalise a capture by moving the preview into place and ingesting it into the workspace.
+pub async fn confirm_capture(
+    app_handle: &tauri::AppHandle,
+    capture_id: &str,
+) -> Result<CroquisCaptureConfirmResponse> {
+    let (state_snapshot, preview_path) = {
+        let guard = ACTIVE_CAPTURE.read().await;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("No active capture session"))?;
+        if state.capture_id != capture_id {
+            bail!("Capture session does not match active request");
+        }
+        let preview = state
+            .preview_path
+            .clone()
+            .ok_or_else(|| anyhow!("Capture preview has not been generated"))?;
+        (state.clone(), preview)
+    };
+
+    fs::create_dir_all(&state_snapshot.save_dir).await.with_context(|| {
+        format!(
+            "Failed to create capture output directory at {}",
+            state_snapshot.save_dir.display()
+        )
+    })?;
+
+    let file_name = format!("croquis_{}.png", get_unique_id());
+    let final_path = state_snapshot.save_dir.join(&file_name);
+
+    match fs::rename(&preview_path, &final_path).await {
+        Ok(_) => {}
+        Err(error) if error.kind() == ErrorKind::CrossDeviceLink => {
+            fs::copy(&preview_path, &final_path).await.with_context(|| {
+                format!("Failed to copy capture to {}", final_path.display())
+            })?;
+            let _ = fs::remove_file(&preview_path).await;
+        }
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("Failed to move capture to {}", final_path.display())
+            });
+        }
+    }
+
+    let mut tx = DB_MANAGER.create_new_tx(&state_snapshot.moa_id).await?;
+
+    let norm_dir = normalize_path(state_snapshot.save_dir.as_path());
+    let storage_info = storage_root::detect_storage_root(&norm_dir)
+        .with_context(|| {
+            format!("Failed to detect storage root for {}", norm_dir.display())
+        })?;
+    let real_folder_id = storage_root::ensure_storage_root_and_real_folder(
+        &mut tx,
+        &storage_info,
+        &norm_dir,
+    )
+    .await?;
+
+    let display_name = final_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("Capture filename contains invalid UTF-8"))?
+        .to_string();
+
+    let file_info = FileInfo::new(
+        final_path.as_path(),
+        real_folder_id.clone(),
+        display_name.clone(),
+    )
+    .await?;
+
+    let file_path_id =
+        FileRepository::insert_file_path(tx.as_mut(), &file_info).await?;
+    let file_content_id =
+        FileRepository::upsert_file_content(tx.as_mut(), &file_info).await?;
+    FileRepository::upsert_file_path_content_binding(
+        tx.as_mut(),
+        &file_path_id,
+        &file_content_id,
+    )
+    .await?;
+
+    NodeRepository::upsert_file_node(
+        tx.as_mut(),
+        "root".to_string(),
+        file_content_id.clone(),
+    )
+    .await?;
+
+    let original_fc_id = FileRepository::find_file_content_id(
+        tx.as_mut(),
+        state_snapshot.image_hash.clone(),
+    )
+    .await?
+    .ok_or_else(|| anyhow!("Original file hash not found for capture"))?;
+
+    let original_node_id =
+        NodeRepository::fetch_node_id_by_fc_id(tx.as_mut(), original_fc_id)
+            .await?
+            .ok_or_else(|| anyhow!("Original node could not be resolved"))?;
+
+    let new_node_id = NodeRepository::fetch_node_id_by_fc_id(
+        tx.as_mut(),
+        file_content_id.clone(),
+    )
+    .await?
+    .ok_or_else(|| anyhow!("Capture node could not be resolved"))?;
+
+    ConnectionRepository::insert_connection(
+        tx.as_mut(),
+        original_node_id,
+        new_node_id,
+        RelationType::CroquisReference,
+        date::get_now_date(),
+    )
+    .await?;
+
+    if file_info.file_exists && file_info.kind_guess == FileType::Image {
+        enqueue_base_job(BaseThumbnailJob {
+            moa_id: state_snapshot.moa_id.clone(),
+            xxhs: file_info.xxh3_64.clone(),
+            source_path: final_path.clone(),
+        })
+        .await;
+    }
+
+    tx.commit().await?;
+
+    {
+        let mut guard = ACTIVE_CAPTURE.write().await;
+        if let Some(state) = guard.as_ref() {
+            if state.capture_id == capture_id {
+                *guard = None;
+            }
+        }
+    }
+
+    if let Some(window) =
+        app_handle.get_webview_window(&state_snapshot.window_label)
+    {
+        let _ = window.close();
+    }
+
+    Ok(CroquisCaptureConfirmResponse {
+        file_path: final_path.to_string_lossy().into_owned(),
+        file_name: display_name,
+    })
+}
+
+/// Cancel the active capture session and clean up any temporary resources.
+pub async fn cancel_capture(
+    app_handle: &tauri::AppHandle,
+    capture_id: &str,
+) -> Result<()> {
+    let state_snapshot = {
+        let guard = ACTIVE_CAPTURE.read().await;
+        guard.as_ref().filter(|state| state.capture_id == capture_id).cloned()
+    };
+
+    if let Some(state) = state_snapshot {
+        if let Some(preview_path) = state.preview_path.as_ref() {
+            let _ = fs::remove_file(preview_path).await;
+        }
+
+        if let Some(window) = app_handle.get_webview_window(&state.window_label)
+        {
+            let _ = window.close();
+        }
+
+        let mut guard = ACTIVE_CAPTURE.write().await;
+        if guard.as_ref().map(|s| s.capture_id.as_str()) == Some(capture_id) {
+            *guard = None;
+        }
+    }
+
+    Ok(())
+}
+
+fn capture_region(
+    monitor: &CroquisCaptureMonitor,
+    rect: &CroquisCaptureRect,
+    out_path: &PathBuf,
+) -> Result<()> {
+    let screens = Screen::all()
+        .map_err(|err| anyhow!("Failed to enumerate screens: {err}"))?;
+
+    let screen = screens
+        .iter()
+        .find(|screen| screen.x() == monitor.x && screen.y() == monitor.y)
+        .or_else(|| {
+            screens.iter().find(|screen| {
+                screen.width() == monitor.width
+                    && screen.height() == monitor.height
+            })
+        })
+        .ok_or_else(|| anyhow!("Unable to match monitor for capture"))?;
+
+    let capture = screen
+        .capture_area(rect.x as i32, rect.y as i32, rect.width, rect.height)
+        .map_err(|err| anyhow!("Failed to capture screen: {err}"))?;
+
+    let buffer = capture.buffer();
+    let mut rgba = Vec::with_capacity(buffer.len());
+    for chunk in buffer.chunks_exact(4) {
+        rgba.push(chunk[2]);
+        rgba.push(chunk[1]);
+        rgba.push(chunk[0]);
+        rgba.push(chunk[3]);
+    }
+
+    image::save_buffer_with_format(
+        out_path,
+        &rgba,
+        rect.width,
+        rect.height,
+        ColorType::Rgba8,
+        ImageFormat::Png,
+    )
+    .map_err(|err| anyhow!("Failed to write capture preview: {err}"))?;
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/services/integrity.rs
+++ b/apps/desktop/src-tauri/src/services/integrity.rs
@@ -121,6 +121,12 @@ pub async fn seed_initial_data(pool: &Pool<Sqlite>) -> Result<()> {
                 0,
                 "Folder(parent) -> Folder(child)",
             ),
+            (
+                RelationType::CroquisReference,
+                1,
+                0,
+                "Original reference -> Croquis capture",
+            ),
         ];
 
         for (kind, default_level, editable, description) in seed_data {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -4,6 +4,7 @@ import Moa from './features/moa/Moa';
 import './i18n';
 import Main from './features/main/Main';
 import CroquisWindow from './features/croquis/CroquisWindow';
+import CroquisCaptureOverlay from './features/croquis/CroquisCaptureOverlay';
 
 // Desktop entry point that keeps routing hash-based for Tauri compatibility.
 const App: React.FC = () => {
@@ -14,6 +15,7 @@ const App: React.FC = () => {
           <Route path="/moa/*" element={<Main />} />
           <Route path="/create-moa/*" element={<Moa />} />
           <Route path="/croquis/*" element={<CroquisWindow />} />
+          <Route path="/croquis-capture/*" element={<CroquisCaptureOverlay />} />
         </Routes>
       </HashRouter>
     </div>

--- a/apps/desktop/src/features/croquis/CroquisCaptureOverlay.tsx
+++ b/apps/desktop/src/features/croquis/CroquisCaptureOverlay.tsx
@@ -1,0 +1,499 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { Button } from '@tgim/ui';
+import {
+  CroquisCaptureContext,
+  CroquisCaptureMonitor,
+  CroquisCapturePreview,
+  CroquisCaptureRect,
+} from '@tgim/types/croquis';
+import { ipc } from '../../lib/ipc';
+import { toast } from 'react-toastify';
+
+const MIN_SELECTION_SIZE = 12;
+
+type SelectionRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type PointerPoint = {
+  x: number;
+  y: number;
+};
+
+type Phase = 'loading' | 'selecting' | 'preview';
+
+type CaptureMode = 'freeform' | 'square';
+
+const normaliseRect = (
+  rect: CroquisCaptureRect,
+  monitor: CroquisCaptureMonitor,
+): CroquisCaptureRect => {
+  const maxWidth = monitor.width;
+  const maxHeight = monitor.height;
+
+  const x = Math.max(0, Math.min(rect.x, maxWidth));
+  const y = Math.max(0, Math.min(rect.y, maxHeight));
+  const width = Math.max(1, Math.min(rect.width, maxWidth - x));
+  const height = Math.max(1, Math.min(rect.height, maxHeight - y));
+
+  return { x, y, width, height };
+};
+
+const CroquisCaptureOverlay: React.FC = () => {
+  const [params] = useSearchParams();
+  const captureId = params.get('capture_id');
+
+  const [context, setContext] = useState<CroquisCaptureContext | null>(null);
+  const [monitorInfo, setMonitorInfo] = useState<CroquisCaptureMonitor | null>(null);
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [mode, setMode] = useState<CaptureMode>('freeform');
+  const [selection, setSelection] = useState<SelectionRect | null>(null);
+  const [preview, setPreview] = useState<CroquisCapturePreview | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const startRef = useRef<PointerPoint | null>(null);
+  const isPointerDownRef = useRef(false);
+  const confirmedRef = useRef(false);
+
+  const windowRef = useRef(getCurrentWindow());
+
+  useEffect(() => {
+    const body = document.body;
+    const previousBg = body.style.backgroundColor;
+    const previousSelect = body.style.userSelect;
+    body.style.backgroundColor = 'rgba(0, 0, 0, 0.45)';
+    body.style.userSelect = 'none';
+    return () => {
+      body.style.backgroundColor = previousBg;
+      body.style.userSelect = previousSelect;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!captureId) {
+      toast.error('Capture session was not found.');
+      void (async () => {
+        await windowRef.current.close();
+      })();
+    }
+  }, [captureId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!captureId) return;
+
+    setPhase('loading');
+    setContext(null);
+
+    void (async () => {
+      try {
+        const ctx = await ipc.croquis.loadCaptureContext(captureId);
+        if (cancelled) return;
+        if (!ctx) {
+          toast.error('Capture session expired.');
+          await windowRef.current.close();
+          return;
+        }
+        setContext(ctx);
+      } catch (error) {
+        console.error('[Croquis] Failed to load capture context', error);
+        toast.error('Failed to load capture session.');
+        await windowRef.current.close();
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [captureId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const win = windowRef.current;
+        const monitor = await win.currentMonitor();
+        if (cancelled) return;
+        if (monitor) {
+          setMonitorInfo({
+            x: monitor.position.x,
+            y: monitor.position.y,
+            width: monitor.size.width,
+            height: monitor.size.height,
+            scaleFactor: monitor.scaleFactor ?? window.devicePixelRatio ?? 1,
+          });
+        } else {
+          const scale = window.devicePixelRatio ?? 1;
+          setMonitorInfo({
+            x: 0,
+            y: 0,
+            width: Math.round(window.innerWidth * scale),
+            height: Math.round(window.innerHeight * scale),
+            scaleFactor: scale,
+          });
+        }
+      } catch (error) {
+        console.error('[Croquis] Failed to resolve monitor info', error);
+        const scale = window.devicePixelRatio ?? 1;
+        setMonitorInfo({
+          x: 0,
+          y: 0,
+          width: Math.round(window.innerWidth * scale),
+          height: Math.round(window.innerHeight * scale),
+          scaleFactor: scale,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (context && monitorInfo) {
+      setPhase('selecting');
+    }
+  }, [context, monitorInfo]);
+
+  useEffect(() => {
+    const body = document.body;
+    if (phase === 'selecting') {
+      body.style.cursor = 'crosshair';
+    } else {
+      body.style.cursor = 'default';
+    }
+    return () => {
+      body.style.cursor = 'default';
+    };
+  }, [phase]);
+
+  useEffect(() => {
+    return () => {
+      if (!captureId || confirmedRef.current) return;
+      void ipc.croquis.cancelCapture(captureId);
+    };
+  }, [captureId]);
+
+  const createSquareRect = useCallback(
+    (start: PointerPoint, current: PointerPoint): SelectionRect => {
+      const deltaX = current.x - start.x;
+      const deltaY = current.y - start.y;
+      const size = Math.max(Math.abs(deltaX), Math.abs(deltaY));
+      const dirX = deltaX < 0 ? -1 : 1;
+      const dirY = deltaY < 0 ? -1 : 1;
+      const endX = start.x + size * dirX;
+      const endY = start.y + size * dirY;
+      const x = Math.min(start.x, endX);
+      const y = Math.min(start.y, endY);
+      return {
+        x,
+        y,
+        width: Math.abs(endX - start.x),
+        height: Math.abs(endY - start.y),
+      };
+    },
+    [],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (phase !== 'selecting' || busy) return;
+      event.preventDefault();
+      const point = { x: event.clientX, y: event.clientY };
+      startRef.current = point;
+      isPointerDownRef.current = true;
+      setSelection({ x: point.x, y: point.y, width: 0, height: 0 });
+    },
+    [busy, phase],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isPointerDownRef.current || !startRef.current || phase !== 'selecting') return;
+      event.preventDefault();
+      const current = { x: event.clientX, y: event.clientY };
+      let rect: SelectionRect;
+      if (mode === 'square') {
+        rect = createSquareRect(startRef.current, current);
+      } else {
+        rect = {
+          x: Math.min(startRef.current.x, current.x),
+          y: Math.min(startRef.current.y, current.y),
+          width: Math.abs(current.x - startRef.current.x),
+          height: Math.abs(current.y - startRef.current.y),
+        };
+      }
+      setSelection(rect);
+    },
+    [createSquareRect, mode, phase],
+  );
+
+  const handlePointerUp = useCallback(
+    async (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!isPointerDownRef.current || phase !== 'selecting') return;
+      event.preventDefault();
+      isPointerDownRef.current = false;
+      if (!selection || !monitorInfo || !captureId) {
+        setSelection(null);
+        return;
+      }
+      if (selection.width < MIN_SELECTION_SIZE || selection.height < MIN_SELECTION_SIZE) {
+        setSelection(null);
+        return;
+      }
+      await (async () => {
+        setBusy(true);
+        setPhase('loading');
+        try {
+          const scale = monitorInfo.scaleFactor || window.devicePixelRatio || 1;
+          const scaled: CroquisCaptureRect = {
+            x: Math.round(selection.x * scale),
+            y: Math.round(selection.y * scale),
+            width: Math.round(selection.width * scale),
+            height: Math.round(selection.height * scale),
+          };
+          const normalized = normaliseRect(scaled, monitorInfo);
+          const response = await ipc.croquis.renderCapturePreview({
+            captureId,
+            rect: normalized,
+            monitor: monitorInfo,
+          });
+          setPreview(response);
+          setSelection(null);
+          setPhase('preview');
+        } catch (error) {
+          console.error('[Croquis] Failed to render capture preview', error);
+          toast.error('Failed to capture selection. Please try again.');
+          setSelection(null);
+          setPhase('selecting');
+        } finally {
+          setBusy(false);
+        }
+      })();
+    },
+    [captureId, monitorInfo, phase, selection],
+  );
+
+  const handleFullScreenCapture = useCallback(() => {
+    if (!monitorInfo || !captureId || phase === 'loading') return;
+    const scale = monitorInfo.scaleFactor || window.devicePixelRatio || 1;
+    const rect: CroquisCaptureRect = {
+      x: 0,
+      y: 0,
+      width: Math.round(monitorInfo.width),
+      height: Math.round(monitorInfo.height),
+    };
+    const viewRect: SelectionRect = {
+      x: 0,
+      y: 0,
+      width: monitorInfo.width / scale,
+      height: monitorInfo.height / scale,
+    };
+
+    setSelection(viewRect);
+    void (async () => {
+      setBusy(true);
+      setPhase('loading');
+      try {
+        const response = await ipc.croquis.renderCapturePreview({
+          captureId,
+          rect: normaliseRect(rect, monitorInfo),
+          monitor: monitorInfo,
+        });
+        setPreview(response);
+        setSelection(null);
+        setPhase('preview');
+      } catch (error) {
+        console.error('[Croquis] Failed to capture full screen', error);
+        toast.error('Failed to capture full screen.');
+        setSelection(null);
+        setPhase('selecting');
+      } finally {
+        setBusy(false);
+      }
+    })();
+  }, [captureId, monitorInfo, phase]);
+
+  const handleRetake = useCallback(() => {
+    setPreview(null);
+    setSelection(null);
+    setPhase('selecting');
+  }, []);
+
+  const handleCancel = useCallback(async () => {
+    if (!captureId) {
+      await windowRef.current.close();
+      return;
+    }
+    try {
+      await ipc.croquis.cancelCapture(captureId);
+    } catch (error) {
+      console.error('[Croquis] Failed to cancel capture', error);
+    } finally {
+      confirmedRef.current = true;
+      await windowRef.current.close();
+    }
+  }, [captureId]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!captureId) return;
+    setBusy(true);
+    try {
+      const result = await ipc.croquis.confirmCapture(captureId);
+      toast.success(`Capture saved as ${result.fileName}`);
+      confirmedRef.current = true;
+      await windowRef.current.close();
+    } catch (error) {
+      console.error('[Croquis] Failed to confirm capture', error);
+      toast.error('Failed to save capture. Please try again.');
+      setBusy(false);
+      setPhase('selecting');
+    }
+  }, [captureId]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        void handleCancel();
+      }
+      if (event.key === 'Enter' && phase === 'preview') {
+        event.preventDefault();
+        void handleConfirm();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [handleCancel, handleConfirm, phase]);
+
+  const previewSrc = useMemo(() => {
+    if (!preview) return null;
+    return convertFileSrc(preview.previewPath);
+  }, [preview]);
+
+  const renderSelectionOverlay = () => {
+    if (!selection || phase !== 'selecting') return null;
+    return (
+      <div
+        className="absolute border-2 border-accent bg-accent/10"
+        style={{
+          left: `${selection.x}px`,
+          top: `${selection.y}px`,
+          width: `${selection.width}px`,
+          height: `${selection.height}px`,
+        }}
+      >
+        <div className="absolute right-2 top-2 rounded bg-accent px-2 py-1 text-xs text-black">
+          {Math.round(selection.width)} × {Math.round(selection.height)}
+        </div>
+      </div>
+    );
+  };
+
+  const renderPreview = () => {
+    if (phase !== 'preview') return null;
+    return (
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center p-12">
+        <div className="pointer-events-auto max-h-full max-w-4xl rounded-lg bg-surface p-4 shadow-xl">
+          {previewSrc ? (
+            <img
+              src={previewSrc}
+              alt="Croquis capture preview"
+              className="max-h-[70vh] max-w-full rounded"
+            />
+          ) : (
+            <div className="p-6 text-center text-sm text-text-soft">Preparing preview…</div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  const renderBottomControls = () => {
+    const disabled = busy || phase === 'loading';
+    if (phase === 'preview') {
+      return (
+        <div className="pointer-events-auto flex items-center gap-3">
+          <Button variant="secondary" onClick={handleRetake} disabled={busy}>
+            Retake
+          </Button>
+          <Button variant="secondary" onClick={handleCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleConfirm} disabled={busy}>
+            Confirm
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="pointer-events-auto flex items-center gap-3">
+        <Button
+          variant="secondary"
+          onClick={() => setMode('freeform')}
+          active={mode === 'freeform'}
+          disabled={disabled}
+        >
+          Freeform
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => setMode('square')}
+          active={mode === 'square'}
+          disabled={disabled}
+        >
+          Square
+        </Button>
+        <Button variant="secondary" onClick={handleFullScreenCapture} disabled={disabled}>
+          Full screen
+        </Button>
+        <Button variant="secondary" onClick={handleCancel} disabled={disabled}>
+          Cancel
+        </Button>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="relative flex h-screen w-screen select-none flex-col text-white"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      <div className="absolute inset-0" />
+      {phase === 'loading' && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-white/80">
+          {busy ? 'Processing capture…' : 'Preparing capture window…'}
+        </div>
+      )}
+
+      <div className="pointer-events-none absolute inset-x-0 top-12 flex justify-center text-center text-sm text-white">
+        {phase === 'selecting'
+          ? 'Drag to select the area to capture or choose an option below.'
+          : phase === 'preview'
+            ? 'Review the capture and confirm or retake.'
+            : 'Preparing capture window…'}
+      </div>
+
+      {renderSelectionOverlay()}
+      {renderPreview()}
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-12 flex justify-center">
+        {renderBottomControls()}
+      </div>
+    </div>
+  );
+};
+
+export default CroquisCaptureOverlay;

--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -6,6 +6,7 @@ import { Button } from '@tgim/ui';
 import { CroquisSession, CroquisSessionImage } from '@tgim/types/croquis';
 import { Pause, Play, SkipBack, SkipForward, Camera } from 'lucide-react';
 import { ipc } from '../../lib/ipc';
+import { toast } from 'react-toastify';
 
 const shuffleImages = (images: CroquisSessionImage[]): CroquisSessionImage[] => {
   const next = [...images];
@@ -32,6 +33,7 @@ const CroquisWindow: React.FC = () => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [timerExpired, setTimerExpired] = useState(false);
   const [isHover, setIsHover] = useState(false); // UI visible only on hover
+  const [isCaptureBusy, setIsCaptureBusy] = useState(false);
 
   const imgRef = useRef<HTMLImageElement | null>(null); // reference to current <img>
   const rafRef = useRef<number | null>(null);
@@ -223,9 +225,24 @@ const CroquisWindow: React.FC = () => {
     setCurrentIndex(prev => Math.min(imageList.length - 1, prev + 1));
   }, [hasNext, imageList.length]);
 
-  const handleCapture = useCallback(() => {
-    window.alert('Capture requested. (Not implemented yet)');
-  }, []);
+  const handleCapture = useCallback(async () => {
+    if (!session || !currentImage || !isCaptureEnabled || isCaptureBusy) {
+      return;
+    }
+
+    setIsCaptureBusy(true);
+    try {
+      await ipc.croquis.startCapture({
+        sessionId: session.sessionId,
+        imageHash: currentImage.hash,
+      });
+    } catch (error) {
+      console.error('[Croquis] Failed to launch capture overlay', error);
+      toast.error('Failed to start capture overlay.');
+    } finally {
+      setIsCaptureBusy(false);
+    }
+  }, [currentImage, isCaptureBusy, isCaptureEnabled, session]);
 
   const elapsedSeconds =
     maxTimeSeconds > 0 ? Math.min(maxTimeSeconds, elapsedMs / 1000) : elapsedMs / 1000;
@@ -325,6 +342,7 @@ const CroquisWindow: React.FC = () => {
                   type="button"
                   variant="secondary"
                   onClick={handleCapture}
+                  disabled={isCaptureBusy}
                   className="flex items-center gap-2"
                 >
                   <Camera className="size-4" />

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -3,6 +3,12 @@ import { invoke } from '@tauri-apps/api/core';
 import { GraphResponse } from '@tgim/types/graph';
 import { CreateFolderPayload, FolderPreview, ThumbRequest, ThumbResponse } from '@tgim/types/file';
 import {
+  CroquisCaptureConfirmResponse,
+  CroquisCaptureContext,
+  CroquisCapturePreview,
+  CroquisCapturePreviewPayload,
+  CroquisCaptureStartPayload,
+  CroquisCaptureStartResponse,
   CroquisOption,
   CroquisSession,
   CroquisStartPayload,
@@ -84,6 +90,29 @@ const croquisIpc = {
   loadOption: async (moaId: string): Promise<CroquisOption | null> => {
     const response = await invoke('load_croquis_option', { moaId });
     return (response as CroquisOption | null) ?? null;
+  },
+  startCapture: async (
+    payload: CroquisCaptureStartPayload,
+  ): Promise<CroquisCaptureStartResponse> => {
+    const response = await invoke('start_croquis_capture', { payload });
+    return response as CroquisCaptureStartResponse;
+  },
+  loadCaptureContext: async (captureId: string): Promise<CroquisCaptureContext | null> => {
+    const response = await invoke('load_croquis_capture_context', { captureId });
+    return (response as CroquisCaptureContext | null) ?? null;
+  },
+  renderCapturePreview: async (
+    payload: CroquisCapturePreviewPayload,
+  ): Promise<CroquisCapturePreview> => {
+    const response = await invoke('render_croquis_capture_preview', { payload });
+    return response as CroquisCapturePreview;
+  },
+  confirmCapture: async (captureId: string): Promise<CroquisCaptureConfirmResponse> => {
+    const response = await invoke('confirm_croquis_capture', { captureId });
+    return response as CroquisCaptureConfirmResponse;
+  },
+  cancelCapture: async (captureId: string): Promise<void> => {
+    await invoke('cancel_croquis_capture', { captureId });
   },
 };
 

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -48,3 +48,51 @@ export interface CroquisStartResponse {
   sessionId: string;
   windowLabel: string;
 }
+
+export interface CroquisCaptureStartPayload {
+  sessionId: string;
+  imageHash: string;
+}
+
+export interface CroquisCaptureStartResponse {
+  captureId: string;
+}
+
+export interface CroquisCaptureContext {
+  captureId: string;
+  sessionId: string;
+  imageHash: string;
+  moaId: string;
+  savePath: string;
+}
+
+export interface CroquisCaptureRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CroquisCaptureMonitor {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scaleFactor: number;
+}
+
+export interface CroquisCapturePreviewPayload {
+  captureId: string;
+  rect: CroquisCaptureRect;
+  monitor: CroquisCaptureMonitor;
+}
+
+export interface CroquisCapturePreview {
+  previewPath: string;
+  rect: CroquisCaptureRect;
+}
+
+export interface CroquisCaptureConfirmResponse {
+  filePath: string;
+  fileName: string;
+}

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -83,4 +83,5 @@ export enum RelationType {
   BelongToFolder = 'belongtofolder',
   ParentFolder = 'parentfolder',
   ChildFolder = 'childfolder',
+  CroquisReference = 'croquisreference',
 }


### PR DESCRIPTION
## Summary
- add a transparent Croquis capture overlay with selection tools, preview flow, and keyboard handling
- trigger captures from the Croquis viewer and expose renderer IPC helpers with shared capture models
- implement the backend capture pipeline, including screenshotting, storage integration, and Croquis graph connections

## Testing
- pnpm lint:check *(fails: missing @eslint/js dependency)*
- pnpm --filter @grim/desktop build *(fails: workspace TypeScript dependencies missing)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: crates.io index blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d18312f6a8832e85a1e28a981e2e01