### PR TITLE
feat: add croquis presets and timer enhancements

### DIFF
--- a/apps/desktop/src-tauri/src/commands/croquis.rs
+++ b/apps/desktop/src-tauri/src/commands/croquis.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::croquis::{
-        CroquisOption, CroquisSession, CroquisStartPayload,
+        CroquisPreferences, CroquisSession, CroquisStartPayload,
         CroquisStartResponse,
     },
     services::croquis_service,
@@ -25,10 +25,12 @@ pub async fn load_croquis_session(
     Ok(croquis_service::load_session(&session_id).await)
 }
 
-/// Load persisted Croquis options for the provided workspace if available.
+/// Load persisted Croquis preferences for the provided workspace if available.
 #[tauri::command]
 pub async fn load_croquis_option(
     moa_id: String,
-) -> Result<Option<CroquisOption>, String> {
-    croquis_service::load_option(&moa_id).await.map_err(|err| err.to_string())
+) -> Result<Option<CroquisPreferences>, String> {
+    croquis_service::load_preferences(&moa_id)
+        .await
+        .map_err(|err| err.to_string())
 }

--- a/apps/desktop/src-tauri/src/models/croquis.rs
+++ b/apps/desktop/src-tauri/src/models/croquis.rs
@@ -45,6 +45,28 @@ pub struct CroquisOption {
     pub is_shuffle: bool,
 }
 
+/// Named preset that stores a single Croquis option payload.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisPreset {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub option: CroquisOption,
+}
+
+/// Collection of Croquis presets remembered for a workspace.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CroquisPreferences {
+    #[serde(default)]
+    pub presets: Vec<CroquisPreset>,
+    #[serde(default)]
+    pub active_preset_id: String,
+}
+
 /// Payload provided by the renderer to start a Croquis session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +76,8 @@ pub struct CroquisStartPayload {
     pub image_hashes: Vec<String>,
     #[serde(default)]
     pub save_option: bool,
