### PR TITLE
Pause thumbnail worker when Moa windows close

### DIFF
--- a/apps/desktop/src-tauri/src/app_launcher/grim.rs
+++ b/apps/desktop/src-tauri/src/app_launcher/grim.rs
@@ -1,6 +1,10 @@
-use tauri::WebviewUrl;
+use tauri::{WebviewUrl, WindowEvent};
 #[cfg(target_os = "macos")]
 use tauri_plugin_decorum::WebviewWindowExt;
+
+use crate::services::file_service::job_queue::{
+    register_moa_window, unregister_moa_window,
+};
 
 /// Launch the primary Moa window for the provided workspace identifier.
 pub fn launch_moa(
@@ -34,6 +38,22 @@ pub fn launch_moa(
     let web_builder = web_builder.decorations(false);
 
     let window = web_builder.build().map_err(|e| e.to_string())?;
+
+    tauri::async_runtime::block_on(async {
+        register_moa_window(&moa_id).await;
+    });
+
+    {
+        let event_id = moa_id.clone();
+        window.on_window_event(move |event| {
+            if matches!(event, WindowEvent::Destroyed) {
+                let event_id = event_id.clone();
+                tauri::async_runtime::spawn(async move {
+                    unregister_moa_window(&event_id).await;
+                });
+            }
+        });
+    }
 
     #[cfg(target_os = "macos")]
     window.create_overlay_titlebar().map_err(|e| e.to_string())?;

--- a/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/job_queue.rs
@@ -66,6 +66,30 @@ struct ThumbnailQueue {
     inflight: HashSet<ThumbnailJobKey>,
 }
 
+impl ThumbnailQueue {
+    fn cancel_by_moa(&mut self, moa_id: &str) {
+        let mut removed = HashSet::new();
+
+        for job in self.high.iter().filter(|job| job.moa_id == moa_id) {
+            removed.insert(ThumbnailJobKey {
+                xxhs: job.xxhs.clone(),
+                thumb_key: job.thumb_key.clone(),
+            });
+        }
+
+        for job in self.low.iter().filter(|job| job.moa_id == moa_id) {
+            removed.insert(ThumbnailJobKey {
+                xxhs: job.xxhs.clone(),
+                thumb_key: job.thumb_key.clone(),
+            });
+        }
+
+        self.high.retain(|job| job.moa_id != moa_id);
+        self.low.retain(|job| job.moa_id != moa_id);
+        self.pending.retain(|key| !removed.contains(key));
+    }
+}
+
 #[derive(Default)]
 struct BaseThumbnailQueue {
     queue: VecDeque<BaseThumbnailJob>,
@@ -77,6 +101,7 @@ struct BaseThumbnailQueue {
 pub struct ThumbnailWorkerState {
     pub queue: Mutex<ThumbnailQueue>,
     pub base_queue: Mutex<BaseThumbnailQueue>,
+    pub active_moas: Mutex<HashSet<String>>,
     pub signal: OnceCell<mpsc::Sender<()>>,
 }
 
@@ -85,6 +110,7 @@ impl Default for ThumbnailWorkerState {
         Self {
             queue: Mutex::new(ThumbnailQueue::default()),
             base_queue: Mutex::new(BaseThumbnailQueue::default()),
+            active_moas: Mutex::new(HashSet::new()),
             signal: OnceCell::new(),
         }
     }
@@ -102,9 +128,13 @@ pub async fn enqueue_jobs(mut jobs: Vec<ThumbnailJob>) {
     }
 
     let state = THUMBNAIL_WORKER_STATE.clone();
+    let active_moas = { state.active_moas.lock().await.clone() };
     {
         let mut queue = state.queue.lock().await;
         for job in jobs.drain(..) {
+            if !active_moas.contains(&job.moa_id) {
+                continue;
+            }
             let key: ThumbnailJobKey = (&job).into();
             if queue.pending.contains(&key) || queue.inflight.contains(&key) {
                 continue;
@@ -156,7 +186,7 @@ pub async fn enqueue_base_job(job: BaseThumbnailJob) {
 /// Take the next job from the queue, prioritising high priority jobs.
 pub async fn take_next_job() -> Option<ThumbnailJob> {
     let mut queue = THUMBNAIL_WORKER_STATE.queue.lock().await;
-    let job = queue.high.pop_front().or_else(|| queue.low.pop_front());
+    let job = queue.high.pop_back().or_else(|| queue.low.pop_back());
 
     if let Some(ref job) = job {
         let key: ThumbnailJobKey = job.into();
@@ -177,7 +207,7 @@ pub async fn finish_job(job: &ThumbnailJob) {
 /// Take the next base thumbnail job from the queue.
 pub async fn take_next_base_job() -> Option<BaseThumbnailJob> {
     let mut queue = THUMBNAIL_WORKER_STATE.base_queue.lock().await;
-    let job = queue.queue.pop_front();
+    let job = queue.queue.pop_back();
 
     if let Some(ref job) = job {
         queue.pending.remove(&job.xxhs);
@@ -199,5 +229,33 @@ pub async fn cancel_pending_base_job(hash: &str) {
 
     if queue.pending.remove(hash) {
         queue.queue.retain(|job| job.xxhs != hash);
+    }
+}
+
+/// Mark the provided Moa as having an open window so jobs can be processed.
+pub async fn register_moa_window(moa_id: &str) {
+    let state = THUMBNAIL_WORKER_STATE.clone();
+    {
+        let mut active = state.active_moas.lock().await;
+        if active.insert(moa_id.to_string()) {
+            if let Some(tx) = state.signal.get() {
+                let _ = tx.try_send(());
+            }
+        }
+    }
+}
+
+/// Remove the Moa from the active set and cancel any queued jobs for it.
+pub async fn unregister_moa_window(moa_id: &str) {
+    let state = THUMBNAIL_WORKER_STATE.clone();
+
+    {
+        let mut active = state.active_moas.lock().await;
+        active.remove(moa_id);
+    }
+
+    {
+        let mut queue = state.queue.lock().await;
+        queue.cancel_by_moa(moa_id);
     }
 }

--- a/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/thumbnail.rs
@@ -27,6 +27,7 @@ use super::{
     job_queue::{
         cancel_pending_base_job, enqueue_jobs, finish_base_job, finish_job,
         take_next_base_job, take_next_job, BaseThumbnailJob, ThumbnailJob,
+        THUMBNAIL_WORKER_STATE,
     },
 };
 
@@ -251,6 +252,15 @@ pub async fn worker_loop(app: AppHandle, mut rx: mpsc::Receiver<()>) {
         let _ = rx.recv().await;
 
         loop {
+            let has_active = {
+                let active = THUMBNAIL_WORKER_STATE.active_moas.lock().await;
+                !active.is_empty()
+            };
+
+            if !has_active {
+                break;
+            }
+
             let mut made_progress = false;
 
             if let Some(base_job) = take_next_base_job().await {


### PR DESCRIPTION
## Summary
- switch the thumbnail job queues to LIFO so the newest work is processed first
- track active Moa windows to pause the worker when no Moa is open and drop queued work for closed workspaces
- register and unregister Moa activity in the window launcher so the worker resumes once a Moa window opens again

## Testing
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings *(fails: cannot reach crates.io in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70bb08034832e8ef88ac16af7cc6d