### PR TITLE
Support crop thumbnails in graph view

### DIFF
--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -405,9 +405,24 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   }, [graphData, rootNodeId]);
 
   const rootFile = useMemo<NodeFile | null>(() => {
-    if (rootNode?.kind !== NodeKind.File) return null;
-    return rootNode.data?.['File'] ?? null;
-  }, [rootNode]);
+    if (!rootNode) return null;
+    if (rootNode.kind === NodeKind.File) {
+      return rootNode.data?.['File'] ?? null;
+    }
+    if (rootNode.kind === NodeKind.Crop) {
+      const crop = rootNode.data?.['Crop'];
+      if (!crop) return null;
+      const originHash = crop.originHash;
+      if (!originHash) return null;
+      const originNode = Object.values(rawNodesById).find(candidate => {
+        if (candidate.kind !== NodeKind.File) return false;
+        const file = candidate.data?.['File'];
+        return file?.xxh364 === originHash;
+      });
+      return originNode?.data?.['File'] ?? null;
+    }
+    return null;
+  }, [rawNodesById, rootNode]);
 
   const cropEntries = useMemo(() => {
     if (!graphData) return [] as { nodeId: string; crop: NodeCrop }[];
@@ -433,9 +448,6 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
       return ['viewer', 'graph'];
     }
     if (rootNode?.kind === NodeKind.Crop) {
-      if (rootFile?.kind === FileType.Image) {
-        return ['viewer', 'crop', 'graph'];
-      }
       return ['viewer', 'graph'];
     }
     return ['graph'];
@@ -470,26 +482,6 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     previousCropRootIdRef.current = rootNode.id;
     setViewType('viewer');
   }, [availableViews, rootNode]);
