### PR TITLE
Add device-aware storage root mapping and tree bindings

### DIFF
--- a/apps/desktop/src-tauri/migrations/001_init.sql
+++ b/apps/desktop/src-tauri/migrations/001_init.sql
@@ -51,9 +51,19 @@ CREATE INDEX IF NOT EXISTS idx_conn_src_dst    ON connection(src_node_id, dst_no
 CREATE INDEX IF NOT EXISTS idx_conn_src_kind   ON connection(src_node_id, kind_id);
 CREATE INDEX IF NOT EXISTS idx_conn_dst_kind   ON connection(dst_node_id, kind_id);
 
+/* ---------------------------------------- Device registry ------------------------------------------ */
+CREATE TABLE IF NOT EXISTS device (
+  id          TEXT PRIMARY KEY NOT NULL,                        -- uuid
+  device_uuid TEXT NOT NULL UNIQUE,
+  name        TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 /* ---------------------------- Storage roots & mounts (portable across OS) -------------------------- */
 CREATE TABLE IF NOT EXISTS storage_root (
   id            TEXT PRIMARY KEY NOT NULL,                             -- uuid
+  device_id     TEXT NOT NULL REFERENCES device(id) ON DELETE CASCADE,
   platform      TEXT,                                         -- 'windows'|'macos'|'linux'|'unknown'
   stable_id     TEXT NOT NULL,                                -- Volume GUID/UUID or //host/share
   secondary_id  TEXT,
@@ -62,7 +72,7 @@ CREATE TABLE IF NOT EXISTS storage_root (
   is_available  INTEGER DEFAULT 0,                            -- boolean
   created_at    TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
-  UNIQUE(platform, stable_id)
+  UNIQUE(device_id, platform, stable_id)
 );
 
 CREATE TABLE IF NOT EXISTS storage_root_mount (
@@ -88,9 +98,9 @@ CREATE TABLE IF NOT EXISTS scan_session (
 /* -------------------------------- Real folder tree (physical) ------------------------------------- */
 CREATE TABLE IF NOT EXISTS real_folder (
   id                TEXT PRIMARY KEY NOT NULL,                         -- uuid
-  storage_root_id   TEXT REFERENCES storage_root(id) ON DELETE SET NULL,
+  tree_id           TEXT NOT NULL,
   parent_id         TEXT REFERENCES real_folder(id) ON DELETE CASCADE,
-  parent_key        TEXT GENERATED ALWAYS AS (COALESCE(parent_id, '_root_')) STORED,
+  parent_key        TEXT GENERATED ALWAYS AS (COALESCE(parent_id, tree_id)) STORED,
   name              TEXT NOT NULL,                            -- single segment
   name_norm         TEXT NOT NULL,                                     -- lowercased for case-insensitive FS
   root_rel_path     TEXT,                                     -- optional cache
@@ -103,11 +113,21 @@ CREATE TABLE IF NOT EXISTS real_folder (
   created_at        TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at        TEXT NOT NULL DEFAULT (datetime('now')),
 
-  UNIQUE (storage_root_id, parent_key, name_norm)
+  UNIQUE (tree_id, parent_key, name_norm)
 );
 
 CREATE INDEX IF NOT EXISTS idx_real_folder_err    ON real_folder(error_flag);
 CREATE INDEX IF NOT EXISTS idx_real_folder_parent ON real_folder(parent_id);
+
+CREATE TABLE IF NOT EXISTS storage_root_tree (
+  storage_root_id TEXT NOT NULL REFERENCES storage_root(id) ON DELETE CASCADE,
+  tree_id         TEXT NOT NULL,
+  created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (storage_root_id, tree_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_storage_root_tree_tree ON storage_root_tree(tree_id);
 
 /* ---------------------------- File content, paths and binds ------------------------------------ */
 CREATE TABLE IF NOT EXISTS file_content (

--- a/apps/desktop/src-tauri/src/db/repository/device_repository.rs
+++ b/apps/desktop/src-tauri/src/db/repository/device_repository.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use sqlx::{Executor, Sqlite};
+
+use crate::utils::{date::get_now_date, identifier::get_unique_id};
+
+/// Repository utilities for device persistence.
+pub struct DeviceRepository;
+
+impl DeviceRepository {
+    /// Ensure a device row exists for the provided UUID and return its identifier.
+    pub async fn ensure_device<'a, E>(
+        executor: &mut E,
+        device_uuid: &str,
+        device_name: Option<&str>,
+    ) -> Result<String>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let new_id = get_unique_id();
+        let now = get_now_date();
+
+        let device_id = sqlx::query_scalar!(
+            r#"
+            INSERT INTO device
+                (id, device_uuid, name, created_at, updated_at)
+            VALUES
+                (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(device_uuid) DO UPDATE SET
+                name = COALESCE(excluded.name, name),
+                updated_at = excluded.updated_at
+            RETURNING id as "id!: String"
+            "#,
+            new_id,
+            device_uuid,
+            device_name,
+            now,
+            now
+        )
+        .fetch_one(&mut *executor)
+        .await?;
+
+        Ok(device_id)
+    }
+}

--- a/apps/desktop/src-tauri/src/db/repository/file_repository.rs
+++ b/apps/desktop/src-tauri/src/db/repository/file_repository.rs
@@ -420,7 +420,7 @@ impl FileRepository {
     /// Look up a real-folder identifier by normalized path components.
     pub async fn _find_folder_id<'a, E>(
         executor: &mut E,
-        sroot_id: String,
+        tree_id: &str,
         current_parent_id: Option<String>,
         name_norm: String,
     ) -> Result<Option<String>>
@@ -431,9 +431,9 @@ impl FileRepository {
             r#"
             SELECT id AS "id!"
             FROM real_folder
-            WHERE storage_root_id = ?1 AND parent_id IS ?2 AND name_norm = ?3
+            WHERE tree_id = ?1 AND parent_id IS ?2 AND name_norm = ?3
             "#,
-            sroot_id,
+            tree_id,
             current_parent_id,
             name_norm
         )
@@ -441,6 +441,102 @@ impl FileRepository {
         .await?;
 
         Ok(folder_id)
+    }
+
+    pub async fn fetch_tree_id_for_storage_root<'a, E>(
+        executor: &mut E,
+        storage_root_id: &str,
+    ) -> Result<Option<String>>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let tree_id = sqlx::query_scalar!(
+            r#"
+            SELECT tree_id AS "tree_id?: String"
+              FROM storage_root_tree
+             WHERE storage_root_id = ?1
+             ORDER BY updated_at DESC
+             LIMIT 1
+            "#,
+            storage_root_id
+        )
+        .fetch_optional(&mut *executor)
+        .await?;
+
+        Ok(tree_id)
+    }
+
+    pub async fn bind_storage_root_to_tree<'a, E>(
+        executor: &mut E,
+        storage_root_id: &str,
+        tree_id: &str,
+    ) -> Result<()>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let now = crate::utils::date::get_now_date();
+
+        sqlx::query!(
+            r#"
+            INSERT INTO storage_root_tree
+                (storage_root_id, tree_id, created_at, updated_at)
+            VALUES
+                (?1, ?2, ?3, ?3)
+            ON CONFLICT(storage_root_id, tree_id) DO UPDATE SET
+                updated_at = excluded.updated_at
+            "#,
+            storage_root_id,
+            tree_id,
+            now
+        )
+        .execute(&mut *executor)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn fetch_tree_id_for_real_folder<'a, E>(
+        executor: &mut E,
+        real_folder_id: &str,
+    ) -> Result<Option<String>>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let tree_id = sqlx::query_scalar!(
+            r#"
+            SELECT tree_id AS "tree_id?: String"
+              FROM real_folder
+             WHERE id = ?1
+            "#,
+            real_folder_id
+        )
+        .fetch_optional(&mut *executor)
+        .await?;
+
+        Ok(tree_id)
+    }
+
+    pub async fn fetch_storage_root_id_for_tree<'a, E>(
+        executor: &mut E,
+        tree_id: &str,
+    ) -> Result<Option<String>>
+    where
+        for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
+    {
+        let storage_root_id = sqlx::query_scalar!(
+            r#"
+            SELECT storage_root_id AS "storage_root_id?: String"
+              FROM storage_root_tree
+             WHERE tree_id = ?1
+             ORDER BY updated_at DESC
+             LIMIT 1
+            "#,
+            tree_id
+        )
+        .fetch_optional(&mut *executor)
+        .await?;
+
+        Ok(storage_root_id)
     }
 
     /// Create a virtual folder node under the specified parent.
@@ -511,19 +607,19 @@ impl FileRepository {
         let folder_id = sqlx::query_scalar!(
             r#"
             INSERT INTO real_folder
-                (id, storage_root_id, parent_id, name, name_norm, root_rel_path, abs_path_cached, mtime, error_flag, error_msg, created_at, updated_at)
+                (id, tree_id, parent_id, name, name_norm, root_rel_path, abs_path_cached, mtime, error_flag, error_msg, created_at, updated_at)
             VALUES
                 (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'success', NULL, ?9, ?10)
-            ON CONFLICT(storage_root_id, parent_key, name_norm) DO UPDATE SET
-                name        = excluded.name,
-                name_norm   = excluded.name_norm,
-                root_rel_path = excluded.root_rel_path,
+            ON CONFLICT(tree_id, parent_key, name_norm) DO UPDATE SET
+                name           = excluded.name,
+                name_norm      = excluded.name_norm,
+                root_rel_path  = excluded.root_rel_path,
                 abs_path_cached = excluded.abs_path_cached,
-                updated_at  = ?10
+                updated_at     = excluded.updated_at
             RETURNING id as "id!: String"
             "#,
             new_id,
-            folder_info.storage_root_id,
+            folder_info.tree_id,
             folder_info.parent_id,
             folder_info.name,
             folder_info.name_norm,

--- a/apps/desktop/src-tauri/src/db/repository/mod.rs
+++ b/apps/desktop/src-tauri/src/db/repository/mod.rs
@@ -1,6 +1,7 @@
 //! Repository modules encapsulating database access patterns.
 
 pub mod connection_repository;
+pub mod device_repository;
 pub mod file_repository;
 pub mod graph_repository;
 pub mod node_repository;

--- a/apps/desktop/src-tauri/src/db/repository/sroot_repository.rs
+++ b/apps/desktop/src-tauri/src/db/repository/sroot_repository.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use sqlx::{Executor, Sqlite};
 
 use crate::{
+    db::repository::device_repository::DeviceRepository,
     models::file::StorageRootInfo,
     utils::{date::get_now_date, identifier::get_unique_id},
 };
@@ -34,6 +35,7 @@ impl SrootRepository {
     /// Upsert a storage-root row and return its identifier.
     pub async fn upsert_storage_root<'a, E>(
         executor: &mut E,
+        device_id: &str,
         sroot_info: &crate::models::file::StorageRootInfo,
     ) -> Result<String>
     where
@@ -45,10 +47,10 @@ impl SrootRepository {
         let sroot_id = sqlx::query_scalar!(
             r#"
             INSERT INTO storage_root
-                (id, platform, stable_id, secondary_id, kind, label, is_available, created_at, updated_at)
+                (id, device_id, platform, stable_id, secondary_id, kind, label, is_available, created_at, updated_at)
             VALUES
-                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-            ON CONFLICT(platform, stable_id) DO UPDATE SET
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            ON CONFLICT(device_id, platform, stable_id) DO UPDATE SET
                 secondary_id = excluded.secondary_id,
                 kind         = excluded.kind,
                 is_available = excluded.is_available,
@@ -56,6 +58,7 @@ impl SrootRepository {
             RETURNING id as "id!: String"
             "#,
             new_id,
+            device_id,
             sroot_info.platform,
             sroot_info.stable_id,
             sroot_info.secondary_id,
@@ -113,9 +116,17 @@ impl SrootRepository {
     where
         for<'e> &'e mut E: Executor<'e, Database = Sqlite>,
     {
+        let device_id = DeviceRepository::ensure_device(
+            &mut *executor,
+            &sroot_info.device_uuid,
+            sroot_info.device_name.as_deref(),
+        )
+        .await?;
+
         // Ensure StorageRoot exists or create it
         let sroot_id =
-            Self::upsert_storage_root(&mut *executor, sroot_info).await?;
+            Self::upsert_storage_root(&mut *executor, &device_id, sroot_info)
+                .await?;
 
         // Ensure StorageRootMount exists or create/update it
         let _sroot_mount_id = Self::upsert_storage_root_mount(

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -248,6 +248,9 @@ impl From<&str> for OsPlatform {
 /// Metadata describing a discovered storage root.
 #[derive(Debug, Clone, FromRow, Serialize)]
 pub struct StorageRootInfo {
+    pub device_uuid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_name: Option<String>,
     pub platform: OsPlatform,
     pub kind: StorageKind,
     pub stable_id: String,
@@ -606,7 +609,7 @@ impl FileInfo {
 /// Payload used to upsert real-folder records in the database.
 pub struct RealFolderData {
     pub id: String,
-    pub storage_root_id: Option<String>,
+    pub tree_id: String,
     pub parent_id: Option<String>,
     pub name: String,
     pub name_norm: String,

--- a/apps/desktop/src-tauri/src/services/bootstrap_service.rs
+++ b/apps/desktop/src-tauri/src/services/bootstrap_service.rs
@@ -795,7 +795,9 @@ async fn ensure_mounted_volume(moa_id: &str) -> Result<()> {
                    ELSE rtrim($2, '/') || '/' || ltrim(root_rel_path, '/')
                END,
                    updated_at = $3
-             WHERE storage_root_id = $1
+             WHERE tree_id IN (
+                 SELECT tree_id FROM storage_root_tree WHERE storage_root_id = $1
+             )
             "#,
         )
         .bind(rid)
@@ -813,7 +815,9 @@ async fn ensure_mounted_volume(moa_id: &str) -> Result<()> {
                     ELSE rtrim($2, '\') || '\' || ltrim(root_rel_path, '\')
                 END,
                     updated_at = $3
-            WHERE storage_root_id = $1
+            WHERE tree_id IN (
+                SELECT tree_id FROM storage_root_tree WHERE storage_root_id = $1
+            )
             "#,
         )
         .bind(rid)

--- a/apps/desktop/src-tauri/src/services/croquis_service.rs
+++ b/apps/desktop/src-tauri/src/services/croquis_service.rs
@@ -499,12 +499,13 @@ async fn register_capture_in_workspace(
     let sroot_info = storage_root::detect_storage_root(&parent_norm)?;
 
     let mut tx = DB_MANAGER.create_new_tx(&moa_id).await?;
-    let real_folder_id = storage_root::ensure_storage_root_and_real_folder(
+    let ensured_folder = storage_root::ensure_storage_root_and_real_folder(
         &mut tx,
         &sroot_info,
         &parent_norm,
     )
     .await?;
+    let real_folder_id = ensured_folder.real_folder_id.clone();
 
     let file_name = file_path
         .file_name()

--- a/apps/desktop/src-tauri/src/services/file_service/detail.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/detail.rs
@@ -305,12 +305,13 @@ pub async fn link_file_path(
 
     let mut tx = DB_MANAGER.create_new_tx(moa_id).await?;
 
-    let real_folder_id = storage_root::ensure_storage_root_and_real_folder(
+    let ensured_folder = storage_root::ensure_storage_root_and_real_folder(
         &mut tx,
         &storage_info,
         &parent,
     )
     .await?;
+    let real_folder_id = ensured_folder.real_folder_id;
 
     let file_info =
         FileInfo::new(moa_id, &norm_path, real_folder_id, file_name)

--- a/apps/desktop/src-tauri/src/services/file_service/folder.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/folder.rs
@@ -29,7 +29,10 @@ use crate::{
         db::DB_MANAGER,
         storage_root::{self, ensure_storage_root_and_real_folder},
     },
-    utils::{file_utils::file_mtime_epoch, path_utils::normalize_path},
+    utils::{
+        file_utils::file_mtime_epoch, identifier::get_unique_id,
+        path_utils::normalize_path,
+    },
 };
 
 use super::{
@@ -605,9 +608,10 @@ pub async fn first_mount_folder(
     let sroot_info = storage_root::detect_storage_root(&norm_path)?;
 
     let virtual_folder_id = node.id.clone();
-    let real_folder_id =
+    let ensured_root =
         ensure_storage_root_and_real_folder(&mut tx, &sroot_info, &norm_path)
             .await?;
+    let real_folder_id = ensured_root.real_folder_id.clone();
 
     let mount_id = FileRepository::create_virtual_folder_mount(
         tx.as_mut(),
@@ -647,6 +651,7 @@ pub async fn first_mount_folder(
         &moa_id,
         real_folder_id.clone(),
         virtual_folder_id.clone(),
+        ensured_root.storage_root_id.clone(),
         &norm_path,
         true,
         Some(true),
@@ -712,6 +717,25 @@ pub async fn sync_virtual_folder(
     })?;
     let mtime = FileInfo::file_mtime_epoch(&metadata)?;
 
+    let tree_id = FileRepository::fetch_tree_id_for_real_folder(
+        tx.as_mut(),
+        &mount.real_folder_id,
+    )
+    .await?
+    .ok_or_else(|| {
+        anyhow!(
+            "Failed to resolve tree for real folder {}",
+            mount.real_folder_id
+        )
+    })?;
+
+    let storage_root_id =
+        FileRepository::fetch_storage_root_id_for_tree(tx.as_mut(), &tree_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!("No storage root associated with tree {tree_id}")
+            })?;
+
     let extension_filter = ExtensionFilter::new(
         &mount.include_extensions,
         &mount.exclude_extensions,
@@ -723,6 +747,7 @@ pub async fn sync_virtual_folder(
         moa_id,
         mount.real_folder_id.clone(),
         virtual_node_id.to_string(),
+        storage_root_id,
         abs_path.as_path(),
         mount.recursive,
         Some(true),
@@ -791,7 +816,7 @@ pub async fn update_virtual_folder_options(
                 &norm_path,
             )
             .await?;
-            new_real_folder_id = Some(ensured);
+            new_real_folder_id = Some(ensured.real_folder_id);
         }
     }
 
@@ -832,6 +857,7 @@ async fn upsert_folder(
     moa_id: &str,
     parent_real_folder_id: String,
     parent_virtual_folder_id: String,
+    storage_root_id: String,
     abs_dir: &Path,
     recursive: bool,
     make_virtual_folder: Option<bool>,
@@ -849,6 +875,7 @@ async fn upsert_folder(
         moa_id,
         parent_real_folder_id,
         parent_virtual_folder_id,
+        &storage_root_id,
         abs_dir,
         recursive,
         make_virtual_folder,
@@ -875,6 +902,7 @@ async fn upsert_folder_impl(
     moa_id: &str,
     parent_real_folder_id: String,
     parent_virtual_folder_id: String,
+    storage_root_id: &str,
     abs_dir: &Path,
     recursive: bool,
     make_virtual_folder: Option<bool>,
@@ -996,15 +1024,6 @@ async fn upsert_folder_impl(
     }
     metrics.record_tree_scanning(tree_scan_timer.elapsed());
 
-    let sroot_id: String = sqlx::query_scalar(
-        "SELECT storage_root_id FROM real_folder\n                     WHERE id = ?",
-    )
-    .bind(&parent_real_folder_id)
-    .fetch_optional(tx.as_mut())
-    .await
-    .with_context(|| "failed to load storage_root for parent_real_folder_id")?
-    .ok_or_else(|| anyhow!("parent_real_folder_id not found: {}", parent_real_folder_id))?;
-
     if recursive {
         for (entry_path, name, child_allowed) in folder_entries {
             let folder_timer = Instant::now();
@@ -1020,8 +1039,9 @@ async fn upsert_folder_impl(
 
             let normalized = normalize_path(&entry_path);
 
-            let child_real_folder_id =
-                ensure_real_folder(tx, sroot_id.clone(), &normalized).await?;
+            let ensured_child =
+                ensure_real_folder(tx, storage_root_id, &normalized).await?;
+            let child_real_folder_id = ensured_child.real_folder_id;
 
             FileRepository::create_virtual_folder_mount(
                 tx.as_mut(),
@@ -1040,6 +1060,7 @@ async fn upsert_folder_impl(
                 moa_id,
                 child_real_folder_id,
                 child_vf.id,
+                storage_root_id,
                 &entry_path,
                 recursive,
                 Some(make_vf),
@@ -1133,38 +1154,81 @@ async fn upsert_file_entry(
 }
 
 /// Ensure that a real folder record exists for the provided path.
+pub struct RealFolderEnsureState {
+    pub real_folder_id: String,
+    pub tree_id: String,
+}
+
 pub async fn ensure_real_folder(
     tx: &mut Transaction<'_, Sqlite>,
-    sroot_id: String,
+    sroot_id: &str,
     norm_path: &PathBuf,
-) -> Result<String> {
-    let mut current_parent_id: Option<String> = None;
-
-    let mount_path = SrootRepository::fetch_mount_path(tx.as_mut(), &sroot_id)
+) -> Result<RealFolderEnsureState> {
+    let mount_path = SrootRepository::fetch_mount_path(tx.as_mut(), sroot_id)
         .await?
         .ok_or_else(|| anyhow!("Failed to fetch mount path"))?;
 
-    let components_path =
-        if let Ok(sub_path) = norm_path.strip_prefix(&mount_path) {
-            sub_path
-        } else {
-            norm_path
-        };
-
-    let components: Vec<&str> = if components_path.as_os_str().is_empty() {
-        vec![""]
+    let tree_id = if let Some(existing) =
+        FileRepository::fetch_tree_id_for_storage_root(tx.as_mut(), sroot_id)
+            .await?
+    {
+        FileRepository::bind_storage_root_to_tree(
+            tx.as_mut(),
+            sroot_id,
+            &existing,
+        )
+        .await?;
+        existing
     } else {
-        components_path
-            .components()
-            .filter_map(|c| c.as_os_str().to_str())
-            .filter(|s| !s.is_empty())
-            .collect()
+        let new_tree_id = get_unique_id();
+        FileRepository::bind_storage_root_to_tree(
+            tx.as_mut(),
+            sroot_id,
+            &new_tree_id,
+        )
+        .await?;
+        new_tree_id
     };
 
-    let mut rel_path = PathBuf::from("");
-    let mut abs_path = PathBuf::from(&mount_path);
-
+    let mount_path_buf = PathBuf::from(&mount_path);
+    let metadata = fs::metadata(&mount_path_buf).await?;
+    let root_mtime = file_mtime_epoch(&metadata)?;
     let now = crate::utils::date::get_now_date();
+
+    let root_data = RealFolderData {
+        id: String::new(),
+        tree_id: tree_id.clone(),
+        parent_id: None,
+        name: String::new(),
+        name_norm: String::new(),
+        root_rel_path: Some(String::new()),
+        abs_path_cached: Some(mount_path.clone()),
+        mtime: root_mtime,
+        error_flag: crate::config::file::IntegrityCheckResult::Success,
+        error_msg: None,
+        last_seen_scan_id: None,
+        last_seen_at: None,
+        created_at: now.clone(),
+        updated_at: now.clone(),
+    };
+
+    let mut current_parent_id = Some(
+        FileRepository::upsert_real_folder(tx.as_mut(), &root_data).await?,
+    );
+
+    let mut rel_path = PathBuf::new();
+    let mut abs_path = mount_path_buf.clone();
+
+    let components_path = match norm_path.strip_prefix(&mount_path_buf) {
+        Ok(sub_path) => sub_path.to_path_buf(),
+        Err(_) => PathBuf::new(),
+    };
+
+    let components: Vec<&str> = components_path
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .filter(|s| !s.is_empty())
+        .collect();
 
     for component in components {
         abs_path.push(component);
@@ -1175,7 +1239,7 @@ pub async fn ensure_real_folder(
 
         let data = RealFolderData {
             id: String::new(),
-            storage_root_id: Some(sroot_id.to_owned()),
+            tree_id: tree_id.clone(),
             parent_id: current_parent_id.clone(),
             name: component.to_string(),
             name_norm: component.to_lowercase(),
@@ -1194,8 +1258,10 @@ pub async fn ensure_real_folder(
         current_parent_id = Some(id);
     }
 
-    current_parent_id
-        .ok_or_else(|| anyhow!("Failed to create or find real_folder ID"))
+    let real_folder_id = current_parent_id
+        .ok_or_else(|| anyhow!("Failed to create or find real_folder ID"))?;
+
+    Ok(RealFolderEnsureState { real_folder_id, tree_id })
 }
 
 /// Fetch a single active file path for the provided xxHash.

--- a/apps/desktop/src-tauri/src/services/file_service/manual.rs
+++ b/apps/desktop/src-tauri/src/services/file_service/manual.rs
@@ -224,7 +224,7 @@ async fn register_path_with_virtual_folder(
         .await
         .context("failed to open transaction")?;
 
-    let real_folder_id = storage_root::ensure_storage_root_and_real_folder(
+    let ensured_folder = storage_root::ensure_storage_root_and_real_folder(
         &mut tx,
         &sroot_info,
         &parent_norm,
@@ -233,6 +233,7 @@ async fn register_path_with_virtual_folder(
     .with_context(|| {
         format!("failed to ensure real folder for {}", parent_norm.display())
     })?;
+    let real_folder_id = ensured_folder.real_folder_id.clone();
 
     let file_name = normalized
         .file_name()

--- a/apps/desktop/src-tauri/src/services/storage_root.rs
+++ b/apps/desktop/src-tauri/src/services/storage_root.rs
@@ -3,12 +3,71 @@
 use crate::db::repository::sroot_repository::SrootRepository;
 use crate::models::file::{StorageKind, StorageRootInfo};
 use crate::services::file_service::ensure_real_folder;
-use crate::utils::date::get_now_date;
-use crate::utils::path_utils::normalize_path;
-use crate::utils::platform::get_current_platfrom;
-use anyhow::Result;
+use crate::utils::{
+    date::get_now_date, identifier::get_unique_id, path_utils::normalize_path,
+    platform::get_current_platfrom,
+};
+use anyhow::{anyhow, Result};
+use dirs_next::home_dir;
 use sqlx::{Sqlite, Transaction};
-use std::path::PathBuf;
+use std::{env, fs, path::PathBuf};
+use tracing::warn;
+
+/// Result returned when ensuring a storage root and its backing real folder.
+pub struct StorageRootEnsureResult {
+    pub storage_root_id: String,
+    pub real_folder_id: String,
+    pub tree_id: String,
+}
+
+fn detect_device_name() -> Option<String> {
+    let candidates = ["GRIM_DEVICE_NAME", "COMPUTERNAME", "HOSTNAME"];
+    for key in candidates {
+        if let Ok(value) = env::var(key) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn resolve_device_identity() -> Result<(String, Option<String>)> {
+    if let Ok(value) = env::var("GRIM_DEVICE_UUID") {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok((trimmed.to_string(), detect_device_name()));
+        }
+    }
+
+    let device_name = detect_device_name();
+
+    if let Some(home) = home_dir() {
+        let device_dir = home.join(".grim");
+        let device_file = device_dir.join("device_uuid");
+
+        if let Ok(stored) = fs::read_to_string(&device_file) {
+            let trimmed = stored.trim();
+            if !trimmed.is_empty() {
+                return Ok((trimmed.to_string(), device_name));
+            }
+        }
+
+        if let Err(err) = fs::create_dir_all(&device_dir) {
+            warn!("failed to prepare device uuid directory: {err}");
+        } else {
+            let new_uuid = get_unique_id();
+            if let Err(err) = fs::write(&device_file, &new_uuid) {
+                warn!("failed to persist device uuid: {err}");
+                return Ok((new_uuid, device_name));
+            }
+            return Ok((new_uuid, device_name));
+        }
+    }
+
+    Ok((get_unique_id(), device_name))
+}
 
 /// Re-export platform-specific helpers behind a single interface.
 #[cfg(target_os = "macos")]
@@ -522,6 +581,7 @@ pub fn get_mount_paths() -> Result<Vec<PathBuf>> {
 pub fn enumerate_mounted_root() -> Result<Vec<StorageRootInfo>> {
     let mut roots = Vec::new();
     let now_s = get_now_date();
+    let (device_uuid, device_name) = resolve_device_identity()?;
 
     let mount_paths = get_mount_paths()?;
     for mp in mount_paths {
@@ -542,6 +602,8 @@ pub fn enumerate_mounted_root() -> Result<Vec<StorageRootInfo>> {
         let is_available = mp.exists();
 
         roots.push(StorageRootInfo {
+            device_uuid: device_uuid.clone(),
+            device_name: device_name.clone(),
             platform: get_current_platfrom(),
             kind,
             stable_id,
@@ -561,6 +623,7 @@ pub fn enumerate_mounted_root() -> Result<Vec<StorageRootInfo>> {
 pub fn detect_storage_root(path: &PathBuf) -> Result<StorageRootInfo> {
     let now_s = get_now_date();
     let norm = normalize_path(path);
+    let (device_uuid, device_name) = resolve_device_identity()?;
 
     // Best-prefix mount point
     let mount_path =
@@ -581,6 +644,8 @@ pub fn detect_storage_root(path: &PathBuf) -> Result<StorageRootInfo> {
     let is_available = mount_path.exists();
 
     Ok(StorageRootInfo {
+        device_uuid,
+        device_name,
         platform: get_current_platfrom(),
         kind,
         stable_id,
@@ -598,14 +663,17 @@ pub async fn ensure_storage_root_and_real_folder(
     tx: &mut Transaction<'_, Sqlite>,
     sroot_info: &StorageRootInfo,
     norm_path: &PathBuf,
-) -> Result<String> {
+) -> Result<StorageRootEnsureResult> {
     // Ensure StorageRoot exists or create it
     let sroot_id =
         SrootRepository::ensure_storage_root(tx.as_mut(), sroot_info).await?;
 
     // Ensure RealFolder exists or create it
-    let real_folder_id =
-        ensure_real_folder(tx, sroot_id.clone(), norm_path).await?;
+    let ensured = ensure_real_folder(tx, &sroot_id, norm_path).await?;
 
-    Ok(real_folder_id)
+    Ok(StorageRootEnsureResult {
+        storage_root_id: sroot_id,
+        real_folder_id: ensured.real_folder_id,
+        tree_id: ensured.tree_id,
+    })
 }


### PR DESCRIPTION
## Summary
- add a device registry, storage_root_tree join table, and tree identifiers so real_folder entries no longer store storage_root_id directly
- capture and persist a stable device UUID, associate storage roots with devices, and expose the information through StorageRootInfo
- update storage root and real folder services/repositories plus bootstrap logic to work with the new tree mapping and device awareness

## Testing
- cargo fmt
- cargo clippy --all-targets -- -D warnings *(fails: unable to download crates index due to 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68d818952ce8832ebc9eb9bce6f0652a