### PR TITLE
Store Moa paths relative to executable

### DIFF
--- a/apps/desktop/src-tauri/src/db/repository/file_repository.rs
+++ b/apps/desktop/src-tauri/src/db/repository/file_repository.rs
@@ -232,9 +232,9 @@ impl FileRepository {
                 (id, virtual_node_id, real_folder_id, created_at, enabled, priority, recursive, sync_enabled, suppress_warnings)
             VALUES
                 (?1, ?2, ?3, ?4, 1, 0, 1, 0, 0)
-            ON CONFLICT(virtual_node_id, real_folder_id) DO NOTHING; 
+            ON CONFLICT(virtual_node_id, real_folder_id) DO NOTHING;
         "#,
-            mount_id, 
+            mount_id,
             virtual_node_id,
             real_folder_id,
             now

--- a/apps/desktop/src-tauri/src/services/moa_services.rs
+++ b/apps/desktop/src-tauri/src/services/moa_services.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::ErrorKind, sync::RwLock};
+use std::{collections::HashMap, io::ErrorKind, path::Path, sync::RwLock};
 
 use anyhow::{anyhow, Context, Result};
 use once_cell::sync::Lazy;
@@ -65,6 +65,12 @@ pub async fn load_moas(app: &tauri::AppHandle) -> Result<Vec<Moa>> {
 
     let mut moas = serde_json::from_str::<Vec<Moa>>(&content)
         .context("Failed to parse stored moa list")?;
+
+    for moa in &mut moas {
+        let absolute_path =
+            path_utils::to_executable_absolute_path(Path::new(&moa.path));
+        moa.path = absolute_path.to_string_lossy().to_string();
+    }
     moas.sort_by(|a, b| b.last_opened_at.cmp(&a.last_opened_at));
 
     let mut moa_data = MOA_DATA.write().unwrap();
@@ -86,8 +92,19 @@ pub async fn load_latest_moas(app: &tauri::AppHandle) -> Result<Option<Moa>> {
 pub async fn save_moas(app: &tauri::AppHandle, moas: &[Moa]) -> Result<()> {
     let moa_file_path = path_utils::get_moa_file_path(app);
 
-    let file_content =
-        serde_json::to_string(moas).context("Failed to serialize moas")?;
+    let stored_moas: Vec<Moa> = moas
+        .iter()
+        .cloned()
+        .map(|mut moa| {
+            let relative_path =
+                path_utils::to_executable_relative_path(Path::new(&moa.path));
+            moa.path = relative_path.to_string_lossy().to_string();
+            moa
+        })
+        .collect();
+
+    let file_content = serde_json::to_string(&stored_moas)
+        .context("Failed to serialize moas")?;
 
     if let Some(parent) = moa_file_path.parent() {
         fs::create_dir_all(parent).await.with_context(|| {

--- a/apps/desktop/src-tauri/src/utils/path_utils.rs
+++ b/apps/desktop/src-tauri/src/utils/path_utils.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tauri::{path::BaseDirectory, AppHandle, Manager};
 
 /// Compute the on-disk path that stores the persisted Moa list.
@@ -42,4 +42,94 @@ pub fn concat_paths(paths: &[PathBuf]) -> PathBuf {
         result.push(path);
     }
     result
+}
+
+/// Resolve the directory that contains the currently running executable.
+pub fn get_executable_dir() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(normalize_path))
+        .or_else(|| std::env::current_dir().ok().map(normalize_path))
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Convert an absolute path into a path relative to the executable directory.
+/// Returns the original path if a relative representation cannot be produced
+/// (for example, when the paths live on different Windows drives).
+pub fn to_executable_relative_path<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let normalized = normalize_path(path);
+    if normalized.is_relative() {
+        return normalized;
+    }
+
+    let executable_dir = get_executable_dir();
+    diff_paths(&normalized, &executable_dir).unwrap_or(normalized)
+}
+
+/// Convert a path relative to the executable directory into an absolute path.
+/// Absolute inputs are returned as-is after normalization.
+pub fn to_executable_absolute_path<P>(path: P) -> PathBuf
+where
+    P: AsRef<Path>,
+{
+    let path = path.as_ref();
+    if path.is_absolute() {
+        return normalize_path(path);
+    }
+
+    let executable_dir = get_executable_dir();
+    normalize_path(executable_dir.join(path))
+}
+
+fn diff_paths(path: &Path, base: &Path) -> Option<PathBuf> {
+    let path_components: Vec<_> = path.components().collect();
+    let base_components: Vec<_> = base.components().collect();
+
+    if let (
+        Some(Component::Prefix(path_prefix)),
+        Some(Component::Prefix(base_prefix)),
+    ) = (path_components.first(), base_components.first())
+    {
+        if path_prefix != base_prefix {
+            return None;
+        }
+    } else if matches!(path_components.first(), Some(Component::Prefix(_)))
+        || matches!(base_components.first(), Some(Component::Prefix(_)))
+    {
+        return None;
+    }
+
+    let mut i = 0;
+    while i < path_components.len()
+        && i < base_components.len()
+        && path_components[i] == base_components[i]
+    {
+        i += 1;
+    }
+
+    let mut result = PathBuf::new();
+
+    for component in &base_components[i..] {
+        match component {
+            Component::Normal(_) | Component::ParentDir => result.push(".."),
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+
+    for component in &path_components[i..] {
+        match component {
+            Component::Normal(part) => result.push(part),
+            Component::ParentDir => result.push(".."),
+            Component::CurDir | Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+
+    if result.as_os_str().is_empty() {
+        Some(PathBuf::from("."))
+    } else {
+        Some(result)
+    }
 }


### PR DESCRIPTION
## Summary
- add path utilities to convert Moa workspace paths between executable-relative and absolute forms
- persist Moa metadata with paths relative to the executable and restore them when loading for portability
- clean up trailing whitespace in the repository to allow formatting to pass

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings *(fails: crates.io index fetch blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d65a827b18832e9fccec46ac8c9b5a