-
-  const rootFile = useMemo<NodeFile | null>(() => {
-    if (!rootNode) return null;
-    if (rootNode.kind === NodeKind.File) {
-      return rootNode.data?.['File'] ?? null;
-    }
-    if (rootNode.kind === NodeKind.Crop) {
-      const crop = rootNode.data?.['Crop'];
-      if (!crop) return null;
-      const originHash = crop.originHash;
-      if (!originHash) return null;
-      const originNode = Object.values(rawNodesById).find(candidate => {
-        if (candidate.kind !== NodeKind.File) return false;
-        const file = candidate.data?.['File'];
-        return file?.xxh364 === originHash;
-      });
-      return originNode?.data?.['File'] ?? null;
-    }
-    return null;
-  }, [rawNodesById, rootNode]);
 
   const activeCrop = useMemo<NodeCrop | null>(() => {
     if (rootNode?.kind !== NodeKind.Crop) return null;
@@ -541,7 +533,12 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const showGraph = viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
   const showGrid = viewType === 'grid' && !!gridData && availableViews.includes('grid');
   const showViewer = viewType === 'viewer' && !!rootFile;
-  const showCrop = viewType === 'crop' && !!rootFile && rootFile.kind === FileType.Image && !!moaId;
+  const showCrop =
+    viewType === 'crop' &&
+    !!rootFile &&
+    rootNode?.kind !== NodeKind.Crop &&
+    rootFile.kind === FileType.Image &&
+    !!moaId;
 
   const handleStartCapture = useCallback(async () => {
     if (!moaId || !captureAnchor) return;

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -55,6 +55,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const [rootNode, setRootNode] = useState<Node | null>(null);
   const [graphRefreshKey, setGraphRefreshKey] = useState(0);
   const [gridRefreshKey, setGridRefreshKey] = useState(0);
+  const [rawNodesById, setRawNodesById] = useState<Record<string, Node>>({});
   const panelRef = useRef<HTMLDivElement | null>(null);
   const { panel, containerId, isActive } = usePanelsStore(
     useShallow(state => ({
@@ -73,6 +74,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     graphData.nodes.forEach(node => {
       nodesMap[node.id] = node;
     });
+    setRawNodesById(nodesMap);
     const connectionsMap: Record<string, Connection[]> = {};
     const incomingConnectionsMap: Record<string, Connection[]> = {};
     graphData.connections.forEach(connection => {
@@ -167,12 +169,13 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           incomingConnections.find(connection => connection.kind === RelationType.Cropped);
 
         let originHash: string | undefined;
+        let originNodeId: string | undefined;
         if (originConnection) {
-          const originNodeId =
+          originNodeId =
             originConnection.kind === RelationType.CroppedOrigin
               ? originConnection.dstNodeId
               : originConnection.srcNodeId;
-          const originNode = nodesMap[originNodeId];
+          const originNode = originNodeId ? nodesMap[originNodeId] : undefined;
           const originFile = originNode?.data?.['File'];
           if (originFile?.xxh364) {
             originHash = originFile.xxh364;
@@ -189,6 +192,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           type: 'crop',
           crop,
           originHash: originHash ?? crop.originHash,
+          originNodeId,
           cropRect: normalizedCropRect ?? undefined,
         };
       } else if (node.kind == NodeKind.Folder && node.data['Folder']) {
@@ -423,10 +427,21 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
       }
       return ['viewer', 'graph'];
     }
+    if (rootNode?.kind === NodeKind.Crop) {
+      if (rootFile?.kind === FileType.Image) {
+        return ['viewer', 'crop', 'graph'];
+      }
+      return ['viewer', 'graph'];
+    }
     return ['graph'];
   }, [rootFile?.kind, rootNode?.kind]);
 
-  const defaultView = useMemo<ViewType>(() => availableViews[0] ?? 'graph', [availableViews]);
+  const defaultView = useMemo<ViewType>(() => {
+    if (rootNode?.kind === NodeKind.Crop && availableViews.includes('viewer')) {
+      return 'viewer';
+    }
+    return availableViews[0] ?? 'graph';
+  }, [availableViews, rootNode?.kind]);
 
   const rootFolder = useMemo(() => {
     if (!rootNode) return null;
@@ -439,9 +454,41 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     }
   }, [availableViews, defaultView, viewType]);
 
+  const previousCropRootIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (rootNode?.kind !== NodeKind.Crop) {
+      previousCropRootIdRef.current = null;
+      return;
+    }
+    if (!rootNode.id || !availableViews.includes('viewer')) return;
+    if (previousCropRootIdRef.current === rootNode.id) return;
+    previousCropRootIdRef.current = rootNode.id;
+    setViewType('viewer');
+  }, [availableViews, rootNode]);
+
   const rootFile = useMemo<NodeFile | null>(() => {
-    if (rootNode?.kind !== NodeKind.File) return null;
-    return rootNode.data?.['File'] ?? null;
+    if (!rootNode) return null;
+    if (rootNode.kind === NodeKind.File) {
+      return rootNode.data?.['File'] ?? null;
+    }
+    if (rootNode.kind === NodeKind.Crop) {
+      const crop = rootNode.data?.['Crop'];
+      if (!crop) return null;
+      const originHash = crop.originHash;
+      if (!originHash) return null;
+      const originNode = Object.values(rawNodesById).find(candidate => {
+        if (candidate.kind !== NodeKind.File) return false;
+        const file = candidate.data?.['File'];
+        return file?.xxh364 === originHash;
+      });
+      return originNode?.data?.['File'] ?? null;
+    }
+    return null;
+  }, [rawNodesById, rootNode]);
+
+  const activeCrop = useMemo<NodeCrop | null>(() => {
+    if (rootNode?.kind !== NodeKind.Crop) return null;
+    return rootNode.data?.['Crop'] ?? null;
   }, [rootNode]);
 
   const captureAnchor = useMemo(() => {
@@ -629,7 +676,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
             onClearPreview={() => {}}
           />
         ) : showViewer && rootFile ? (
-          <FileViewer file={rootFile} moaId={moaId} />
+          <FileViewer file={rootFile} moaId={moaId} crop={activeCrop ?? undefined} />
         ) : showCrop && rootFile && moaId ? (
           <ImageCropView
             file={rootFile}

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -74,15 +74,65 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
       nodesMap[node.id] = node;
     });
     const connectionsMap: Record<string, Connection[]> = {};
+    const incomingConnectionsMap: Record<string, Connection[]> = {};
     graphData.connections.forEach(connection => {
       if (!connectionsMap[connection.srcNodeId]) {
         connectionsMap[connection.srcNodeId] = [];
       }
       connectionsMap[connection.srcNodeId].push(connection);
+
+      if (!incomingConnectionsMap[connection.dstNodeId]) {
+        incomingConnectionsMap[connection.dstNodeId] = [];
+      }
+      incomingConnectionsMap[connection.dstNodeId].push(connection);
     });
 
     const nodes: GraphNode[] = [];
     const links: GraphConnection[] = [];
+
+    const clamp01 = (value: number) => {
+      if (!Number.isFinite(value)) return 0;
+      return Math.min(1, Math.max(0, value));
+    };
+
+    const toNormalizedCropRect = (crop: NodeCrop) => {
+      let startX = crop.startX;
+      let startY = crop.startY;
+      let width = crop.width;
+      let height = crop.height;
+
+      if (!crop.isRelative) {
+        const referenceWidth = crop.referenceWidth ?? null;
+        const referenceHeight = crop.referenceHeight ?? null;
+
+        if (!referenceWidth || !referenceHeight || referenceWidth <= 0 || referenceHeight <= 0) {
+          return null;
+        }
+
+        startX = startX / referenceWidth;
+        startY = startY / referenceHeight;
+        width = width / referenceWidth;
+        height = height / referenceHeight;
+      }
+
+      const startXClamped = clamp01(startX);
+      const startYClamped = clamp01(startY);
+      const endXClamped = clamp01(startX + width);
+      const endYClamped = clamp01(startY + height);
+      const normalizedWidth = endXClamped - startXClamped;
+      const normalizedHeight = endYClamped - startYClamped;
+
+      if (normalizedWidth <= 0 || normalizedHeight <= 0) {
+        return null;
+      }
+
+      return {
+        startX: startXClamped,
+        startY: startYClamped,
+        width: normalizedWidth,
+        height: normalizedHeight,
+      };
+    };
 
     const getGraphNodeData = (node: Node, graphNodeId?: string): GraphNode => {
       const defaultSize = 14;
@@ -109,6 +159,28 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
         };
       } else if (node.kind === NodeKind.Crop && node.data['Crop']) {
         const crop = node.data['Crop'] as NodeCrop;
+        const outgoingConnections = connectionsMap[node.id] ?? [];
+        const incomingConnections = incomingConnectionsMap[node.id] ?? [];
+
+        const originConnection =
+          outgoingConnections.find(connection => connection.kind === RelationType.CroppedOrigin) ??
+          incomingConnections.find(connection => connection.kind === RelationType.Cropped);
+
+        let originHash: string | undefined;
+        if (originConnection) {
+          const originNodeId =
+            originConnection.kind === RelationType.CroppedOrigin
+              ? originConnection.dstNodeId
+              : originConnection.srcNodeId;
+          const originNode = nodesMap[originNodeId];
+          const originFile = originNode?.data?.['File'];
+          if (originFile?.xxh364) {
+            originHash = originFile.xxh364;
+          }
+        }
+
+        const normalizedCropRect = toNormalizedCropRect(crop);
+
         return {
           id: graphNodeId,
           nodeId: node.id,
@@ -116,6 +188,8 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
           size: nodeSize,
           type: 'crop',
           crop,
+          originHash: originHash ?? crop.originHash,
+          cropRect: normalizedCropRect ?? undefined,
         };
       } else if (node.kind == NodeKind.Folder && node.data['Folder']) {
         let data = node.data['Folder'];

--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -404,6 +404,11 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
     return id;
   }, [graphData, rootNodeId]);
 
+  const rootFile = useMemo<NodeFile | null>(() => {
+    if (rootNode?.kind !== NodeKind.File) return null;
+    return rootNode.data?.['File'] ?? null;
+  }, [rootNode]);
+
   const cropEntries = useMemo(() => {
     if (!graphData) return [] as { nodeId: string; crop: NodeCrop }[];
     const unique = new Map<string, NodeCrop>();
@@ -536,8 +541,7 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
   const showGraph = viewType === 'graph' && graphData && rootNodeId && rootGraphNodeId;
   const showGrid = viewType === 'grid' && !!gridData && availableViews.includes('grid');
   const showViewer = viewType === 'viewer' && !!rootFile;
-  const showCrop =
-    viewType === 'crop' && !!rootFile && rootFile.kind === FileType.Image && !!moaId;
+  const showCrop = viewType === 'crop' && !!rootFile && rootFile.kind === FileType.Image && !!moaId;
 
   const handleStartCapture = useCallback(async () => {
     if (!moaId || !captureAnchor) return;

--- a/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
+++ b/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { FileType } from '@tgim/types/file';
-import { NodeFile } from '@tgim/types/graph';
+import { NodeCrop, NodeFile } from '@tgim/types/graph';
 import { ipc } from '../../../../lib/ipc';
 import { FileText } from 'lucide-react';
 import { cn } from '@tgim/utils/index';
@@ -10,13 +10,100 @@ import Button from '@tgim/ui/Button';
 import FileDetailSidebar from './FileDetailSidebar';
 import { ImageItem } from '@tgim/types/grid';
 
+type NormalizedCropRect = {
+  startX: number;
+  startY: number;
+  width: number;
+  height: number;
+};
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const toNormalizedCropRect = (crop?: NodeCrop | null): NormalizedCropRect | null => {
+  if (!crop) return null;
+
+  const normalizedFromPayload = (crop as unknown as { normalizedRect?: NormalizedCropRect }).normalizedRect;
+  if (normalizedFromPayload) {
+    const { startX, startY, width, height } = normalizedFromPayload;
+    if ([startX, startY, width, height].every(isFiniteNumber)) {
+      const startXClamped = clamp01(startX);
+      const startYClamped = clamp01(startY);
+      const endXClamped = clamp01(startX + width);
+      const endYClamped = clamp01(startY + height);
+      const normalizedWidth = endXClamped - startXClamped;
+      const normalizedHeight = endYClamped - startYClamped;
+      if (normalizedWidth > 0 && normalizedHeight > 0) {
+        return {
+          startX: startXClamped,
+          startY: startYClamped,
+          width: normalizedWidth,
+          height: normalizedHeight,
+        };
+      }
+    }
+  }
+
+  const values = [crop.startX, crop.startY, crop.width, crop.height];
+  if (!values.every(isFiniteNumber)) {
+    return null;
+  }
+
+  let startX = crop.startX;
+  let startY = crop.startY;
+  let width = crop.width;
+  let height = crop.height;
+
+  if (!crop.isRelative) {
+    const referenceWidth = crop.referenceWidth ?? null;
+    const referenceHeight = crop.referenceHeight ?? null;
+    if (
+      isFiniteNumber(referenceWidth) &&
+      referenceWidth > 0 &&
+      isFiniteNumber(referenceHeight) &&
+      referenceHeight > 0
+    ) {
+      startX = startX / referenceWidth;
+      startY = startY / referenceHeight;
+      width = width / referenceWidth;
+      height = height / referenceHeight;
+    } else {
+      const alreadyNormalized = values.every(value => value >= 0 && value <= 1);
+      if (!alreadyNormalized) {
+        return null;
+      }
+    }
+  }
+
+  const startXClamped = clamp01(startX);
+  const startYClamped = clamp01(startY);
+  const endXClamped = clamp01(startX + width);
+  const endYClamped = clamp01(startY + height);
+  const normalizedWidth = endXClamped - startXClamped;
+  const normalizedHeight = endYClamped - startYClamped;
+
+  if (normalizedWidth <= 0 || normalizedHeight <= 0) {
+    return null;
+  }
+
+  return {
+    startX: startXClamped,
+    startY: startYClamped,
+    width: normalizedWidth,
+    height: normalizedHeight,
+  };
+};
+
 interface FileViewerProps {
   file: NodeFile;
   moaId: string | null;
   className?: string;
+  crop?: NodeCrop | null;
 }
 
-const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className }) => {
+const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop }) => {
   const [viewerSidebarVisible, setViewerSidebarVisible] = useState(false);
 
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -24,6 +111,12 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className }) => {
     file.kind === FileType.Image ? 'loading' : 'idle',
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const imageWrapperRef = useRef<HTMLDivElement | null>(null);
+  const imageElementRef = useRef<HTMLImageElement | null>(null);
+  const [imageMetrics, setImageMetrics] = useState<
+    { width: number; height: number; offsetX: number; offsetY: number } | null
+  >(null);
+  const normalizedCropRect = useMemo(() => toNormalizedCropRect(crop), [crop]);
 
   useEffect(() => {
     if (file.kind !== FileType.Image) {
@@ -62,6 +155,71 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className }) => {
       isCancelled = true;
     };
   }, [file.kind, file.xxh364, moaId]);
+
+  useEffect(() => {
+    if (status !== 'ready') {
+      setImageMetrics(null);
+    }
+  }, [status]);
+
+  useEffect(() => {
+    if (!normalizedCropRect) {
+      setImageMetrics(null);
+      return;
+    }
+
+    const updateMetrics = () => {
+      const wrapper = imageWrapperRef.current;
+      const img = imageElementRef.current;
+      if (!wrapper || !img) return;
+      const naturalWidth = img.naturalWidth;
+      const naturalHeight = img.naturalHeight;
+      if (!(naturalWidth > 0 && naturalHeight > 0)) return;
+
+      const wrapperRect = wrapper.getBoundingClientRect();
+      const wrapperWidth = wrapperRect.width;
+      const wrapperHeight = wrapperRect.height;
+      if (!(wrapperWidth > 0 && wrapperHeight > 0)) return;
+
+      const imageAspect = naturalWidth / naturalHeight;
+      const wrapperAspect = wrapperWidth / wrapperHeight;
+      let displayWidth = wrapperWidth;
+      let displayHeight = wrapperHeight;
+      let offsetX = 0;
+      let offsetY = 0;
+
+      if (imageAspect > wrapperAspect) {
+        displayWidth = wrapperWidth;
+        displayHeight = wrapperWidth / Math.max(imageAspect, 1e-6);
+        offsetY = (wrapperHeight - displayHeight) / 2;
+      } else {
+        displayHeight = wrapperHeight;
+        displayWidth = wrapperHeight * imageAspect;
+        offsetX = (wrapperWidth - displayWidth) / 2;
+      }
+
+      setImageMetrics({ width: displayWidth, height: displayHeight, offsetX, offsetY });
+    };
+
+    const resizeObserver = new ResizeObserver(() => updateMetrics());
+    if (imageWrapperRef.current) {
+      resizeObserver.observe(imageWrapperRef.current);
+    }
+
+    const img = imageElementRef.current;
+    if (img) {
+      img.addEventListener('load', updateMetrics);
+    }
+
+    updateMetrics();
+
+    return () => {
+      resizeObserver.disconnect();
+      if (img) {
+        img.removeEventListener('load', updateMetrics);
+      }
+    };
+  }, [imageSrc, normalizedCropRect]);
 
   const fileDescription = useMemo(() => {
     switch (file.kind) {
@@ -142,13 +300,34 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className }) => {
                 {/* Content area (scrolling) */}
                 <div className="flex-1 min-h-0">
                   {file?.kind === FileType.Image ? (
-                    <div className="flex h-full items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted">
+                    <div
+                      ref={imageWrapperRef}
+                      className="relative flex h-full items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted"
+                    >
                       {status === 'ready' && imageSrc ? (
-                        <img
-                          src={imageSrc}
-                          alt={file?.fileName ?? 'image'}
-                          className="h-full w-full max-h-full max-w-full object-contain"
-                        />
+                        <>
+                          <img
+                            ref={imageElementRef}
+                            src={imageSrc}
+                            alt={file?.fileName ?? 'image'}
+                            className="h-full w-full max-h-full max-w-full object-contain"
+                          />
+                          {normalizedCropRect && imageMetrics ? (
+                            <div
+                              className="pointer-events-none absolute rounded-md border-2 border-primary/80 bg-primary/15 shadow-[0_0_0_1px_rgba(15,23,42,0.15)]"
+                              style={{
+                                left:
+                                  imageMetrics.offsetX +
+                                  normalizedCropRect.startX * imageMetrics.width,
+                                top:
+                                  imageMetrics.offsetY +
+                                  normalizedCropRect.startY * imageMetrics.height,
+                                width: normalizedCropRect.width * imageMetrics.width,
+                                height: normalizedCropRect.height * imageMetrics.height,
+                              }}
+                            />
+                          ) : null}
+                        </>
                       ) : status === 'loading' ? (
                         <p className="text-sm text-muted-foreground">이미지를 불러오는 중...</p>
                       ) : (

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -1,5 +1,11 @@
 import usePanelsStore from '@tgim/stores/panelStore';
-import { Connection, GraphConnection, GraphData, GraphNode } from '@tgim/types/graph';
+import {
+  Connection,
+  GraphConnection,
+  GraphData,
+  GraphNode,
+  NodeCrop,
+} from '@tgim/types/graph';
 import { NodeRenderer, clearNodeSpriteCaches, getGraphPalette } from '@tgim/ui/index';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
@@ -19,6 +25,95 @@ interface Props {
 }
 
 const GRAPH_THUMB_SIZE = 64;
+
+type NormalizedCropRect = {
+  startX: number;
+  startY: number;
+  width: number;
+  height: number;
+};
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+const toNormalizedCropRect = (
+  crop: NodeCrop | undefined,
+  fallback?: NormalizedCropRect,
+): NormalizedCropRect | undefined => {
+  if (!crop) return fallback;
+
+  const normalizedFromPayload = (crop as unknown as { normalizedRect?: NormalizedCropRect }).normalizedRect;
+  if (normalizedFromPayload) {
+    const { startX, startY, width, height } = normalizedFromPayload;
+    if ([startX, startY, width, height].every(isFiniteNumber)) {
+      const startXClamped = clamp01(startX);
+      const startYClamped = clamp01(startY);
+      const endXClamped = clamp01(startX + width);
+      const endYClamped = clamp01(startY + height);
+      const normalizedWidth = endXClamped - startXClamped;
+      const normalizedHeight = endYClamped - startYClamped;
+      if (normalizedWidth > 0 && normalizedHeight > 0) {
+        return {
+          startX: startXClamped,
+          startY: startYClamped,
+          width: normalizedWidth,
+          height: normalizedHeight,
+        };
+      }
+    }
+  }
+
+  const values = [crop.startX, crop.startY, crop.width, crop.height];
+  if (!values.every(isFiniteNumber)) {
+    return fallback;
+  }
+
+  let startX = crop.startX;
+  let startY = crop.startY;
+  let width = crop.width;
+  let height = crop.height;
+
+  if (!crop.isRelative) {
+    const referenceWidth = crop.referenceWidth ?? null;
+    const referenceHeight = crop.referenceHeight ?? null;
+    if (
+      isFiniteNumber(referenceWidth) &&
+      referenceWidth > 0 &&
+      isFiniteNumber(referenceHeight) &&
+      referenceHeight > 0
+    ) {
+      startX = startX / referenceWidth;
+      startY = startY / referenceHeight;
+      width = width / referenceWidth;
+      height = height / referenceHeight;
+    } else {
+      const alreadyNormalized = values.every(value => value >= 0 && value <= 1);
+      if (!alreadyNormalized) {
+        return fallback;
+      }
+    }
+  }
+
+  const startXClamped = clamp01(startX);
+  const startYClamped = clamp01(startY);
+  const endXClamped = clamp01(startX + width);
+  const endYClamped = clamp01(startY + height);
+  const normalizedWidth = endXClamped - startXClamped;
+  const normalizedHeight = endYClamped - startYClamped;
+
+  if (normalizedWidth <= 0 || normalizedHeight <= 0) {
+    return fallback;
+  }
+
+  return {
+    startX: startXClamped,
+    startY: startYClamped,
+    width: normalizedWidth,
+    height: normalizedHeight,
+  };
+};
 
 const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -242,6 +337,13 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
         linkWidth={1.5}
         linkCurvature={0}
         nodeCanvasObject={(node, ctx, globalScale) => {
+          const normalizedCrop = toNormalizedCropRect(
+            node.type === 'crop' ? (node.crop as NodeCrop | undefined) : undefined,
+            node.cropRect as NormalizedCropRect | undefined,
+          );
+          if (normalizedCrop) {
+            node.cropRect = normalizedCrop;
+          }
           NodeRenderer(node.type)?.(
             ctx,
             {
@@ -251,7 +353,7 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
               label: node.label,
               url: node.url,
               thumbKey: node.thumbKey,
-              cropRect: node.cropRect,
+              cropRect: normalizedCrop,
             },
             globalScale,
           );

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -9,7 +9,7 @@ import useThumbStore from '@tgim/stores/thumbStore';
 import { useMoa } from '@tgim/hooks/useMoa';
 import { ResizeMode } from '@tgim/types/file';
 import { convertFileSrc } from '@tauri-apps/api/core';
-import { useThumbnails } from '../../../../hooks';
+import { ThumbnailRequest, useThumbnails } from '../../../../hooks';
 import { useTheme } from '../../../../theme/ThemeProvider';
 
 interface Props {
@@ -88,7 +88,16 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
   };
   const [prunedTree, setPrunedTree] = useState(getPrunedTree());
   const imageNodes = useMemo(
-    () => prunedTree.nodes.filter(node => node.type === 'image' && node.hash),
+    () =>
+      prunedTree.nodes.filter(node => {
+        if (node.type === 'image') {
+          return typeof node.hash === 'string' && node.hash.length > 0;
+        }
+        if (node.type === 'crop') {
+          return typeof node.originHash === 'string' && node.originHash.length > 0;
+        }
+        return false;
+      }),
     [prunedTree.nodes],
   );
   const imageNodesRef = useRef<GraphNode[]>([]);
@@ -99,37 +108,40 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
   useEffect(() => {
     if (imageNodes.length === 0) return;
 
-    const requests = imageNodes
-      .filter(
-        (node): node is GraphNode & { hash: string } =>
-          typeof node.hash === 'string' && node.hash.length > 0,
-      )
-      .map(node => {
-        const request = {
-          hash: node.hash,
-          width: GRAPH_THUMB_SIZE,
-          height: GRAPH_THUMB_SIZE,
-          dpr: 1 as const,
-          mode: ResizeMode.Original,
-        };
-        const key = getThumbnailKey(request);
-        if (node.thumbKey !== key) {
-          node.thumbKey = key;
-          node.url = undefined;
-        }
+    const requests = imageNodes.reduce<ThumbnailRequest[]>((acc, node) => {
+      const hash =
+        node.type === 'crop'
+          ? (typeof node.originHash === 'string' ? node.originHash : undefined)
+          : (typeof node.hash === 'string' ? node.hash : undefined);
+      if (!hash) return acc;
 
-        const url = getThumbnailUrl(request).url;
-        if (url !== undefined) {
-          node.url = convertFileSrc(url);
-          node.key = getThumbnailKey(request);
-        }
-        return { ...request, key };
-      });
+      const request: ThumbnailRequest = {
+        hash,
+        width: GRAPH_THUMB_SIZE,
+        height: GRAPH_THUMB_SIZE,
+        dpr: 1 as const,
+        mode: ResizeMode.Original,
+      };
+      const key = getThumbnailKey(request);
+      if (node.thumbKey !== key) {
+        node.thumbKey = key;
+        node.url = undefined;
+      }
+
+      const { url } = getThumbnailUrl(request);
+      if (url !== undefined) {
+        node.url = convertFileSrc(url);
+        node.key = key;
+      }
+
+      acc.push({ ...request, key });
+      return acc;
+    }, []);
 
     if (requests.length === 0) return;
 
     void ensureThumbnails(requests);
-  }, [ensureThumbnails, getThumbnailKey, imageNodes]);
+  }, [ensureThumbnails, getThumbnailKey, getThumbnailUrl, imageNodes]);
 
   useEffect(() => {
     const unsubscribe = useThumbStore.subscribe(
@@ -239,6 +251,7 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
               label: node.label,
               url: node.url,
               thumbKey: node.thumbKey,
+              cropRect: node.cropRect,
             },
             globalScale,
           );

--- a/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
-import {
-  PointerSelectionMode,
-  PointerSelectionRect,
-  usePointerSelection,
-} from '@tgim/hooks';
+import { PointerSelectionMode, PointerSelectionRect, usePointerSelection } from '@tgim/hooks';
 import { NodeCrop, NodeFile } from '@tgim/types/graph';
 import { FileDetail } from '@tgim/types/file';
 import { ipc } from '../../../../lib/ipc';
@@ -89,11 +85,7 @@ const computeSelectionData = (
 const approx = (value: number, expected: number, tolerance = FULL_IMAGE_TOLERANCE) =>
   Math.abs(value - expected) <= tolerance;
 
-const resolveCropRect = (
-  crop: NodeCrop,
-  sourceWidth: number,
-  sourceHeight: number,
-) => {
+const resolveCropRect = (crop: NodeCrop, sourceWidth: number, sourceHeight: number) => {
   if (sourceWidth <= 0 || sourceHeight <= 0) return null;
 
   const referenceWidth = crop.referenceWidth ?? sourceWidth;
@@ -133,9 +125,7 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
   const [sidebarVisible, setSidebarVisible] = useState(false);
   const [mode, setMode] = useState<PointerSelectionMode>('freeform');
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [imageStatus, setImageStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
-    'loading',
-  );
+  const [imageStatus, setImageStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('loading');
   const [detail, setDetail] = useState<FileDetail | null>(null);
   const [naturalSize, setNaturalSize] = useState<{ width: number; height: number } | null>(null);
   const [activeCrop, setActiveCrop] = useState<CropEntry | null>(null);
@@ -203,7 +193,10 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
 
   const handleImageLoad = useCallback(() => {
     if (!imageRef.current) return;
-    setNaturalSize({ width: imageRef.current.naturalWidth, height: imageRef.current.naturalHeight });
+    setNaturalSize({
+      width: imageRef.current.naturalWidth,
+      height: imageRef.current.naturalHeight,
+    });
     setImageStatus('ready');
   }, []);
 
@@ -254,12 +247,25 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
   );
 
   const displaySelection = useMemo(() => {
-    if (!selection || !imageRef.current) return null;
+    if (!selection || !imageRef.current || !interactionSurfaceRef.current) return null;
     if (sourceWidth == null || sourceHeight == null) return null;
-    const bounds = imageRef.current.getBoundingClientRect();
-    const data = computeSelectionData(selection, bounds, sourceWidth, sourceHeight);
-    return data?.display ?? null;
-  }, [selection, sourceHeight, sourceWidth]);
+
+    const imageRect = imageRef.current.getBoundingClientRect();
+    const surfaceRect = interactionSurfaceRef.current.getBoundingClientRect();
+
+    const data = computeSelectionData(selection, imageRect, sourceWidth, sourceHeight);
+    if (!data) return null;
+
+    const offsetLeft = imageRect.left - surfaceRect.left;
+    const offsetTop = imageRect.top - surfaceRect.top;
+
+    return {
+      x: data.display.x + offsetLeft,
+      y: data.display.y + offsetTop,
+      width: data.display.width,
+      height: data.display.height,
+    };
+  }, [selection, sourceWidth, sourceHeight]);
 
   useEffect(() => {
     if (!completedSelection || !imageRef.current) return;
@@ -409,7 +415,9 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex flex-col">
                     <h2 className="text-lg font-semibold">{file.fileName}</h2>
-                    <p className="text-sm text-muted-foreground">드래그하여 새로운 크롭을 생성하세요.</p>
+                    <p className="text-sm text-muted-foreground">
+                      드래그하여 새로운 크롭을 생성하세요.
+                    </p>
                   </div>
                   <Button
                     type="button"
@@ -526,7 +534,8 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
                   </div>
                 </div>
                 <div className="rounded-lg border border-border bg-background p-3 text-sm text-muted-foreground">
-                  이미지 위를 드래그하여 영역을 선택하면 새로운 크롭이 생성됩니다. 전체 이미지를 선택하는 것은 허용되지 않습니다.
+                  이미지 위를 드래그하여 영역을 선택하면 새로운 크롭이 생성됩니다. 전체 이미지를
+                  선택하는 것은 허용되지 않습니다.
                 </div>
               </div>
             </SplitPanel>
@@ -541,7 +550,9 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
             {(() => {
               const rect = resolveCropRect(activeCrop.crop, sourceWidth, sourceHeight);
               if (!rect) {
-                return <p className="text-sm text-muted-foreground">크롭 정보를 불러올 수 없습니다.</p>;
+                return (
+                  <p className="text-sm text-muted-foreground">크롭 정보를 불러올 수 없습니다.</p>
+                );
               }
               const scale = Math.min(600 / Math.max(rect.width, rect.height), 1);
               const displayWidth = Math.max(rect.width * scale, 1);

--- a/packages/ui/src/Node.tsx
+++ b/packages/ui/src/Node.tsx
@@ -142,6 +142,13 @@ export const getGraphPalette = () => graphPalette;
 // Types for rendering
 // =========================
 
+type NormalizedCropRect = {
+  startX: number;
+  startY: number;
+  width: number;
+  height: number;
+};
+
 type NodeProp = {
   [key: string]: any; // extensible payload
   x: number;
@@ -152,6 +159,7 @@ type NodeProp = {
   size: number; // logical diameter
   label: string;
   icon?: 'circle' | 'tag' | 'folder' | 'image';
+  cropRect?: NormalizedCropRect;
 };
 
 export type NodeRenderer = (
@@ -175,6 +183,8 @@ const withCtx = (ctx: CanvasRenderingContext2D, draw: () => void) => {
 
 /** Keep stroke width roughly constant regardless of zoom */
 const constPx = (v: number, globalScale: number) => Math.max(1, v / Math.max(0.001, globalScale));
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
 
 /** Rounded-rect path helper */
 function roundRect(
@@ -735,62 +745,131 @@ const imageRenderer: NodeRenderer = (ctx, node, globalScale) => {
   ctx.drawImage(backplate, node.x - side / 2, node.y - side / 2, side, side);
 
   const src = resolveImageSrc(node);
-  let tile: HTMLCanvasElement | undefined;
-  if (src) tile = getMaskedImageTile(src, contentSize, contentSize, clipRadius, scaleB);
+  const cropRect = node.cropRect as NormalizedCropRect | undefined;
+  const hasCropRect =
+    cropRect &&
+    Number.isFinite(cropRect.startX) &&
+    Number.isFinite(cropRect.startY) &&
+    Number.isFinite(cropRect.width) &&
+    Number.isFinite(cropRect.height);
 
-  withCtx(ctx, () => {
-    ctx.imageSmoothingEnabled = true;
-    // @ts-ignore
-    ctx.imageSmoothingQuality = 'high';
+  let cropImage: HTMLImageElement | undefined;
+  let cropSource:
+    | { sx: number; sy: number; sw: number; sh: number }
+    | undefined;
 
-    if (tile) {
-      ctx.drawImage(
-        tile,
-        node.x - contentSize / 2,
-        node.y - contentSize / 2,
-        contentSize,
-        contentSize,
-      );
-    } else {
-      const phKey = `imgph|${side}|${radius}|${padding}|${clipRadius}|${scaleB}`;
-      const placeholder = getOrCreateSprite(
-        phKey,
-        side,
-        side,
-        g => {
-          roundRect(g, padding, padding, contentSize, contentSize, clipRadius);
-          g.strokeStyle = palette.placeholderStroke;
-          g.lineWidth = Math.max(1, 1.5 / Math.max(0.001, scaleB));
-          g.stroke();
+  if (src && hasCropRect) {
+    const rect = cropRect as NormalizedCropRect;
+    const candidate = getOrCreateImage(src);
+    if (candidate.complete && candidate.naturalWidth > 0 && candidate.naturalHeight > 0) {
+      const iw = candidate.naturalWidth;
+      const ih = candidate.naturalHeight;
+      const startXNorm = clamp01(rect.startX);
+      const startYNorm = clamp01(rect.startY);
+      const endXNorm = clamp01(rect.startX + rect.width);
+      const endYNorm = clamp01(rect.startY + rect.height);
+      const widthNorm = Math.max(0, endXNorm - startXNorm);
+      const heightNorm = Math.max(0, endYNorm - startYNorm);
 
-          g.beginPath();
-          g.arc(
-            padding + contentSize * 0.28,
-            padding + contentSize * 0.32,
-            contentSize * 0.12,
-            0,
-            Math.PI * 2,
-          );
-          g.fillStyle = palette.placeholderAccent;
-          g.fill();
+      const sxPx = startXNorm * iw;
+      const syPx = startYNorm * ih;
+      const exPx = Math.min(iw, sxPx + widthNorm * iw);
+      const eyPx = Math.min(ih, syPx + heightNorm * ih);
+      const sw = Math.max(1, exPx - sxPx);
+      const sh = Math.max(1, eyPx - syPx);
 
-          g.beginPath();
-          const baseY = padding + contentSize * 0.78;
-          g.moveTo(padding + contentSize * 0.08, baseY);
-          g.lineTo(padding + contentSize * 0.35, padding + contentSize * 0.48);
-          g.lineTo(padding + contentSize * 0.55, baseY);
-          g.lineTo(padding + contentSize * 0.48, baseY);
-          g.lineTo(padding + contentSize * 0.72, padding + contentSize * 0.58);
-          g.lineTo(padding + contentSize * 0.92, baseY);
-          g.closePath();
-          g.fillStyle = palette.placeholderFill;
-          g.fill();
-        },
-        scaleB,
-      );
-      ctx.drawImage(placeholder, node.x - side / 2, node.y - side / 2, side, side);
+      if (sw > 0 && sh > 0) {
+        cropImage = candidate;
+        cropSource = { sx: sxPx, sy: syPx, sw, sh };
+      }
     }
-  });
+  }
+
+  let tile: HTMLCanvasElement | undefined;
+  if (src && (!cropImage || !cropSource)) {
+    tile = getMaskedImageTile(src, contentSize, contentSize, clipRadius, scaleB);
+  }
+
+  const drawX = node.x - contentSize / 2;
+  const drawY = node.y - contentSize / 2;
+
+  const drawWithMask = (render: () => void) => {
+    withCtx(ctx, () => {
+      ctx.imageSmoothingEnabled = true;
+      // @ts-ignore
+      ctx.imageSmoothingQuality = 'high';
+      roundRect(ctx, drawX, drawY, contentSize, contentSize, clipRadius);
+      ctx.clip();
+      render();
+    });
+  };
+
+  if (cropImage && cropSource && cropSource.sw > 0 && cropSource.sh > 0) {
+    const { sx, sy, sw, sh } = cropSource;
+    const sourceImage = cropImage;
+    const cropAspect = sw / sh;
+    if (cropAspect > 0 && isFinite(cropAspect)) {
+      let drawWidth = contentSize;
+      let drawHeight = drawWidth / cropAspect;
+      if (drawHeight > contentSize) {
+        drawHeight = contentSize;
+        drawWidth = drawHeight * cropAspect;
+      }
+      const dx = drawX + (contentSize - drawWidth) / 2;
+      const dy = drawY + (contentSize - drawHeight) / 2;
+
+      drawWithMask(() => {
+        ctx.drawImage(sourceImage, sx, sy, sw, sh, dx, dy, drawWidth, drawHeight);
+      });
+      return;
+    }
+  }
+
+  if (tile) {
+    const tileCanvas = tile;
+    drawWithMask(() => {
+      ctx.drawImage(tileCanvas, drawX, drawY, contentSize, contentSize);
+    });
+    return;
+  }
+
+  const phKey = `imgph|${side}|${radius}|${padding}|${clipRadius}|${scaleB}`;
+  const placeholder = getOrCreateSprite(
+    phKey,
+    side,
+    side,
+    g => {
+      roundRect(g, padding, padding, contentSize, contentSize, clipRadius);
+      g.strokeStyle = palette.placeholderStroke;
+      g.lineWidth = Math.max(1, 1.5 / Math.max(0.001, scaleB));
+      g.stroke();
+
+      g.beginPath();
+      g.arc(
+        padding + contentSize * 0.28,
+        padding + contentSize * 0.32,
+        contentSize * 0.12,
+        0,
+        Math.PI * 2,
+      );
+      g.fillStyle = palette.placeholderAccent;
+      g.fill();
+
+      g.beginPath();
+      const baseY = padding + contentSize * 0.78;
+      g.moveTo(padding + contentSize * 0.08, baseY);
+      g.lineTo(padding + contentSize * 0.35, padding + contentSize * 0.48);
+      g.lineTo(padding + contentSize * 0.55, baseY);
+      g.lineTo(padding + contentSize * 0.48, baseY);
+      g.lineTo(padding + contentSize * 0.72, padding + contentSize * 0.58);
+      g.lineTo(padding + contentSize * 0.92, baseY);
+      g.closePath();
+      g.fillStyle = palette.placeholderFill;
+      g.fill();
+    },
+    scaleB,
+  );
+  ctx.drawImage(placeholder, node.x - side / 2, node.y - side / 2, side, side);
 
   // drawLabelCached(ctx, node, globalScale); // enable if you want labels under images
 };
@@ -807,6 +886,7 @@ export default (key: GraphNodeType): NodeRenderer => {
     tag: tagRenderer as NodeRenderer,
     folder: folderRenderer as NodeRenderer,
     image: imageRenderer as NodeRenderer,
+    crop: imageRenderer as NodeRenderer,
     document: documentRenderer as NodeRenderer,
   };
   return (map as NodeRendererType)[key];


### PR DESCRIPTION
## Summary
- detect crop nodes while transforming panel graph data, capturing normalized crop rectangles and origin hashes
- request origin thumbnails for crop nodes in the graph view and forward crop metadata to the canvas renderer
- render cropped regions in the shared image renderer while continuing to support image nodes and placeholders

## Testing
- pnpm lint:check *(fails: missing @eslint/js dependency in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dab798e590832eb4ec9048685a5b7b