### PR TITLE
Show only folders in file tree and open on double click

### DIFF
--- a/packages/stores/src/fileTreeStore.ts
+++ b/packages/stores/src/fileTreeStore.ts
@@ -1,12 +1,5 @@
 import { create } from 'zustand';
-import {
-  FileTreeData,
-  GraphResponse,
-  NodeFile,
-  NodeFolder,
-  NodeKind,
-  RelationType,
-} from '@tgim/types/index';
+import { FileTreeData, GraphResponse, NodeFolder, NodeKind, RelationType } from '@tgim/types/index';
 
 interface FileTreeState {
   // current tree data
@@ -172,14 +165,16 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
     const incoming = new Map<string, number>();
 
     for (const n of nodes) {
+      if (n.kind !== NodeKind.Folder) continue;
+
       const folderData = (n.data?.['Folder'] as NodeFolder) ?? undefined;
-      const fileData = (n.data?.['File'] as NodeFile) ?? undefined;
+
       nodeMap.set(n.id, {
         id: n.id,
-        name: folderData?.folder_name ?? fileData?.file_name ?? '',
-        icon: n.kind === 'folder' ? 'folder' : 'file',
-        type: n.kind === 'folder' ? NodeKind.Folder : NodeKind.File,
-        children: n.kind === 'folder' ? [] : undefined,
+        name: folderData?.folder_name ?? '',
+        icon: 'folder',
+        type: NodeKind.Folder,
+        children: [],
       });
 
       incoming.set(n.id, 0);
@@ -187,8 +182,7 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
     const childrenMap = new Map<string, FileTreeData[]>();
 
     for (const conn of connections) {
-      if (conn.kind !== RelationType.ChildFolder && conn.kind !== RelationType.ContainsFile)
-        continue;
+      if (conn.kind !== RelationType.ChildFolder) continue;
 
       const parent = nodeMap.get(conn.src_node_id);
       const child = nodeMap.get(conn.dst_node_id);
@@ -205,11 +199,7 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
     }
 
     for (const [id, node] of nodeMap) {
-      if (node.type === 'folder') {
-        node.children = childrenMap.get(id) ?? [];
-      } else {
-        node.children = undefined;
-      }
+      node.children = childrenMap.get(id) ?? [];
     }
 
     const roots: FileTreeData[] = [];

--- a/packages/ui/src/FileTree.tsx
+++ b/packages/ui/src/FileTree.tsx
@@ -29,6 +29,19 @@ export const TreeNode: React.FC<{
 }) => {
   const isFolder = node.type === NodeKind.Folder;
   const isFile = node.type === NodeKind.File;
+  const clickTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearClickTimeout = React.useCallback(() => {
+    if (clickTimeoutRef.current) {
+      clearTimeout(clickTimeoutRef.current);
+      clickTimeoutRef.current = null;
+    }
+  }, []);
+
+  React.useEffect(() => () => clearClickTimeout(), [clearClickTimeout]);
+
+  const hasModifierKey = (event: React.MouseEvent) =>
+    event.shiftKey || event.metaKey || event.ctrlKey || event.altKey;
+
   const {
     attributes,
     listeners,
@@ -59,8 +72,30 @@ export const TreeNode: React.FC<{
         )}
         onClick={e => {
           onSelect?.(e, node.id);
-          if (isFolder && !e.shiftKey && !e.metaKey && !e.ctrlKey) onToggle(node.id);
-          if (isFile && !e.shiftKey && !e.metaKey && !e.ctrlKey) openFile(node);
+          if (hasModifierKey(e)) return;
+
+          if (isFolder) {
+            clearClickTimeout();
+            clickTimeoutRef.current = setTimeout(() => {
+              onToggle(node.id);
+              clearClickTimeout();
+            }, 200);
+          } else if (isFile) {
+            openFile(node);
+          }
+        }}
+        onDoubleClick={e => {
+          if (hasModifierKey(e)) return;
+
+          if (isFolder) {
+            clearClickTimeout();
+            if (!expanded) {
+              onToggle(node.id);
+            }
+            openFile(node);
+          } else if (isFile) {
+            openFile(node);
+          }
         }}
         {...attributes}
         {...listeners}


### PR DESCRIPTION
## Summary
- filter the file tree store to omit file nodes and keep only folders when building the tree data
- update the file tree UI to delay single-click expansion and open a folder's graph view when double-clicked without modifiers

## Testing
- `pnpm format:write`
- `pnpm lint:check` *(fails: missing @eslint/js dependency in the environment)*
- `pnpm --filter @grim/desktop build` *(fails: workspace dependencies like React and Tauri packages are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d28ca820f8832ea057daa90a7123af