+    #[serde(default)]
+    pub preferences: Option<CroquisPreferences>,
 }
 
 /// Metadata describing an ensured Croquis base image.

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -9,8 +9,8 @@ use crate::{
     app_launcher,
     bootstrap::PATH_MANAGER,
     models::croquis::{
-        CroquisOption, CroquisSession, CroquisSessionImage,
-        CroquisStartPayload, CroquisStartResponse,
+        CroquisOption, CroquisPreferences, CroquisPreset, CroquisSession,
+        CroquisSessionImage, CroquisStartPayload, CroquisStartResponse,
     },
     services::file_service::{
         folder::fetch_one_file_path,
@@ -28,15 +28,31 @@ pub async fn start_session(
     app_handle: &tauri::AppHandle,
     payload: CroquisStartPayload,
 ) -> Result<CroquisStartResponse> {
-    let CroquisStartPayload { moa_id, option, image_hashes, save_option } =
-        payload;
+    let CroquisStartPayload {
+        moa_id,
+        option,
+        image_hashes,
+        save_option,
+        preferences,
+    } = payload;
 
     if image_hashes.is_empty() {
         bail!("At least one image hash must be provided to start Croquis");
     }
 
     if save_option {
-        persist_option(&moa_id, &option).await?;
+        let preferences_to_persist = preferences.unwrap_or_else(|| {
+            let preset_id = get_unique_id();
+            CroquisPreferences {
+                active_preset_id: preset_id.clone(),
+                presets: vec![CroquisPreset {
+                    id: preset_id,
+                    name: "Preset 1".to_string(),
+                    option: option.clone(),
+                }],
+            }
+        });
+        persist_preferences(&moa_id, &preferences_to_persist).await?;
     }
 
     let mut images: Vec<CroquisSessionImage> =
@@ -120,8 +136,10 @@ pub async fn load_session(session_id: &str) -> Option<CroquisSession> {
     sessions.get(session_id).cloned()
 }
 
-/// Load the persisted Croquis option payload from the workspace settings directory.
-pub async fn load_option(moa_id: &str) -> Result<Option<CroquisOption>> {
+/// Load the persisted Croquis preferences from the workspace settings directory.
+pub async fn load_preferences(
+    moa_id: &str,
+) -> Result<Option<CroquisPreferences>> {
     let paths = PATH_MANAGER
         .get_or_add(moa_id)
         .await
@@ -132,22 +150,65 @@ pub async fn load_option(moa_id: &str) -> Result<Option<CroquisOption>> {
 
     match fs::read(&file_path).await {
         Ok(payload) => {
-            let option = serde_json::from_slice(&payload)
-                .context("Failed to deserialise Croquis options")?;
-            Ok(Some(option))
+            match serde_json::from_slice::<CroquisPreferences>(&payload) {
+                Ok(mut preferences) => {
+                    if preferences.presets.is_empty() {
+                        let preset_id = get_unique_id();
+                        preferences.presets.push(CroquisPreset {
+                            id: preset_id.clone(),
+                            name: "Preset 1".to_string(),
+                            option: CroquisOption::default(),
+                        });
+                        preferences.active_preset_id = preset_id;
+                    } else if preferences.active_preset_id.is_empty()
+                        || !preferences.presets.iter().any(|preset| {
+                            preset.id == preferences.active_preset_id
+                        })
+                    {
+                        if let Some(first) = preferences.presets.first() {
+                            preferences.active_preset_id = first.id.clone();
+                        }
+                    }
+
+                    Ok(Some(preferences))
+                }
+                Err(primary_error) => {
+                    match serde_json::from_slice::<CroquisOption>(&payload) {
+                        Ok(option) => {
+                            let preset_id = get_unique_id();
+                            let preferences = CroquisPreferences {
+                                active_preset_id: preset_id.clone(),
+                                presets: vec![CroquisPreset {
+                                    id: preset_id,
+                                    name: "Preset 1".to_string(),
+                                    option,
+                                }],
+                            };
+                            Ok(Some(preferences))
+                        }
+                        Err(_) => Err(primary_error).context(format!(
+                            "Failed to deserialise Croquis preferences from {}",
+                            file_path.display()
+                        )),
+                    }
+                }
+            }
         }
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error).with_context(|| {
             format!(
-                "Failed to read Croquis options from {}",
+                "Failed to read Croquis preferences from {}",
                 file_path.display()
             )
         }),
     }
 }
 
-/// Persist the Croquis option payload into the workspace `.moa/settings` folder.
-async fn persist_option(moa_id: &str, option: &CroquisOption) -> Result<()> {
+/// Persist the Croquis preferences into the workspace `.moa/settings` folder.
+async fn persist_preferences(
+    moa_id: &str,
+    preferences: &CroquisPreferences,
+) -> Result<()> {
     let paths = PATH_MANAGER
         .get_or_add(moa_id)
         .await
@@ -162,11 +223,14 @@ async fn persist_option(moa_id: &str, option: &CroquisOption) -> Result<()> {
     })?;
 
     let file_path = settings_dir.join("croquis.json");
-    let payload = serde_json::to_vec_pretty(option)
-        .context("Failed to serialise Croquis options")?;
+    let payload = serde_json::to_vec_pretty(preferences)
+        .context("Failed to serialise Croquis preferences")?;
 
     fs::write(&file_path, payload).await.with_context(|| {
-        format!("Failed to write Croquis options to {}", file_path.display())
+        format!(
+            "Failed to write Croquis preferences to {}",
+            file_path.display()
+        )
     })?;
 
     Ok(())

--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -1,11 +1,16 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { join } from '@tauri-apps/api/path';
 import { Button, Input, Modal, Switch } from '@tgim/ui';
-import { CroquisOption, CroquisStartResponse } from '@tgim/types/croquis';
+import { CroquisOption, CroquisPreferences, CroquisStartResponse } from '@tgim/types/croquis';
 import { ipc } from '../../lib/ipc';
 import { open as pickerOpen } from '@tauri-apps/plugin-dialog';
 
 import { toast } from 'react-toastify';
+import {
+  createPreset,
+  normaliseCroquisOption,
+  normaliseCroquisPreferences,
+} from './lib/preferences';
 
 type WindowPreset = {
   label: string;
@@ -19,35 +24,90 @@ const WINDOW_PRESETS: WindowPreset[] = [
   { label: '512xauto', width: '512', height: '0' },
 ];
 
-const normaliseCroquisOption = (option: CroquisOption): CroquisOption => ({
-  window: {
-    width: option.window?.width ?? null,
-    height: option.window?.height ?? null,
-  },
-  auto: {
-    isSkip: option.auto?.isSkip ?? false,
-  },
-  timer: {
-    maxTime:
-      option.timer?.maxTime ??
-      (option.timer as unknown as { maxTime?: number } | undefined)?.maxTime ??
-      60,
-  },
-  isCapture: option.isCapture ?? false,
-  savePath: option.savePath ?? '',
-  isGray: option.isGray ?? false,
-  isShuffle: option.isShuffle ?? false,
-});
+const TIMER_PRESETS = [
+  { label: '30s', seconds: 30 },
+  { label: '1m', seconds: 60 },
+  { label: '3m', seconds: 3 * 60 },
+  { label: '5m', seconds: 5 * 60 },
+  { label: '10m', seconds: 10 * 60 },
+  { label: '30m', seconds: 30 * 60 },
+] as const;
+
+const clampSeconds = (value: number): number => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.round(value));
+};
+
+const formatTimer = (seconds: number): string => {
+  const total = clampSeconds(seconds);
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+  const parts: string[] = [];
+
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (secs || parts.length === 0) parts.push(`${secs}s`);
+
+  return parts.join(' ');
+};
+
+const parseTimerInput = (raw: string): number | null => {
+  const value = raw.trim().toLowerCase();
+  if (!value) return null;
+
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  if (value.includes(':')) {
+    const parts = value.split(':');
+    if (parts.length >= 2 && parts.length <= 3 && parts.every(part => /^\d+$/.test(part))) {
+      const numbers = parts.map(Number);
+      if (numbers.length === 2) {
+        const [minutes, seconds] = numbers;
+        return minutes * 60 + seconds;
+      }
+      if (numbers.length === 3) {
+        const [hours, minutes, seconds] = numbers;
+        return hours * 3600 + minutes * 60 + seconds;
+      }
+    }
+  }
+
+  const unitPattern = /(\d+)\s*(h(?:ours?)?|m(?:in(?:utes)?)?|s(?:ec(?:onds)?)?)/g;
+  let match: RegExpExecArray | null;
+  let total = 0;
+  let matched = false;
+
+  while ((match = unitPattern.exec(value)) !== null) {
+    matched = true;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    if (Number.isNaN(amount)) continue;
+
+    if (unit.startsWith('h')) {
+      total += amount * 3600;
+    } else if (unit.startsWith('m')) {
+      total += amount * 60;
+    } else {
+      total += amount;
+    }
+  }
+
+  return matched ? total : null;
+};
 
 export type CroquisStartModalConfirmPayload = {
   response: CroquisStartResponse;
   option: CroquisOption;
+  preferences: CroquisPreferences;
   remember: boolean;
 };
 
 type CroquisStartModalProps = {
   open: boolean;
-  option: CroquisOption;
+  preferences: CroquisPreferences;
   moaId: string | null;
   imageHashes: string[];
   remember?: boolean;
@@ -57,19 +117,29 @@ type CroquisStartModalProps = {
 
 const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   open,
-  option,
+  preferences,
   moaId,
   imageHashes,
-  remember = false,
+  remember = true,
   onConfirm,
   onClose,
 }) => {
-  const [localOption, setLocalOption] = useState<CroquisOption>(() =>
-    normaliseCroquisOption(option),
+  const [preferencesState, setPreferencesState] = useState<CroquisPreferences>(() =>
+    normaliseCroquisPreferences(preferences),
   );
+  const activePreset = useMemo(
+    () =>
+      preferencesState.presets.find(preset => preset.id === preferencesState.activePresetId) ??
+      preferencesState.presets[0],
+    [preferencesState],
+  );
+  const activeOption = useMemo(() => normaliseCroquisOption(activePreset?.option), [activePreset]);
   const [rememberSettings, setRememberSettings] = useState<boolean>(Boolean(remember));
   const [submitting, setSubmitting] = useState(false);
+  const [timerInput, setTimerInput] = useState(() => formatTimer(activeOption.timer.maxTime));
+  const [editingTimer, setEditingTimer] = useState(false);
   const hasUserInteractedRef = useRef(false);
+
   const markInteracted = useCallback(() => {
     hasUserInteractedRef.current = true;
   }, []);
@@ -77,9 +147,15 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
   useEffect(() => {
     if (!open) return;
     hasUserInteractedRef.current = false;
-    setLocalOption(normaliseCroquisOption(option));
+    setPreferencesState(normaliseCroquisPreferences(preferences));
     setRememberSettings(Boolean(remember));
-  }, [open, option, remember]);
+    setEditingTimer(false);
+  }, [open, preferences, remember]);
+
+  useEffect(() => {
+    if (editingTimer) return;
+    setTimerInput(formatTimer(activeOption.timer.maxTime));
+  }, [activeOption.timer.maxTime, editingTimer]);
 
   useEffect(() => {
     if (!open || !moaId) return;
@@ -88,12 +164,12 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
 
     void (async () => {
       try {
-        const persistedOption = await ipc.croquis.loadOption(moaId);
-        if (cancelled || !persistedOption) return;
+        const persisted = await ipc.croquis.loadPreferences(moaId);
+        if (cancelled || !persisted) return;
         if (hasUserInteractedRef.current) return;
-        setLocalOption(normaliseCroquisOption(persistedOption));
+        setPreferencesState(normaliseCroquisPreferences(persisted));
       } catch (error) {
-        console.error('[Croquis] Failed to load saved options', error);
+        console.error('[Croquis] Failed to load saved presets', error);
       }
     })();
 
@@ -104,7 +180,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
 
   useEffect(() => {
     if (!open || !moaId) return;
-    if (localOption.savePath) return;
+    if (activeOption.savePath) return;
 
     let cancelled = false;
 
@@ -115,10 +191,24 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
         if (!target) return;
         const defaultPath = await join(target.path, 'croquis');
         if (cancelled) return;
-        setLocalOption(prev => ({
-          ...prev,
-          savePath: defaultPath,
-        }));
+        setPreferencesState(prev => {
+          const activeId = prev.activePresetId;
+          const nextPresets = prev.presets.map(preset => {
+            if (preset.id !== activeId) return preset;
+            if (preset.option.savePath) return preset;
+            return {
+              ...preset,
+              option: {
+                ...preset.option,
+                savePath: defaultPath,
+              },
+            };
+          });
+          return {
+            ...prev,
+            presets: nextPresets,
+          };
+        });
       } catch (error) {
         console.error('[Croquis] Failed to resolve default save path', error);
       }
@@ -127,20 +217,61 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [open, moaId, localOption.savePath]);
+  }, [open, moaId, activeOption.savePath]);
 
-  const selectedCount = imageHashes.length;
+  const updateActiveOption = useCallback(
+    (updater: (option: CroquisOption) => CroquisOption) => {
+      markInteracted();
+      setPreferencesState(prev => {
+        const nextPresets = prev.presets.map(preset => {
+          if (preset.id !== prev.activePresetId) return preset;
+          const base = normaliseCroquisOption(preset.option);
+          const nextOption = normaliseCroquisOption(updater(base));
+          return {
+            ...preset,
+            option: nextOption,
+          };
+        });
+        return {
+          ...prev,
+          presets: nextPresets,
+        };
+      });
+    },
+    [markInteracted],
+  );
 
-  const windowWidth = localOption.window?.width ?? '';
-  const windowHeight = localOption.window?.height ?? '';
+  const handlePresetSelect = useCallback(
+    (presetId: string) => {
+      markInteracted();
+      setEditingTimer(false);
+      setPreferencesState(prev => {
+        if (prev.activePresetId === presetId) return prev;
+        return {
+          ...prev,
+          activePresetId: presetId,
+        };
+      });
+    },
+    [markInteracted],
+  );
 
-  const skipMode = localOption.auto.isSkip ? 'auto' : 'manual';
-  const rememberMode = rememberSettings ? 'remember' : 'session';
+  const handleAddPreset = useCallback(() => {
+    markInteracted();
+    setEditingTimer(false);
+    setPreferencesState(prev => {
+      const index = prev.presets.length;
+      const nextPreset = createPreset(`Preset ${index + 1}`, activeOption, index);
+      return {
+        presets: [...prev.presets, nextPreset],
+        activePresetId: nextPreset.id,
+      };
+    });
+  }, [activeOption, markInteracted]);
 
   const handleWindowPresetClick = useCallback(
     (preset: WindowPreset) => {
-      markInteracted();
-      setLocalOption(prev => ({
+      updateActiveOption(prev => ({
         ...prev,
         window: {
           width: preset.width,
@@ -148,71 +279,120 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
         },
       }));
     },
-    [markInteracted],
+    [updateActiveOption],
   );
 
   const handleWindowDimensionChange = useCallback(
-    (key: 'width' | 'height') => {
-      return (event: React.ChangeEvent<HTMLInputElement>) => {
-        const value = event.target.value;
-        markInteracted();
-        setLocalOption(prev => ({
-          ...prev,
-          window: {
-            ...prev.window,
-            [key]: value ? value : null,
-          },
-        }));
-      };
+    (key: 'width' | 'height') => (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      updateActiveOption(prev => ({
+        ...prev,
+        window: {
+          ...prev.window,
+          [key]: value ? value : null,
+        },
+      }));
     },
-    [markInteracted],
+    [updateActiveOption],
   );
 
-  const handleTimerChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const next = Number(event.target.value);
-      const safeValue = Number.isFinite(next) && next >= 0 ? next : 0;
-      markInteracted();
-      setLocalOption(prev => {
-        const timer = {
+  const handleTimerPresetClick = useCallback(
+    (seconds: number) => {
+      setEditingTimer(false);
+      updateActiveOption(prev => ({
+        ...prev,
+        timer: {
           ...prev.timer,
-          maxTime: safeValue,
-        } as typeof prev.timer & { maxTime?: number };
-        timer.maxTime = safeValue;
-        return {
-          ...prev,
-          timer,
-        };
-      });
+          maxTime: seconds,
+        },
+      }));
     },
-    [markInteracted],
+    [updateActiveOption],
+  );
+
+  const handleTimerInputFocus = useCallback(() => {
+    setEditingTimer(true);
+    setTimerInput(activeOption.timer.maxTime.toString());
+  }, [activeOption.timer.maxTime]);
+
+  const handleTimerInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setTimerInput(event.target.value);
+  }, []);
+
+  const commitTimerInput = useCallback(() => {
+    const parsed = parseTimerInput(timerInput);
+    const safeValue = clampSeconds(parsed ?? activeOption.timer.maxTime ?? 0);
+    setEditingTimer(false);
+    updateActiveOption(prev => ({
+      ...prev,
+      timer: {
+        ...prev.timer,
+        maxTime: safeValue,
+      },
+    }));
+    setTimerInput(formatTimer(safeValue));
+  }, [activeOption.timer.maxTime, timerInput, updateActiveOption]);
+
+  const handleTimerInputBlur = useCallback(() => {
+    commitTimerInput();
+  }, [commitTimerInput]);
+
+  const handleTimerInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.currentTarget.blur();
+      }
+      if (event.key === 'Escape') {
+        setEditingTimer(false);
+        setTimerInput(formatTimer(activeOption.timer.maxTime));
+        event.currentTarget.blur();
+      }
+    },
+    [activeOption.timer.maxTime],
+  );
+
+  const handleSkipModeChange = useCallback(
+    (value: 'manual' | 'auto') => {
+      updateActiveOption(prev => ({
+        ...prev,
+        auto: {
+          ...prev.auto,
+          isSkip: value === 'auto',
+        },
+      }));
+    },
+    [updateActiveOption],
   );
 
   const handleToggleOption = useCallback(
-    (key: 'isGray' | 'isCapture' | 'isShuffle') => {
-      markInteracted();
-      setLocalOption(prev => ({
+    (key: 'isGray' | 'isShuffle' | 'isCapture') => {
+      updateActiveOption(prev => ({
         ...prev,
         [key]: !prev[key],
       }));
     },
-    [markInteracted],
+    [updateActiveOption],
   );
 
   const handleSavePathChange = useCallback(
     (value: string) => {
-      markInteracted();
-      setLocalOption(prev => ({
+      updateActiveOption(prev => ({
         ...prev,
         savePath: value,
       }));
     },
-    [markInteracted],
+    [updateActiveOption],
   );
 
   const handleCancel = useCallback(() => {
     onClose();
   }, [onClose]);
+
+  const selectedCount = imageHashes.length;
+  const windowWidth = activeOption.window?.width ?? '';
+  const windowHeight = activeOption.window?.height ?? '';
+  const skipMode: 'manual' | 'auto' = activeOption.auto.isSkip ? 'auto' : 'manual';
+  const rememberMode = rememberSettings ? 'remember' : 'session';
 
   const handleConfirm = useCallback(async () => {
     if (submitting) return;
@@ -227,27 +407,32 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
 
     setSubmitting(true);
     try {
-      const maxTimeValue =
-        localOption.timer.maxTime ??
-        (localOption.timer as unknown as { maxTime?: number }).maxTime ??
-        60;
-      const payloadOption = {
-        ...localOption,
-        auto: { isSkip: skipMode === 'auto' },
-        timer: {
-          ...localOption.timer,
-          maxTime: maxTimeValue,
-        },
-      } as CroquisOption & { timer: CroquisOption['timer'] & { maxTime?: number } };
-      payloadOption.timer.maxTime = maxTimeValue;
+      const payloadOption = normaliseCroquisOption(activeOption);
+      const safeMaxTime = clampSeconds(payloadOption.timer.maxTime);
+      payloadOption.timer.maxTime = safeMaxTime;
+
+      const preferencesPayload: CroquisPreferences = {
+        activePresetId: preferencesState.activePresetId,
+        presets: preferencesState.presets.map(preset => ({
+          ...preset,
+          option: normaliseCroquisOption(preset.option),
+        })),
+      };
 
       const response = await ipc.croquis.startSession({
         moaId,
         imageHashes,
         option: payloadOption,
         saveOption: rememberSettings,
+        preferences: preferencesPayload,
       });
-      await onConfirm?.({ response, option: localOption, remember: rememberSettings });
+
+      await onConfirm?.({
+        response,
+        option: payloadOption,
+        preferences: preferencesPayload,
+        remember: rememberSettings,
+      });
       onClose();
       return response;
     } catch (error) {
@@ -257,210 +442,256 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
       setSubmitting(false);
     }
   }, [
+    activeOption,
     imageHashes,
-    localOption,
     moaId,
     onClose,
     onConfirm,
+    preferencesState,
     rememberSettings,
     selectedCount,
     submitting,
   ]);
 
-  if (!open) {
+  if (!open || !activePreset) {
     return null;
   }
 
+  const activeTimerSeconds = activeOption.timer.maxTime;
+
   return (
     <Modal onClose={handleCancel} dismissible>
-      <div className="flex w-[32rem] max-w-full flex-col gap-6 text-text">
-        <div>
-          <h2 className="text-lg font-semibold">Start Croquis session</h2>
-          <p className="mt-1 text-sm text-text-soft">
-            {selectedCount === 1
-              ? '1 image selected'
-              : `${selectedCount.toLocaleString()} images selected`}
-          </p>
-        </div>
-
-        <section className="space-y-3">
-          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-            Window size
-          </header>
-          <div className="flex flex-wrap gap-2">
-            {WINDOW_PRESETS.map(preset => {
-              const isActive =
-                (preset.width ?? '') === (localOption.window?.width ?? '') &&
-                (preset.height ?? '') === (localOption.window?.height ?? '');
-              return (
+      <div className="flex w-[48rem] max-w-full flex-col gap-5 text-text md:flex-row">
+        <aside className="flex shrink-0 flex-col gap-3 md:w-44">
+          <div>
+            <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+              Presets
+            </header>
+            <div className="mt-2 flex max-h-[22rem] flex-col gap-2 overflow-y-auto pr-1">
+              {preferencesState.presets.map(preset => (
                 <Button
-                  key={preset.label}
+                  key={preset.id}
+                  type="button"
                   variant="toggle"
-                  active={isActive}
-                  onClick={() => handleWindowPresetClick(preset)}
+                  active={preset.id === preferencesState.activePresetId}
+                  className="justify-start"
+                  onClick={() => handlePresetSelect(preset.id)}
                 >
-                  {preset.label}
+                  {preset.name}
                 </Button>
-              );
-            })}
+              ))}
+            </div>
           </div>
-          <div className="grid grid-cols-2 gap-3">
-            <label className="flex flex-col gap-1 text-sm">
-              <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-                Width
-              </span>
-              <Input.Input
-                type="number"
-                min={0}
-                inputMode="numeric"
-                className="input-default"
-                value={windowWidth}
-                placeholder="e.g. 1280"
-                onChange={handleWindowDimensionChange('width')}
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-sm">
-              <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-                Height
-              </span>
-              <Input.Input
-                type="number"
-                min={0}
-                inputMode="numeric"
-                className="input-default"
-                value={windowHeight}
-                placeholder="e.g. 720"
-                onChange={handleWindowDimensionChange('height')}
-              />
-            </label>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-            Auto skip
-          </header>
-          <Switch
-            current={skipMode}
-            onChanged={value => {
-              markInteracted();
-              setLocalOption(prev => ({
-                ...prev,
-                auto: {
-                  ...prev.auto,
-                  isSkip: value === 'auto',
-                },
-              }));
-            }}
-            options={[
-              { name: 'Auto skip breaks', value: 'auto' },
-              { name: 'Manual control', value: 'manual' },
-            ]}
-          />
-        </section>
-
-        <section className="space-y-3">
-          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-            Timer
-          </header>
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-              Seconds per pose
-            </span>
-            <Input.Input
-              type="number"
-              min={5}
-              step={5}
-              inputMode="numeric"
-              className="input-default"
-              value={localOption.timer.maxTime.toString()}
-              onChange={handleTimerChange}
-            />
-          </label>
-        </section>
-
-        <section className="space-y-3">
-          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-            Session options
-          </header>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="toggle"
-              active={localOption.isCapture}
-              onClick={() => handleToggleOption('isCapture')}
-            >
-              Capture reference
-            </Button>
-            <Button
-              type="button"
-              variant="toggle"
-              active={localOption.isGray}
-              onClick={() => handleToggleOption('isGray')}
-            >
-              Grayscale
-            </Button>
-            <Button
-              type="button"
-              variant="toggle"
-              active={localOption.isShuffle}
-              onClick={() => handleToggleOption('isShuffle')}
-            >
-              Shuffle order
-            </Button>
-          </div>
-        </section>
-
-        <section className="space-y-3">
-          <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-            Saving
-          </header>
-          <label
-            className="flex flex-col gap-1 text-sm"
-            onClick={async () => {
-              const result = await pickerOpen({ directory: true });
-              if (!result) return;
-              handleSavePathChange(result);
-            }}
-          >
-            <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
-              Save path
-            </span>
-            <Input.Input
-              type="text"
-              className="input-default"
-              value={localOption.savePath}
-              placeholder="Path for captured images"
-              readOnly
-            />
-          </label>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-xs text-text-soft">
-              Remember these settings for this workspace?
-            </span>
-            <Switch
-              current={rememberMode}
-              onChanged={value => setRememberSettings(value === 'remember')}
-              options={[
-                { name: 'This session', value: 'session' },
-                { name: 'Remember', value: 'remember' },
-              ]}
-            />
-          </div>
-        </section>
-
-        <div className="flex justify-end gap-2">
-          <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
-            Cancel
+          <Button type="button" variant="ghost" className="justify-start" onClick={handleAddPreset}>
+            + Add preset
           </Button>
-          <Button
-            type="button"
-            variant="primary"
-            onClick={handleConfirm}
-            disabled={submitting || !selectedCount}
-          >
-            {submitting ? 'Starting…' : 'Start Croquis'}
-          </Button>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <div>
+              <h2 className="text-lg font-semibold">Start Croquis session</h2>
+              <p className="mt-1 text-sm text-text-soft">
+                {selectedCount === 1
+                  ? '1 image selected'
+                  : `${selectedCount.toLocaleString()} images selected`}
+              </p>
+            </div>
+            <div className="rounded-md border border-border px-2 py-1 text-xs text-text-soft">
+              {activePreset.name}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <section className="space-y-2">
+              <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Window size
+              </header>
+              <div className="flex flex-wrap gap-2">
+                {WINDOW_PRESETS.map(preset => {
+                  const isActive =
+                    (preset.width ?? '') === windowWidth && (preset.height ?? '') === windowHeight;
+                  return (
+                    <Button
+                      key={preset.label}
+                      type="button"
+                      variant="toggle"
+                      active={isActive}
+                      onClick={() => handleWindowPresetClick(preset)}
+                    >
+                      {preset.label}
+                    </Button>
+                  );
+                })}
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                    Width
+                  </span>
+                  <Input.Input
+                    type="number"
+                    min={0}
+                    inputMode="numeric"
+                    className="input-default"
+                    value={windowWidth}
+                    placeholder="e.g. 1280"
+                    onChange={handleWindowDimensionChange('width')}
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                    Height
+                  </span>
+                  <Input.Input
+                    type="number"
+                    min={0}
+                    inputMode="numeric"
+                    className="input-default"
+                    value={windowHeight}
+                    placeholder="e.g. 720"
+                    onChange={handleWindowDimensionChange('height')}
+                  />
+                </label>
+              </div>
+            </section>
+
+            <section className="space-y-2">
+              <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Timer
+              </header>
+              <div className="flex flex-wrap gap-2">
+                {TIMER_PRESETS.map(preset => (
+                  <Button
+                    key={preset.label}
+                    type="button"
+                    variant="toggle"
+                    active={activeTimerSeconds === preset.seconds}
+                    onClick={() => handleTimerPresetClick(preset.seconds)}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+              </div>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                  Seconds per pose
+                </span>
+                <Input.Input
+                  type="text"
+                  inputMode="numeric"
+                  className="input-default"
+                  value={timerInput}
+                  placeholder="e.g. 1m 30s"
+                  onFocus={handleTimerInputFocus}
+                  onBlur={handleTimerInputBlur}
+                  onChange={handleTimerInputChange}
+                  onKeyDown={handleTimerInputKeyDown}
+                  spellCheck={false}
+                />
+              </label>
+              <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Pose control
+              </header>
+              <Switch
+                current={skipMode}
+                onChanged={value => handleSkipModeChange((value as 'manual' | 'auto') ?? 'manual')}
+                options={[
+                  { name: 'Manual', value: 'manual' },
+                  { name: 'Auto skip', value: 'auto' },
+                ]}
+              />
+            </section>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <section className="space-y-2">
+              <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Session options
+              </header>
+              <div className="flex flex-wrap gap-2">
+                {skipMode === 'manual' && (
+                  <Button
+                    type="button"
+                    variant="toggle"
+                    active={activeOption.isCapture}
+                    onClick={() => handleToggleOption('isCapture')}
+                  >
+                    Capture reference
+                  </Button>
+                )}
+                <Button
+                  type="button"
+                  variant="toggle"
+                  active={activeOption.isGray}
+                  onClick={() => handleToggleOption('isGray')}
+                >
+                  Grayscale
+                </Button>
+                <Button
+                  type="button"
+                  variant="toggle"
+                  active={activeOption.isShuffle}
+                  onClick={() => handleToggleOption('isShuffle')}
+                >
+                  Shuffle order
+                </Button>
+              </div>
+            </section>
+
+            <section className="space-y-2">
+              <header className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                Saving
+              </header>
+              <label
+                className="flex cursor-pointer flex-col gap-1 text-sm"
+                onClick={async () => {
+                  const result = await pickerOpen({ directory: true });
+                  if (!result) return;
+                  handleSavePathChange(result);
+                }}
+              >
+                <span className="text-xs font-semibold uppercase tracking-wide text-text-soft">
+                  Save path
+                </span>
+                <Input.Input
+                  type="text"
+                  className="input-default"
+                  value={activeOption.savePath}
+                  placeholder="Path for captured images"
+                  readOnly
+                />
+              </label>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-xs text-text-soft">Remember for this workspace?</span>
+                <Switch
+                  current={rememberMode}
+                  onChanged={value => {
+                    markInteracted();
+                    setRememberSettings(value === 'remember');
+                  }}
+                  options={[
+                    { name: 'Session only', value: 'session' },
+                    { name: 'Remember', value: 'remember' },
+                  ]}
+                />
+              </div>
+            </section>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              onClick={handleConfirm}
+              disabled={submitting || !selectedCount}
+            >
+              {submitting ? 'Starting…' : 'Start Croquis'}
+            </Button>
+          </div>
         </div>
       </div>
     </Modal>

--- a/apps/desktop/src/features/croquis/lib/preferences.ts
+++ b/apps/desktop/src/features/croquis/lib/preferences.ts
@@ -1,0 +1,101 @@
+import { CroquisOption, CroquisPreferences, CroquisPreset } from '@tgim/types/croquis';
+
+const generatePresetId = (): string => {
+  const cryptoApi = globalThis.crypto;
+  if (typeof cryptoApi?.randomUUID === 'function') {
+    return cryptoApi.randomUUID();
+  }
+  return `preset-${Math.random().toString(36).slice(2, 10)}`;
+};
+
+export const createDefaultCroquisOption = (): CroquisOption => ({
+  window: {
+    width: null,
+    height: null,
+  },
+  auto: {
+    isSkip: false,
+  },
+  timer: {
+    maxTime: 60,
+  },
+  isCapture: false,
+  savePath: '',
+  isGray: false,
+  isShuffle: false,
+});
+
+export const normaliseCroquisOption = (option?: CroquisOption | null): CroquisOption => {
+  const fallback = createDefaultCroquisOption();
+  const next = option ?? fallback;
+
+  const maxTimeRaw = next.timer?.maxTime;
+  const maxTimeValue = Number.isFinite(maxTimeRaw)
+    ? Math.max(0, Math.round(maxTimeRaw as number))
+    : fallback.timer.maxTime;
+
+  return {
+    window: {
+      width: next.window?.width ?? null,
+      height: next.window?.height ?? null,
+    },
+    auto: {
+      isSkip: next.auto?.isSkip ?? false,
+    },
+    timer: {
+      maxTime: maxTimeValue,
+    },
+    isCapture: next.isCapture ?? false,
+    savePath: next.savePath ?? '',
+    isGray: next.isGray ?? false,
+    isShuffle: next.isShuffle ?? false,
+  };
+};
+
+const resolvePresetName = (name: string | undefined, index: number): string => {
+  const trimmed = name?.trim();
+  if (trimmed) return trimmed;
+  return `Preset ${index + 1}`;
+};
+
+export const createPreset = (
+  name: string,
+  option?: CroquisOption | null,
+  fallbackIndex = 0,
+): CroquisPreset => ({
+  id: generatePresetId(),
+  name: resolvePresetName(name, fallbackIndex),
+  option: normaliseCroquisOption(option),
+});
+
+export const createDefaultCroquisPreferences = (): CroquisPreferences => {
+  const preset = createPreset('Preset 1', createDefaultCroquisOption());
+  return {
+    presets: [preset],
+    activePresetId: preset.id,
+  };
+};
+
+export const normaliseCroquisPreferences = (
+  preferences?: CroquisPreferences | null,
+): CroquisPreferences => {
+  const rawPresets = preferences?.presets ?? [];
+  const presets = rawPresets.length
+    ? rawPresets.map((preset, index) => ({
+        id: preset?.id ?? generatePresetId(),
+        name: resolvePresetName(preset?.name, index),
+        option: normaliseCroquisOption(preset?.option),
+      }))
+    : createDefaultCroquisPreferences().presets;
+
+  const fallbackActiveId = presets[0]?.id ?? createPreset('Preset 1').id;
+  const requestedActiveId = preferences?.activePresetId;
+  const activePresetId = presets.some(preset => preset.id === requestedActiveId)
+    ? (requestedActiveId as string)
+    : fallbackActiveId;
+
+  return {
+    presets,
+    activePresetId,
+  };
+};

--- a/apps/desktop/src/features/main/panel/panels/GridView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GridView.tsx
@@ -10,10 +10,11 @@ import { useThumbnails } from '../../../../hooks';
 import Masonry from 'react-masonry-css';
 import { FixedSizeGrid as WindowGrid, GridChildComponentProps } from 'react-window';
 import { Button } from '@tgim/ui';
-import { CroquisOption } from '@tgim/types/croquis';
+import { CroquisPreferences } from '@tgim/types/croquis';
 import CroquisStartModal, {
   CroquisStartModalConfirmPayload,
 } from '../../../croquis/CroquisStartModal';
+import { createDefaultCroquisPreferences } from '../../../croquis/lib/preferences';
 import ThumbnailStorageModal from '../../../file/modal/ThumbnailStorageModal';
 
 /* ---------------------------------------------
@@ -74,16 +75,6 @@ const SIZES: Size[] = ['small', 'medium', 'large'];
 const LAYOUTS: Layout[] = ['grid', 'masonry'];
 const MAX_ITEMS_PER_REQ = 100;
 const INITIAL_FETCH_COUNT = 50;
-
-const createDefaultCroquisOption = (): CroquisOption => ({
-  window: { width: null, height: null },
-  auto: { isSkip: true },
-  timer: { maxTime: 1000 },
-  isCapture: false,
-  savePath: '',
-  isGray: false,
-  isShuffle: false,
-});
 
 // Debounce Hook (unchanged)
 function useDebouncedEffect(fn: () => void, deps: React.DependencyList, delay: number) {
@@ -228,10 +219,10 @@ const GridView: React.FC<Props> = ({ gridData }) => {
   }, [images]);
 
   const [croquisModalOpen, setCroquisModalOpen] = useState(false);
-  const [croquisOption, setCroquisOption] = useState<CroquisOption>(() =>
-    createDefaultCroquisOption(),
+  const [croquisPreferences, setCroquisPreferences] = useState<CroquisPreferences>(() =>
+    createDefaultCroquisPreferences(),
   );
-  const [rememberCroquisOption, setRememberCroquisOption] = useState(false);
+  const [rememberCroquisOption, setRememberCroquisOption] = useState(true);
   const [storageModalOpen, setStorageModalOpen] = useState(false);
 
   const selectedCount = selected.size;
@@ -255,8 +246,8 @@ const GridView: React.FC<Props> = ({ gridData }) => {
   }, []);
 
   const handleCroquisConfirm = useCallback(
-    ({ option, remember }: CroquisStartModalConfirmPayload) => {
-      setCroquisOption(option);
+    ({ preferences, remember }: CroquisStartModalConfirmPayload) => {
+      setCroquisPreferences(preferences);
       setRememberCroquisOption(remember);
       clearSelection();
     },
@@ -493,7 +484,7 @@ const GridView: React.FC<Props> = ({ gridData }) => {
       </div>
       <CroquisStartModal
         open={croquisModalOpen && selectedCount > 0}
-        option={croquisOption}
+        preferences={croquisPreferences}
         remember={rememberCroquisOption}
         imageHashes={selectedHashes}
         moaId={moaId}

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -10,6 +10,7 @@ import {
 } from '@tgim/types/file';
 import {
   CroquisOption,
+  CroquisPreferences,
   CroquisSession,
   CroquisStartPayload,
   CroquisStartResponse,
@@ -100,9 +101,9 @@ const croquisIpc = {
     const response = await invoke('load_croquis_session', { sessionId });
     return (response as CroquisSession | null) ?? null;
   },
-  loadOption: async (moaId: string): Promise<CroquisOption | null> => {
+  loadPreferences: async (moaId: string): Promise<CroquisPreferences | null> => {
     const response = await invoke('load_croquis_option', { moaId });
-    return (response as CroquisOption | null) ?? null;
+    return (response as CroquisPreferences | null) ?? null;
   },
 };
 

--- a/packages/types/src/croquis.ts
+++ b/packages/types/src/croquis.ts
@@ -21,11 +21,23 @@ export interface CroquisOption {
   isShuffle: boolean;
 }
 
+export interface CroquisPreset {
+  id: string;
+  name: string;
+  option: CroquisOption;
+}
+
+export interface CroquisPreferences {
+  presets: CroquisPreset[];
+  activePresetId: string;
+}
+
 export interface CroquisStartPayload {
   moaId: string;
   option: CroquisOption;
   imageHashes: string[];
   saveOption?: boolean;
+  preferences?: CroquisPreferences;
 }
 
 export interface CroquisSessionImage {


### PR DESCRIPTION
## Summary
- add reusable croquis preferences helper with preset utilities
- redesign Croquis start modal with preset tabs, timer presets, and formatted input
- track croquis preferences in GridView and persist through backend/IPCs
- extend backend models and services to save/load croquis presets alongside options

## Testing
- pnpm format:write *(pass)*
- pnpm lint:check *(fails: missing @eslint/js due to unavailable registry access)*
- pnpm --filter @grim/desktop build *(fails: node_modules missing because pnpm install cannot reach registry)*
- cargo fmt --all *(pass with nightly warnings)*
- cargo clippy --all-targets -- -D warnings *(fails: crates.io unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d28bc44108832e832b4866c53b8f29