### PR TITLE
Add image crop tooling to panel

### DIFF
--- a/apps/desktop/src-tauri/migrations/001_init.sql
+++ b/apps/desktop/src-tauri/migrations/001_init.sql
@@ -1,7 +1,7 @@
 /* ------------------------------------ Core graph (virtual) ---------------------------------------- */
 CREATE TABLE IF NOT EXISTS node (
   id         TEXT PRIMARY KEY NOT NULL,                               -- uuid  
-  kind       TEXT NOT NULL CHECK (kind IN ('folder','file','tag','annotation','memo')),
+  kind       TEXT NOT NULL CHECK (kind IN ('folder','file','tag','annotation','memo','crop')),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -29,10 +29,11 @@ import { Button } from '@tgim/ui';
 import cn from '@tgim/utils/cn';
 import { Split } from '@tgim/ui/Splitter';
 import FileDetailSidebar from './panels/FileDetailSidebar';
-import { Camera, Eye, GitBranch, LayoutGrid } from 'lucide-react';
+import { Camera, Crop, Eye, GitBranch, LayoutGrid } from 'lucide-react';
 import FileViewer from './panels/FileViewer';
 import { useFileDrop } from '../../../../../../packages/hooks/src/useFileDrop';
 import { toast } from 'react-toastify';
+import ImageCropView from './panels/ImageCropView';
 
 const DEFAULT_CAPTURE_LINK = 'relativeimage';
 const FOLDER_CAPTURE_FORWARD_LINK = RelationType.ContainsFile;
@@ -43,7 +44,7 @@ interface PanelProps {
   hidden?: boolean;
 }
 
-type ViewType = 'graph' | 'grid' | 'viewer';
+type ViewType = 'graph' | 'grid' | 'viewer' | 'crop';
 
 const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const [viewType, setViewType] = useState<ViewType>('graph');
@@ -325,15 +326,31 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     return id;
   }, [graphData, rootNodeId]);
 
+  const cropEntries = useMemo(() => {
+    if (!graphData) return [] as { nodeId: string; crop: NodeCrop }[];
+    const unique = new Map<string, NodeCrop>();
+    graphData.nodes.forEach(node => {
+      if (node.type === 'crop' && node.crop) {
+        unique.set(node.nodeId, node.crop);
+      }
+    });
+    const entries = Array.from(unique.entries()).map(([nodeId, crop]) => ({ nodeId, crop }));
+    if (!rootFile?.xxh364) return entries;
+    return entries.filter(entry => entry.crop.originHash === rootFile.xxh364);
+  }, [graphData, rootFile?.xxh364]);
+
   const availableViews = useMemo<ViewType[]>(() => {
     if (rootNode?.kind === NodeKind.Folder) {
       return ['grid', 'graph'];
     }
     if (rootNode?.kind === NodeKind.File) {
+      if (rootFile?.kind === FileType.Image) {
+        return ['viewer', 'crop', 'graph'];
+      }
       return ['viewer', 'graph'];
     }
     return ['graph'];
-  }, [rootNode?.kind]);
+  }, [rootFile?.kind, rootNode?.kind]);
 
   const defaultView = useMemo<ViewType>(() => availableViews[0] ?? 'graph', [availableViews]);
 
@@ -398,6 +415,8 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const showGraph = viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
   const showGrid = viewType === 'grid' && !!gridData && availableViews.includes('grid');
   const showViewer = viewType === 'viewer' && !!rootFile;
+  const showCrop =
+    viewType === 'crop' && !!rootFile && rootFile.kind === FileType.Image && !!moaId;
 
   const handleStartCapture = useCallback(async () => {
     if (!moaId || !captureAnchor) return;
@@ -442,6 +461,8 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         return LayoutGrid;
       case 'viewer':
         return Eye;
+      case 'crop':
+        return Crop;
       case 'graph':
       default:
         return GitBranch;
@@ -495,6 +516,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
                   graph: '그래프 보기',
                   grid: '그리드 보기',
                   viewer: '뷰어 보기',
+                  crop: '크롭 도구',
                 };
 
                 return (
@@ -534,6 +556,13 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           />
         ) : showViewer && rootFile ? (
           <FileViewer file={rootFile} moaId={moaId} />
+        ) : showCrop && rootFile && moaId ? (
+          <ImageCropView
+            file={rootFile}
+            moaId={moaId!}
+            crops={cropEntries}
+            onRefresh={refreshPanelData}
+          />
         ) : null}
       </div>
     </div>,

