### PR TITLE
Normalize IPC payload casing for the renderer

### DIFF
--- a/apps/desktop/src/features/croquis/CroquisStartModal.tsx
+++ b/apps/desktop/src/features/croquis/CroquisStartModal.tsx
@@ -337,7 +337,7 @@ const CroquisStartModal: React.FC<CroquisStartModalProps> = ({
     void (async () => {
       try {
         const moas = await ipc.moa.loadMoas();
-        const target = moas.find(moa => moa.moa_id === moaId);
+        const target = moas.find(moa => moa.moaId === moaId);
         if (!target) return;
         const defaultPath = await join(target.path, target.name, 'croquis');
         if (cancelled) return;

--- a/apps/desktop/src/features/main/Main.tsx
+++ b/apps/desktop/src/features/main/Main.tsx
@@ -17,6 +17,7 @@ import PanelContainer from './panel/Container';
 import { ThumbResSpec } from '@tgim/types/file';
 import useThumbStore from '@tgim/stores/thumbStore';
 import { useTheme } from '../../theme/ThemeProvider';
+import { convertKeysToCamel } from '@tgim/utils/object';
 
 interface LayoutPorps {
   layoutId: string;
@@ -168,8 +169,9 @@ const Main: React.FC = () => {
     let unlisten: (() => void) | undefined;
     const initListener = async () => {
       unlisten = await listen<{ items: ThumbResSpec[] }>('thumbnails://created', event => {
-        event.payload.items.forEach(item => {
-          upsertThumb(item.thumb_key, {
+        const payload = convertKeysToCamel(event.payload) as { items: ThumbResSpec[] };
+        payload.items.forEach(item => {
+          upsertThumb(item.thumbKey, {
             status: 'ready',
             url: item.url,
             updatedAt: Date.now(),

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -70,7 +70,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     as();
   }, [moaId]);
   const transformDataToGraphData = useCallback((graphData: GraphResponse): GraphData => {
-    setRootNodeId(graphData.root_node_id);
+    setRootNodeId(graphData.rootNodeId);
 
     const nodesMap: Record<string, Node> = {};
     graphData.nodes.forEach(node => {
@@ -78,10 +78,10 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     });
     const connectionsMap: Record<string, Connection[]> = {};
     graphData.connections.forEach(connection => {
-      if (!connectionsMap[connection.src_node_id]) {
-        connectionsMap[connection.src_node_id] = [];
+      if (!connectionsMap[connection.srcNodeId]) {
+        connectionsMap[connection.srcNodeId] = [];
       }
-      connectionsMap[connection.src_node_id].push(connection);
+      connectionsMap[connection.srcNodeId].push(connection);
     });
 
     const nodes: GraphNode[] = [];
@@ -89,7 +89,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
 
     const getGraphNodeData = (node: Node, graphNodeId?: string): GraphNode => {
       const defaultSize = 14;
-      const nodeSize = node.id == graphData.root_node_id ? defaultSize * 1.6 : defaultSize;
+      const nodeSize = node.id == graphData.rootNodeId ? defaultSize * 1.6 : defaultSize;
       if (!graphNodeId) graphNodeId = createNewId();
 
       if (node.kind == NodeKind.File && node.data['File']) {
@@ -105,10 +105,10 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         return {
           id: graphNodeId,
           nodeId: node.id,
-          label: data.file_name ?? 'file',
+          label: data.fileName ?? 'file',
           size: nodeSize,
           type: type,
-          hash: data.xxh3_64,
+          hash: data.xxh364,
         };
       } else if (node.kind == NodeKind.Folder && node.data['Folder']) {
         let data = node.data['Folder'];
@@ -116,7 +116,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         return {
           id: graphNodeId,
           nodeId: node.id,
-          label: data.folder_name ?? 'folder',
+          label: data.folderName ?? 'folder',
           size: nodeSize,
           type: 'folder',
         };
@@ -159,7 +159,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         const node = nodesMap[origId];
         const newNode = getGraphNodeData(node, newId);
         newNode.depth = depth;
-        if (node.id == graphData.root_node_id) {
+        if (node.id == graphData.rootNodeId) {
           newNode.fx = 0;
           newNode.fy = 0;
         }
@@ -185,7 +185,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         for (const connection of connections) {
           if (prevLevel !== 3)
             stack.push({
-              origId: connection.dst_node_id,
+              origId: connection.dstNodeId,
               parentNewId: newId,
               via: connection,
               prevLevel: connection.level,
@@ -196,7 +196,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
 
       // rootNewId must exist because startNodeId produced at least one node
       return rootNewId!;
-    })(graphData.root_node_id, 99);
+    })(graphData.rootNodeId, 99);
 
     return {
       nodes,
@@ -204,7 +204,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     };
   }, []);
   const transformDataToGridData = useCallback(async (data: GraphResponse): Promise<GridData> => {
-    const items = data.nodes.filter(node => node.id !== data.root_node_id);
+    const items = data.nodes.filter(node => node.id !== data.rootNodeId);
     const imageItems: ImageItem[] = [];
     items.forEach(item => {
       if (item.kind == NodeKind.File && item.data['File']) {
@@ -213,10 +213,10 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         imageItems.push({
           id: createNewId(),
           nodeId: item.id,
-          name: data.file_name,
+          name: data.fileName,
           type: data.kind,
           size: data.size,
-          hash: data.xxh3_64,
+          hash: data.xxh364,
         });
       }
     });

--- a/apps/desktop/src/features/moa/layout/ManageMoaSidebar.tsx
+++ b/apps/desktop/src/features/moa/layout/ManageMoaSidebar.tsx
@@ -25,7 +25,7 @@ const MoaIcon = () => (
 
 // Sidebar for switching between existing MOAs and language preferences.
 const ManageMoaSideBar: React.FC = () => {
-  const [moas, setMoas] = useState<{ name: string; path: string; moa_id: string }[]>([]);
+  const [moas, setMoas] = useState<{ name: string; path: string; moaId: string }[]>([]);
 
   const { t, i18n } = useTranslation(['common', 'moa']);
 
@@ -64,7 +64,10 @@ const ManageMoaSideBar: React.FC = () => {
       style={{ WebkitAppRegion: 'drag', width: '300px' } as React.CSSProperties}
     >
       {/* Item list */}
-      <div className="flex flex-col gap-1 px-4" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+      <div
+        className="flex flex-col gap-1 px-4"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
         {moas.length === 0 ? (
           <div className="mt-6 rounded-lg border border-dashed border-border-sidebar bg-surface-muted px-4 py-6 text-sm text-text-soft">
             {t('moa:empty_recent', { defaultValue: '최근에 연 보관함이 없습니다.' })}
@@ -76,7 +79,7 @@ const ManageMoaSideBar: React.FC = () => {
                 variant="list-item"
                 key={moa.name + moa.path}
                 onClick={() => {
-                  void handleMoaClick(moa.moa_id);
+                  void handleMoaClick(moa.moaId);
                 }}
                 className="flex items-start justify-between rounded-lg px-3 py-2 transition-colors"
               >

--- a/apps/desktop/src/lib/ipc.ts
+++ b/apps/desktop/src/lib/ipc.ts
@@ -19,6 +19,7 @@ import {
   CroquisStartPayload,
   CroquisStartResponse,
 } from '@tgim/types/croquis';
+import { convertKeysToCamel } from '@tgim/utils/object';
 
 const appWindow = getCurrentWindow();
 
@@ -43,22 +44,28 @@ const moaIpc = {
       path: string;
       moa_id: string;
     }[];
-    return response;
+    return convertKeysToCamel(response) as { name: string; path: string; moaId: string }[];
   },
   createMoa: async (data: { name: string; path: string }) => {
     const response = (await invoke('create_moa', { moa: data })) as {
       name: string;
       path: string;
-      moaId: string;
+      moa_id: string;
+      last_opened_at?: number | null;
     };
-    return response;
+    return convertKeysToCamel(response) as {
+      name: string;
+      path: string;
+      moaId: string;
+      lastOpenedAt?: number | null;
+    };
   },
   openMoa: async (moaId: string) => {
     await invoke('open_moa', { moaId });
   },
   bootsrapMoa: async (moaId: string): Promise<GraphResponse> => {
     const response = (await invoke('bootstrap_moa', { moaId })) as GraphResponse;
-    return response;
+    return convertKeysToCamel(response) as GraphResponse;
   },
 };
 
@@ -68,18 +75,18 @@ const graphIpc = {
   },
   getGraphOne: async (moaId: string, nodeId: string): Promise<GraphResponse> => {
     const response = await invoke('get_graph_one', { moaId, nodeId });
-    return response as GraphResponse;
+    return convertKeysToCamel(response) as GraphResponse;
   },
 };
 
 const fileIpc = {
   getThumbnails: async (moaId: string, data: ThumbRequest) => {
     const response = await invoke('get_thumbnails', { data, moaId });
-    return response as ThumbResponse;
+    return convertKeysToCamel(response) as ThumbResponse;
   },
   previewFolderImport: async (path: string): Promise<FolderPreview> => {
     const response = await invoke('preview_folder_import', { path });
-    return response as FolderPreview;
+    return convertKeysToCamel(response) as FolderPreview;
   },
   syncFolder: async (moaId: string, virtualNodeId: string) => {
     await invoke('sync_folder_mount', { moaId, virtualNodeId });
@@ -96,7 +103,7 @@ const fileIpc = {
 const thumbnailIpc = {
   getUsage: async (): Promise<ThumbnailUsage> => {
     const response = await invoke('get_thumbnail_usage');
-    return response as ThumbnailUsage;
+    return convertKeysToCamel(response) as ThumbnailUsage;
   },
   clearDerived: async () => {
     await invoke('clear_thumbnail_cache');
@@ -109,15 +116,15 @@ const thumbnailIpc = {
 const croquisIpc = {
   startSession: async (payload: CroquisStartPayload): Promise<CroquisStartResponse> => {
     const response = await invoke('start_croquis_session', { payload });
-    return response as CroquisStartResponse;
+    return convertKeysToCamel(response) as CroquisStartResponse;
   },
   loadSession: async (sessionId: string): Promise<CroquisSession | null> => {
     const response = await invoke('load_croquis_session', { sessionId });
-    return (response as CroquisSession | null) ?? null;
+    return (convertKeysToCamel(response) as CroquisSession | null) ?? null;
   },
   loadPreferences: async (moaId: string): Promise<CroquisPreferences | null> => {
     const response = await invoke('load_croquis_option', { moaId });
-    return (response as CroquisPreferences | null) ?? null;
+    return (convertKeysToCamel(response) as CroquisPreferences | null) ?? null;
   },
   openCaptureOverlay: async (payload: { sessionId: string; moaId: string; hash: string }) => {
     await invoke('open_croquis_capture_overlay', { payload });

--- a/packages/hooks/src/useThumbnails.ts
+++ b/packages/hooks/src/useThumbnails.ts
@@ -95,7 +95,7 @@ export function useThumbnails({ moaId, maxBatchSize = DEFAULT_MAX_BATCH }: UseTh
           const response = await ipc.file.getThumbnails(moaId, { items: chunk });
           response.items.forEach(item => {
             item.specs.forEach(spec => {
-              const key = spec.thumb_key;
+              const key = spec.thumbKey;
               if (!key) return;
 
               switch (spec.status) {
@@ -103,7 +103,7 @@ export function useThumbnails({ moaId, maxBatchSize = DEFAULT_MAX_BATCH }: UseTh
                   upsertThumb(key, { status: 'ready', url: spec.url });
                   break;
                 case ThumbStatus.Error:
-                  upsertThumb(key, { status: 'error', error: spec.error_msg });
+                  upsertThumb(key, { status: 'error', error: spec.errorMsg });
                   break;
                 default:
                   upsertThumb(key, { status: 'pending' });

--- a/packages/stores/src/fileTreeStore.ts
+++ b/packages/stores/src/fileTreeStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { FileTreeData, GraphResponse, NodeFolder, NodeKind, RelationType } from '@tgim/types/index';
-import { convertKeysToCamel, snakeToCamel } from '@tgim/utils/object';
+import { convertKeysToCamel } from '@tgim/utils/object';
 
 interface FileTreeState {
   // current tree data
@@ -175,7 +175,7 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
 
       nodeMap.set(n.id, {
         id: n.id,
-        name: folderData?.folder_name ?? '',
+        name: folderData?.folderName ?? '',
         icon: 'folder',
         type: NodeKind.Folder,
         children: [],
@@ -190,8 +190,8 @@ const useFileTreeStore = create<FileTreeState>((set, get) => ({
     for (const conn of connections) {
       if (conn.kind !== RelationType.ChildFolder) continue;
 
-      const parent = nodeMap.get(conn.src_node_id);
-      const child = nodeMap.get(conn.dst_node_id);
+      const parent = nodeMap.get(conn.srcNodeId);
+      const child = nodeMap.get(conn.dstNodeId);
 
       if (!parent || !child) continue;
       if (parent.id === child.id) continue;

--- a/packages/types/src/file.ts
+++ b/packages/types/src/file.ts
@@ -60,9 +60,9 @@ export interface ThumbRequest {
 export interface ThumbResSpec {
   status: ThumbStatus;
   url?: string;
-  thumb_key: string;
+  thumbKey: string;
   enqueued: boolean;
-  error_msg?: string;
+  errorMsg?: string;
 }
 
 export interface ThumbResInfo {

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -3,7 +3,7 @@ import { FileType, FolderHealthState, FolderMountState } from './file';
 export interface GraphResponse {
   nodes: Node[];
   connections: Connection[];
-  root_node_id: string;
+  rootNodeId: string;
 }
 
 export interface GraphData {
@@ -39,9 +39,9 @@ export interface GraphConnection {
 
 export interface Connection {
   id: string;
-  src_node_id: string;
-  dst_node_id: string;
-  kind_rule_id: string;
+  srcNodeId: string;
+  dstNodeId: string;
+  kindRuleId: string;
   kind: RelationType;
   level: number;
 }
@@ -53,8 +53,8 @@ export interface Node {
     ['File']?: NodeFile;
     ['Folder']?: NodeFolder;
   };
-  created_at: string;
-  updated_at: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export enum NodeKind {
@@ -63,20 +63,20 @@ export enum NodeKind {
 }
 
 export interface NodeFolder {
-  folder_id: string;
-  node_id: string;
-  folder_name: string | null;
+  folderId: string;
+  nodeId: string;
+  folderName: string | null;
   mounts?: FolderMountState[];
   health?: FolderHealthState;
 }
 
 export interface NodeFile {
-  file_id: string;
-  node_id: string;
+  fileId: string;
+  nodeId: string;
   sha256: string | null;
-  xxh3_64: string;
+  xxh364: string;
   kind: FileType;
-  file_name: string;
+  fileName: string;
   size: number;
 }
 

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,5 +1,5 @@
 export const snakeToCamel = (str: string): string => {
-  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+  return str.replace(/_([a-z0-9])/g, (_, letter: string) => letter.toUpperCase());
 };
 
 export function convertKeysToCamel<T>(obj: T): any {


### PR DESCRIPTION
## Summary
- convert IPC responses to camelCase via the shared key conversion helper and update graph/thumbnail TypeScript types
- update React stores and panels to consume camelCase graph data and thumbnail payloads
- normalize Moa metadata usage and extend snakeToCamel to handle numeric suffixes

## Testing
- pnpm exec prettier --write apps/desktop/src/features/croquis/CroquisStartModal.tsx apps/desktop/src/features/main/Main.tsx apps/desktop/src/features/main/panel/Panel.tsx apps/desktop/src/features/moa/layout/ManageMoaSidebar.tsx apps/desktop/src/lib/ipc.ts packages/hooks/src/useThumbnails.ts packages/stores/src/fileTreeStore.ts packages/types/src/file.ts packages/types/src/graph.ts packages/utils/src/object.ts
- pnpm lint:check *(fails: missing @eslint/js because the registry returns 403 in this environment)*
- pnpm --filter @grim/desktop build *(fails: workspace dependencies such as React are unavailable without registry access)*
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: crates.io index returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a7fee9e8832e8be7388204a6abe4