### PR TITLE
Handle thumbnail cache purge events

### DIFF
--- a/apps/desktop/src-tauri/src/services/file_service/cache.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/cache.rs
@@ -17,6 +17,19 @@ pub struct ThumbCacheUsage {
     pub total_files: u64,
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+enum ThumbPurgeScope {
+    Base,
+    Derived,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ThumbPurgeEvent {
+    scope: ThumbPurgeScope,
+}
+
 pub async fn collect_thumb_cache_usage(
     app: &AppHandle,
 ) -> Result<ThumbCacheUsage> {
@@ -42,14 +55,19 @@ pub async fn collect_thumb_cache_usage(
 pub async fn clear_base_thumb_cache(app: &AppHandle) -> Result<()> {
     let root = cache_root(app)?;
     let base_path = root.join("base");
-    remove_path(base_path.as_path()).await
+    remove_path(base_path.as_path()).await?;
+    emit_thumb_purged(app, ThumbPurgeScope::Base)?;
+    Ok(())
 }
 
 pub async fn clear_derived_thumb_cache(app: &AppHandle) -> Result<()> {
     let root = cache_root(app)?;
     let metadata = match tokio::fs::metadata(root.as_path()).await {
         Ok(metadata) => metadata,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            emit_thumb_purged(app, ThumbPurgeScope::Derived)?;
+            return Ok(());
+        }
         Err(err) => {
             return Err(err).context(format!(
                 "failed to inspect thumbnail cache root: {}",
@@ -59,7 +77,9 @@ pub async fn clear_derived_thumb_cache(app: &AppHandle) -> Result<()> {
     };
 
     if !metadata.is_dir() {
-        return remove_path(root.as_path()).await;
+        remove_path(root.as_path()).await?;
+        emit_thumb_purged(app, ThumbPurgeScope::Derived)?;
+        return Ok(());
     }
 
     let mut entries = tokio::fs::read_dir(root.as_path())
@@ -78,6 +98,7 @@ pub async fn clear_derived_thumb_cache(app: &AppHandle) -> Result<()> {
         remove_path(path.as_path()).await?;
     }
 
+    emit_thumb_purged(app, ThumbPurgeScope::Derived)?;
     Ok(())
 }
 
@@ -208,4 +229,10 @@ async fn remove_path(path: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn emit_thumb_purged(app: &AppHandle, scope: ThumbPurgeScope) -> Result<()> {
+    let payload = ThumbPurgeEvent { scope };
+    app.emit("thumbnails://purged", payload)
+        .context("failed to emit thumbnail purge event")
 }

--- a/apps/desktop/src-tauri/src/services/file_service/cache.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/cache.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use tauri::{path::BaseDirectory, AppHandle, Manager};
+use tauri::{path::BaseDirectory, AppHandle, Emitter, Manager};
 
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/apps/desktop/src/features/main/Main.tsx
+++ b/apps/desktop/src/features/main/Main.tsx
@@ -153,9 +153,10 @@ const Main: React.FC = () => {
       leftSidebar: state.sidebars.left,
     })),
   );
-  const { upsertThumb } = useThumbStore(
+  const { upsertThumb, resetThumbs } = useThumbStore(
     useShallow(state => ({
       upsertThumb: state.upsert,
+      resetThumbs: state.reset,
     })),
   );
   // React to thumbnail worker updates to keep local caches in sync.
@@ -183,6 +184,22 @@ const Main: React.FC = () => {
       unlisten?.();
     };
   }, [moaId, upsertThumb]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    const initListener = async () => {
+      unlisten = await listen<{ scope: 'base' | 'derived' }>('thumbnails://purged', () => {
+        resetThumbs();
+      });
+    };
+
+    void initListener();
+
+    return () => {
+      unlisten?.();
+    };
+  }, [resetThumbs]);
 
   // Load the initial graph and subscribe to bootstrap progress events.
   useEffect(() => {

--- a/packages/stores/src/thumbStore.ts
+++ b/packages/stores/src/thumbStore.ts
@@ -29,6 +29,7 @@ interface ThumbState {
   touch: (thumbKey: ThumbKey) => void;
   attach: (hash: string, thumbKey: ThumbKey) => void;
   evictLRU: (max: number) => void;
+  reset: () => void;
 
   getThumbPathByKey: (key: ThumbKey) => string | undefined;
 }
@@ -109,6 +110,24 @@ export const useThumbStore = create<ThumbState>()(
               if (v) s.byKey[k] = { ...v, url: undefined };
             }
           }
+        });
+      },
+
+      reset: () => {
+        const entries = Object.values(get().byKey);
+        for (const entry of entries) {
+          const url = entry?.url;
+          if (url?.startsWith('blob:')) {
+            try {
+              URL.revokeObjectURL(url);
+            } catch {}
+          }
+        }
+
+        set(s => {
+          s.byKey = {};
+          s.byHash = {};
+          s.lru = [];
         });
       },
 


### PR DESCRIPTION
## Summary
- emit a `thumbnails://purged` event from the Tauri cache clearing commands
- add a reset helper to the thumbnail store to drop cached entries safely
- listen for the purge event in the renderer and clear the local thumbnail cache

## Testing
- pnpm exec prettier --write packages/stores/src/thumbStore.ts apps/desktop/src/features/main/Main.tsx
- pnpm lint:check *(fails: missing @eslint/js because workspace dependencies cannot be installed in the sandbox)*
- pnpm --filter @grim/desktop build *(fails: workspace dependencies cannot be installed in the sandbox)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: 403 while downloading crates index in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d23d87e288832ea52ea63dcf523063