--- a/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
@@ -1,0 +1,585 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import {
+  PointerSelectionMode,
+  PointerSelectionRect,
+  usePointerSelection,
+} from '@tgim/hooks';
+import { NodeCrop, NodeFile } from '@tgim/types/graph';
+import { FileDetail } from '@tgim/types/file';
+import { ipc } from '../../../../lib/ipc';
+import { Split } from '@tgim/ui/Splitter';
+import Button from '@tgim/ui/Button';
+import Modal from '@tgim/ui/Modal';
+import { cn } from '@tgim/utils/index';
+import { toast } from 'react-toastify';
+
+interface CropEntry {
+  nodeId: string;
+  crop: NodeCrop;
+}
+
+interface ImageCropViewProps {
+  file: NodeFile;
+  moaId: string;
+  crops: CropEntry[];
+  onRefresh: () => Promise<void>;
+}
+
+type SelectionData = {
+  display: { x: number; y: number; width: number; height: number };
+  absolute: { startX: number; startY: number; width: number; height: number };
+  normalized: { startX: number; startY: number; width: number; height: number };
+};
+
+const FULL_IMAGE_TOLERANCE = 1e-3;
+const PREVIEW_MAX_EDGE = 220;
+const MIN_SELECTION_SIZE = 4;
+
+const clampSelectionToBounds = (
+  rect: PointerSelectionRect,
+  bounds: DOMRect,
+): { x: number; y: number; width: number; height: number } | null => {
+  const startX = Math.max(rect.x, bounds.left);
+  const startY = Math.max(rect.y, bounds.top);
+  const endX = Math.min(rect.x + rect.width, bounds.right);
+  const endY = Math.min(rect.y + rect.height, bounds.bottom);
+
+  if (endX <= startX || endY <= startY) {
+    return null;
+  }
+
+  return {
+    x: startX - bounds.left,
+    y: startY - bounds.top,
+    width: endX - startX,
+    height: endY - startY,
+  };
+};
+
+const computeSelectionData = (
+  rect: PointerSelectionRect,
+  bounds: DOMRect,
+  sourceWidth: number,
+  sourceHeight: number,
+): SelectionData | null => {
+  const display = clampSelectionToBounds(rect, bounds);
+  if (!display || sourceWidth <= 0 || sourceHeight <= 0) return null;
+
+  const scaleX = sourceWidth / bounds.width;
+  const scaleY = sourceHeight / bounds.height;
+
+  const absolute = {
+    startX: display.x * scaleX,
+    startY: display.y * scaleY,
+    width: display.width * scaleX,
+    height: display.height * scaleY,
+  };
+
+  const normalized = {
+    startX: absolute.startX / sourceWidth,
+    startY: absolute.startY / sourceHeight,
+    width: absolute.width / sourceWidth,
+    height: absolute.height / sourceHeight,
+  };
+
+  return { display, absolute, normalized };
+};
+
+const approx = (value: number, expected: number, tolerance = FULL_IMAGE_TOLERANCE) =>
+  Math.abs(value - expected) <= tolerance;
+
+const resolveCropRect = (
+  crop: NodeCrop,
+  sourceWidth: number,
+  sourceHeight: number,
+) => {
+  if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+
+  const referenceWidth = crop.referenceWidth ?? sourceWidth;
+  const referenceHeight = crop.referenceHeight ?? sourceHeight;
+
+  if (referenceWidth <= 0 || referenceHeight <= 0) {
+    return null;
+  }
+
+  let startX = crop.startX;
+  let startY = crop.startY;
+  let width = crop.width;
+  let height = crop.height;
+
+  if (crop.isRelative) {
+    startX *= referenceWidth;
+    startY *= referenceHeight;
+    width *= referenceWidth;
+    height *= referenceHeight;
+  }
+
+  const scaleX = sourceWidth / referenceWidth;
+  const scaleY = sourceHeight / referenceHeight;
+
+  return {
+    startX: startX * scaleX,
+    startY: startY * scaleY,
+    width: width * scaleX,
+    height: height * scaleY,
+  };
+};
+
+const formatDimensions = (width: number, height: number) =>
+  `${Math.round(width)} × ${Math.round(height)}`;
+
+const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRefresh }) => {
+  const [sidebarVisible, setSidebarVisible] = useState(false);
+  const [mode, setMode] = useState<PointerSelectionMode>('freeform');
+  const [imageSrc, setImageSrc] = useState<string | null>(null);
+  const [imageStatus, setImageStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
+    'loading',
+  );
+  const [detail, setDetail] = useState<FileDetail | null>(null);
+  const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
+  const [activeCrop, setActiveCrop] = useState<CropEntry | null>(null);
+  const [creatingCrop, setCreatingCrop] = useState(false);
+
+  const interactionSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const imageRef = useRef<HTMLImageElement | null>(null);
+
+  const sourceWidth = detail?.file.width ?? naturalSize?.width ?? null;
+  const sourceHeight = detail?.file.height ?? naturalSize?.height ?? null;
+
+  useEffect(() => {
+    let cancelled = false;
+    setImageStatus('loading');
+    setImageSrc(null);
+    setNaturalSize(null);
+
+    const loadImage = async () => {
+      try {
+        const path = await ipc.file.getFilePath(moaId, file.xxh364);
+        if (cancelled) return;
+        setImageSrc(convertFileSrc(path));
+        setImageStatus('loading');
+      } catch (error) {
+        console.error('[ImageCropView] Failed to load original image path', error);
+        if (cancelled) return;
+        setImageStatus('error');
+        toast.error('원본 이미지를 불러올 수 없습니다.');
+      }
+    };
+
+    void loadImage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [file.xxh364, moaId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetail(null);
+
+    const loadDetail = async () => {
+      try {
+        const nextDetail = await ipc.file.getFileDetail(moaId, file.xxh364);
+        if (cancelled) return;
+        setDetail(nextDetail);
+      } catch (error) {
+        console.error('[ImageCropView] Failed to load file detail', error);
+        if (cancelled) return;
+        toast.error('이미지 정보를 불러오지 못했습니다.');
+      }
+    };
+
+    void loadDetail();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [file.xxh364, moaId]);
+
+  useEffect(() => {
+    setActiveCrop(null);
+  }, [file.nodeId]);
+
+  const handleImageLoad = useCallback(() => {
+    if (!imageRef.current) return;
+    setNaturalSize({ width: imageRef.current.naturalWidth, height: imageRef.current.naturalHeight });
+    setImageStatus('ready');
+  }, []);
+
+  const handleImageError = useCallback(() => {
+    setImageStatus('error');
+    setImageSrc(null);
+    toast.error('이미지를 표시할 수 없습니다.');
+  }, []);
+
+  const selectionEnabled =
+    imageStatus === 'ready' && !creatingCrop && sourceWidth != null && sourceHeight != null;
+
+  const {
+    selection,
+    completedSelection,
+    resetSelection,
+    clearCompletedSelection,
+    handlePointerDown: basePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerCancel,
+  } = usePointerSelection<HTMLDivElement>({
+    mode,
+    minSize: MIN_SELECTION_SIZE,
+    disabled: !selectionEnabled,
+  });
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!selectionEnabled || !imageRef.current) return;
+      const bounds = imageRef.current.getBoundingClientRect();
+      if (
+        event.clientX < bounds.left ||
+        event.clientX > bounds.right ||
+        event.clientY < bounds.top ||
+        event.clientY > bounds.bottom
+      ) {
+        return;
+      }
+      basePointerDown(event);
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // ignore if pointer capture fails
+      }
+    },
+    [basePointerDown, selectionEnabled],
+  );
+
+  const displaySelection = useMemo(() => {
+    if (!selection || !imageRef.current) return null;
+    if (sourceWidth == null || sourceHeight == null) return null;
+    const bounds = imageRef.current.getBoundingClientRect();
+    const data = computeSelectionData(selection, bounds, sourceWidth, sourceHeight);
+    return data?.display ?? null;
+  }, [selection, sourceHeight, sourceWidth]);
+
+  useEffect(() => {
+    if (!completedSelection || !imageRef.current) return;
+    if (sourceWidth == null || sourceHeight == null) {
+      clearCompletedSelection();
+      resetSelection();
+      toast.error('이미지 크기를 확인할 수 없습니다.');
+      return;
+    }
+
+    const bounds = imageRef.current.getBoundingClientRect();
+    const data = computeSelectionData(completedSelection, bounds, sourceWidth, sourceHeight);
+    if (!data) {
+      clearCompletedSelection();
+      resetSelection();
+      toast.error('선택 영역이 유효하지 않습니다.');
+      return;
+    }
+
+    const { absolute, normalized } = data;
+
+    const isFullImage =
+      approx(normalized.startX, 0) &&
+      approx(normalized.startY, 0) &&
+      approx(normalized.width, 1) &&
+      approx(normalized.height, 1);
+
+    if (isFullImage) {
+      toast.warn('이미지 전체는 선택할 수 없습니다.');
+      clearCompletedSelection();
+      resetSelection();
+      return;
+    }
+
+    const referenceWidth = detail?.file.width ?? Math.round(sourceWidth);
+    const referenceHeight = detail?.file.height ?? Math.round(sourceHeight);
+
+    const createCrop = async () => {
+      setCreatingCrop(true);
+      try {
+        await ipc.graph.createImageCrop(moaId, {
+          originNodeId: file.nodeId,
+          originHash: file.xxh364,
+          rect: {
+            startX: absolute.startX,
+            startY: absolute.startY,
+            width: absolute.width,
+            height: absolute.height,
+          },
+          referenceWidth,
+          referenceHeight,
+          isRelative: false,
+          normalizedRect: {
+            startX: normalized.startX,
+            startY: normalized.startY,
+            width: normalized.width,
+            height: normalized.height,
+          },
+        });
+        await onRefresh();
+      } catch (error) {
+        console.error('[ImageCropView] Failed to create crop node', error);
+        toast.error('크롭을 생성하지 못했습니다.');
+      } finally {
+        setCreatingCrop(false);
+        clearCompletedSelection();
+        resetSelection();
+      }
+    };
+
+    void createCrop();
+  }, [
+    clearCompletedSelection,
+    completedSelection,
+    detail?.file.height,
+    detail?.file.width,
+    file.nodeId,
+    file.xxh364,
+    moaId,
+    onRefresh,
+    resetSelection,
+    sourceHeight,
+    sourceWidth,
+  ]);
+
+  const sortedCrops = useMemo(() => {
+    return [...crops].sort((a, b) => {
+      const aTime = new Date(a.crop.createdAt).getTime();
+      const bTime = new Date(b.crop.createdAt).getTime();
+      return bTime - aTime;
+    });
+  }, [crops]);
+
+  const renderCropPreview = useCallback(
+    (entry: CropEntry) => {
+      if (!imageSrc || sourceWidth == null || sourceHeight == null) return null;
+      const rect = resolveCropRect(entry.crop, sourceWidth, sourceHeight);
+      if (!rect) return null;
+
+      const maxEdge = Math.max(rect.width, rect.height);
+      const scale = maxEdge > 0 ? Math.min(PREVIEW_MAX_EDGE / maxEdge, 1) : 1;
+      const displayWidth = Math.max(rect.width * scale, 1);
+      const displayHeight = Math.max(rect.height * scale, 1);
+      const backgroundSize = `${sourceWidth * scale}px ${sourceHeight * scale}px`;
+      const backgroundPosition = `${-rect.startX * scale}px ${-rect.startY * scale}px`;
+
+      return (
+        <button
+          key={entry.nodeId}
+          type="button"
+          onClick={() => setActiveCrop(entry)}
+          className="flex flex-col gap-2 rounded-lg border border-border bg-surface-muted p-2 text-left shadow-sm transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <div
+            className="flex items-center justify-center overflow-hidden rounded-md bg-background"
+            style={{ width: displayWidth, height: displayHeight }}
+          >
+            <div
+              className="h-full w-full"
+              style={{
+                backgroundImage: `url(${imageSrc})`,
+                backgroundRepeat: 'no-repeat',
+                backgroundSize,
+                backgroundPosition,
+              }}
+            />
+          </div>
+          <div className="flex flex-col text-xs text-muted-foreground">
+            <span>크기: {formatDimensions(rect.width, rect.height)}</span>
+            <span>
+              위치: {Math.round(rect.startX)}, {Math.round(rect.startY)}
+            </span>
+          </div>
+        </button>
+      );
+    },
+    [imageSrc, sourceHeight, sourceWidth],
+  );
+
+  return (
+    <div className="flex h-full w-full flex-col gap-4 p-4">
+      <Split position="horizontal" className="h-full w-full">
+        {({ Panel: SplitPanel }) => (
+          <>
+            <SplitPanel key="crop-view" minSize={360}>
+              <div className="flex h-full min-h-0 w-full flex-col gap-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex flex-col">
+                    <h2 className="text-lg font-semibold">{file.fileName}</h2>
+                    <p className="text-sm text-muted-foreground">드래그하여 새로운 크롭을 생성하세요.</p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="icon"
+                    className="h-8 w-8"
+                    onClick={() => setSidebarVisible(prev => !prev)}
+                    aria-label={sidebarVisible ? '옵션 숨기기' : '옵션 보기'}
+                    aria-controls="image-crop-options"
+                    aria-expanded={sidebarVisible}
+                  >
+                    {sidebarVisible ? '>' : '<'}
+                  </Button>
+                </div>
+                <div className="flex flex-1 min-h-0 gap-4 overflow-hidden">
+                  <div
+                    ref={interactionSurfaceRef}
+                    className={cn(
+                      'relative flex flex-1 items-center justify-center overflow-hidden rounded-xl border border-border bg-surface-muted',
+                      creatingCrop && 'opacity-75',
+                    )}
+                    onPointerDown={handlePointerDown}
+                    onPointerMove={handlePointerMove}
+                    onPointerUp={event => {
+                      handlePointerUp(event);
+                      try {
+                        event.currentTarget.releasePointerCapture(event.pointerId);
+                      } catch {
+                        // ignore release failure
+                      }
+                    }}
+                    onPointerLeave={handlePointerCancel}
+                    onPointerCancel={handlePointerCancel}
+                  >
+                    {imageSrc && imageStatus !== 'error' ? (
+                      <>
+                        <img
+                          ref={imageRef}
+                          src={imageSrc}
+                          alt={file.fileName}
+                          onLoad={handleImageLoad}
+                          onError={handleImageError}
+                          className="max-h-full max-w-full object-contain"
+                        />
+                        {imageStatus === 'loading' ? (
+                          <span className="absolute bottom-3 left-3 rounded bg-surface px-2 py-1 text-xs text-muted-foreground shadow">
+                            이미지를 불러오는 중...
+                          </span>
+                        ) : null}
+                      </>
+                    ) : imageStatus === 'loading' ? (
+                      <span className="text-sm text-muted-foreground">이미지를 불러오는 중...</span>
+                    ) : (
+                      <span className="text-sm text-destructive">이미지를 표시할 수 없습니다.</span>
+                    )}
+
+                    {displaySelection ? (
+                      <div
+                        className="pointer-events-none absolute border-2 border-accent/80 bg-accent/10"
+                        style={{
+                          left: displaySelection.x,
+                          top: displaySelection.y,
+                          width: displaySelection.width,
+                          height: displaySelection.height,
+                        }}
+                      />
+                    ) : null}
+                  </div>
+                  <div className="flex w-64 flex-col gap-3 overflow-y-auto pr-1">
+                    <h3 className="text-sm font-semibold">생성된 크롭</h3>
+                    {sortedCrops.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">아직 생성된 크롭이 없습니다.</p>
+                    ) : (
+                      <div className="flex flex-col gap-3">
+                        {sortedCrops.map(entry => renderCropPreview(entry))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </SplitPanel>
+            <SplitPanel
+              key="crop-options"
+              canHidden
+              hidden={!sidebarVisible}
+              onHidden={hidden => hidden && setSidebarVisible(false)}
+              hiddenSize={200}
+              minSize={240}
+              initialSize={280}
+            >
+              <div
+                id="image-crop-options"
+                className="flex h-full w-full flex-col gap-4 border-l border-border bg-surface-muted p-4"
+              >
+                <h3 className="text-base font-semibold">크롭 옵션</h3>
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm text-muted-foreground">선택 모드</span>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="toggle"
+                      active={mode === 'freeform'}
+                      onClick={() => setMode('freeform')}
+                    >
+                      자유 형태
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="toggle"
+                      active={mode === 'square'}
+                      onClick={() => setMode('square')}
+                    >
+                      정사각형
+                    </Button>
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border bg-background p-3 text-sm text-muted-foreground">
+                  이미지 위를 드래그하여 영역을 선택하면 새로운 크롭이 생성됩니다. 전체 이미지를 선택하는 것은 허용되지 않습니다.
+                </div>
+              </div>
+            </SplitPanel>
+          </>
+        )}
+      </Split>
+
+      {activeCrop && imageSrc && sourceWidth != null && sourceHeight != null ? (
+        <Modal onClose={() => setActiveCrop(null)} className="max-h-[90vh] max-w-[90vw]">
+          <div className="flex flex-col gap-4">
+            <h3 className="text-lg font-semibold">크롭 상세 보기</h3>
+            {(() => {
+              const rect = resolveCropRect(activeCrop.crop, sourceWidth, sourceHeight);
+              if (!rect) {
+                return <p className="text-sm text-muted-foreground">크롭 정보를 불러올 수 없습니다.</p>;
+              }
+              const scale = Math.min(600 / Math.max(rect.width, rect.height), 1);
+              const displayWidth = Math.max(rect.width * scale, 1);
+              const displayHeight = Math.max(rect.height * scale, 1);
+              const backgroundSize = `${sourceWidth * scale}px ${sourceHeight * scale}px`;
+              const backgroundPosition = `${-rect.startX * scale}px ${-rect.startY * scale}px`;
+
+              return (
+                <div className="flex flex-col gap-3">
+                  <div
+                    className="self-start overflow-hidden rounded-xl border border-border bg-background shadow"
+                    style={{ width: displayWidth, height: displayHeight }}
+                  >
+                    <div
+                      className="h-full w-full"
+                      style={{
+                        backgroundImage: `url(${imageSrc})`,
+                        backgroundRepeat: 'no-repeat',
+                        backgroundSize,
+                        backgroundPosition,
+                      }}
+                    />
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    <p>크기: {formatDimensions(rect.width, rect.height)}</p>
+                    <p>
+                      위치: {Math.round(rect.startX)}, {Math.round(rect.startY)}
+                    </p>
+                    <p>생성일: {new Date(activeCrop.crop.createdAt).toLocaleString()}</p>
+                  </div>
+                </div>
+              );
+            })()}
+          </div>
+        </Modal>
+      ) : null}
+    </div>
+  );
+};
+
+export default ImageCropView;

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -134,4 +134,5 @@ export interface CreateImageCropPayload {
   referenceWidth?: number | null;
   referenceHeight?: number | null;
   isRelative?: boolean;
+  normalizedRect?: CropRectangle;
 }


### PR DESCRIPTION
## Summary
- add a crop view option to image panels and surface it in the panel toolbar
- implement an ImageCropView with pointer-based selection, existing crop previews, and crop detail modal
- extend the crop payload type to carry normalized rectangle data for IPC calls

## Testing
- pnpm lint:check *(fails: missing @eslint/js in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa9fe09f0832eb117194bd09ccca1