### PR TITLE
Add viewer splitter sidebar controls

### DIFF
--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -54,6 +54,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const [rootNode, setRootNode] = useState<Node | null>(null);
   const [graphRefreshKey, setGraphRefreshKey] = useState(0);
   const [gridRefreshKey, setGridRefreshKey] = useState(0);
+  const [viewerSidebarVisible, setViewerSidebarVisible] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const { panel, containerId, isActive } = usePanelsStore(
     useShallow(state => ({
@@ -362,6 +363,28 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     return rootNode.data?.['File'] ?? null;
   }, [rootNode]);
 
+  const viewerSidebarImage = useMemo<ImageItem | null>(() => {
+    if (!rootFile || rootFile.kind !== FileType.Image) return null;
+
+    return {
+      id: rootFile.fileId,
+      nodeId: rootFile.nodeId,
+      name: rootFile.fileName,
+      type: rootFile.kind,
+      hash: rootFile.xxh364,
+      size: rootFile.size,
+    };
+  }, [rootFile]);
+
+  useEffect(() => {
+    if (viewType !== 'viewer') {
+      setViewerSidebarVisible(false);
+      return;
+    }
+
+    setViewerSidebarVisible(Boolean(viewerSidebarImage));
+  }, [viewType, viewerSidebarImage]);
+
   const captureAnchor = useMemo(() => {
     if (!rootNode) return null;
 
@@ -539,6 +562,18 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
               })}
             </div>
           ) : null}
+          {viewType === 'viewer' && viewerSidebarImage ? (
+            <Button
+              type="button"
+              variant="icon"
+              aria-label={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
+              title={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
+              onClick={() => setViewerSidebarVisible(prev => !prev)}
+              className="h-8 w-8"
+            >
+              {viewerSidebarVisible ? '>' : '<'}
+            </Button>
+          ) : null}
         </div>
       </div>
       <div className="relative flex-1 min-h-0 bg-surface">
@@ -583,7 +618,32 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
             )}
           </Split>
         ) : showViewer && rootFile ? (
-          <FileViewer file={rootFile} moaId={moaId} />
+          <Split position="horizontal" className="h-full w-full">
+            {({ Panel: SplitPanel }) => (
+              <>
+                <SplitPanel key="viewer" minSize={320}>
+                  <FileViewer file={rootFile} moaId={moaId} />
+                </SplitPanel>
+                {viewerSidebarImage ? (
+                  <SplitPanel
+                    key="viewer-sidebar"
+                    canHidden
+                    hidden={!viewerSidebarVisible}
+                    onHidden={hidden => hidden && setViewerSidebarVisible(false)}
+                    hiddenSize={200}
+                    minSize={280}
+                    initialSize={360}
+                  >
+                    <FileDetailSidebar
+                      moaId={moaId}
+                      image={viewerSidebarVisible ? viewerSidebarImage : null}
+                      onClose={() => setViewerSidebarVisible(false)}
+                    />
+                  </SplitPanel>
+                ) : null}
+              </>
+            )}
+          </Split>
         ) : null}
       </div>
     </div>,

--- a/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
+++ b/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
@@ -4,13 +4,15 @@ import { FileType } from '@tgim/types/file';
 import { NodeFile } from '@tgim/types/graph';
 import { ipc } from '../../../../lib/ipc';
 import { FileText } from 'lucide-react';
+import { cn } from '@tgim/utils/index';
 
 interface FileViewerProps {
   file: NodeFile;
   moaId: string | null;
+  className?: string;
 }
 
-const FileViewer: React.FC<FileViewerProps> = ({ file, moaId }) => {
+const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className }) => {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
     file.kind === FileType.Image ? 'loading' : 'idle',
@@ -75,19 +77,24 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId }) => {
   }, [file.kind]);
 
   return (
-    <div className="flex h-full w-full flex-col gap-4 p-6 text-foreground">
-      <div className="flex flex-col items-center gap-1 text-center">
+    <div
+      className={cn(
+        'flex h-full min-h-0 w-full flex-col gap-4 overflow-hidden p-6 text-foreground',
+        className,
+      )}
+    >
+      <div className="flex flex-shrink-0 flex-col items-center gap-1 text-center">
         <p className="max-w-full truncate text-lg font-semibold">{file.fileName}</p>
         <p className="text-sm text-muted-foreground">{fileDescription}</p>
       </div>
 
       {file.kind === FileType.Image ? (
-        <div className="flex flex-1 items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted">
+        <div className="flex flex-1 min-h-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted">
           {status === 'ready' && imageSrc ? (
             <img
               src={imageSrc}
               alt={file.fileName}
-              className="max-h-full max-w-full object-contain"
+              className="h-full w-full max-h-full max-w-full object-contain"
             />
           ) : status === 'loading' ? (
             <p className="text-sm text-muted-foreground">이미지를 불러오는 중...</p>
@@ -98,7 +105,7 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId }) => {
           )}
         </div>
       ) : (
-        <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-border bg-surface-muted">
+        <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-4 rounded-lg border border-dashed border-border bg-surface-muted">
           <FileText className="h-12 w-12 text-muted-foreground" />
           <div className="flex flex-col items-center gap-1 text-center">
             <p className="text-sm text-muted-foreground">미리보기를 지원하지 않는 파일입니다.</p>


### PR DESCRIPTION
## Summary
- wrap the viewer panel in the Split layout so the detail sidebar mirrors the grid view
- derive an ImageItem payload from the root file for the sidebar and expose toolbar controls to toggle it
- update FileViewer styling so the preview stretches correctly when the sidebar opens or closes

## Testing
- pnpm lint:check *(fails: Cannot find package '@eslint/js' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68da6ffd0724832ea63cf17b1c837a25