### PR TITLE
Refactor crop helpers into shared utilities

### DIFF
--- a/apps/desktop/src/features/main/panel/Panel.tsx
+++ b/apps/desktop/src/features/main/panel/Panel.tsx
@@ -34,6 +34,7 @@ import FileViewer from './panels/FileViewer';
 import { useFileDrop } from '../../../../../../packages/hooks/src/useFileDrop';
 import { toast } from 'react-toastify';
 import ImageCropView from './panels/ImageCropView';
+import { toNormalizedCropRect } from '@tgim/utils/crop';
 
 const DEFAULT_CAPTURE_LINK = 'relativeimage';
 const FOLDER_CAPTURE_FORWARD_LINK = RelationType.ContainsFile;
@@ -93,50 +94,6 @@ const Panel: React.FC<PanelProps> = ({ panelId, hidden }) => {
 
     const nodes: GraphNode[] = [];
     const links: GraphConnection[] = [];
-
-    const clamp01 = (value: number) => {
-      if (!Number.isFinite(value)) return 0;
-      return Math.min(1, Math.max(0, value));
-    };
-
-    const toNormalizedCropRect = (crop: NodeCrop) => {
-      let startX = crop.startX;
-      let startY = crop.startY;
-      let width = crop.width;
-      let height = crop.height;
-
-      if (!crop.isRelative) {
-        const referenceWidth = crop.referenceWidth ?? null;
-        const referenceHeight = crop.referenceHeight ?? null;
-
-        if (!referenceWidth || !referenceHeight || referenceWidth <= 0 || referenceHeight <= 0) {
-          return null;
-        }
-
-        startX = startX / referenceWidth;
-        startY = startY / referenceHeight;
-        width = width / referenceWidth;
-        height = height / referenceHeight;
-      }
-
-      const startXClamped = clamp01(startX);
-      const startYClamped = clamp01(startY);
-      const endXClamped = clamp01(startX + width);
-      const endYClamped = clamp01(startY + height);
-      const normalizedWidth = endXClamped - startXClamped;
-      const normalizedHeight = endYClamped - startYClamped;
-
-      if (normalizedWidth <= 0 || normalizedHeight <= 0) {
-        return null;
-      }
-
-      return {
-        startX: startXClamped,
-        startY: startYClamped,
-        width: normalizedWidth,
-        height: normalizedHeight,
-      };
-    };
 
     const getGraphNodeData = (node: Node, graphNodeId?: string): GraphNode => {
       const defaultSize = 14;

--- a/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
+++ b/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
@@ -4,11 +4,12 @@ import { FileType } from '@tgim/types/file';
 import { Connection, GraphResponse, Node, NodeCrop, NodeFile } from '@tgim/types/graph';
 import { ipc } from '../../../../lib/ipc';
 import { FileText } from 'lucide-react';
-import { cn, toNormalizedCropRect } from '@tgim/utils/index';
+import { cn } from '@tgim/utils/index';
 import { Split } from '@tgim/ui/Splitter';
 import Button from '@tgim/ui/Button';
 import FileDetailSidebar from './FileDetailSidebar';
 import { ImageItem } from '@tgim/types/grid';
+import { useNormalizedCropRect } from '@tgim/hooks/useCropRect';
 
 interface FileViewerProps {
   file: NodeFile;
@@ -33,7 +34,7 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
     offsetX: number;
     offsetY: number;
   } | null>(null);
-  const normalizedCropRect = useMemo(() => toNormalizedCropRect(crop), [crop]);
+  const normalizedCropRect = useNormalizedCropRect(crop);
 
   useEffect(() => {
     if (file.kind !== FileType.Image) {

--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -1,5 +1,6 @@
 import usePanelsStore from '@tgim/stores/panelStore';
 import { Connection, GraphConnection, GraphData, GraphNode, NodeCrop } from '@tgim/types/graph';
+import { NormalizedCropRect } from '@tgim/types/crop';
 import { NodeRenderer, clearNodeSpriteCaches, getGraphPalette } from '@tgim/ui/index';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import ForceGraph2D, { ForceGraphMethods } from 'react-force-graph-2d';
@@ -11,6 +12,7 @@ import { ResizeMode } from '@tgim/types/file';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { ThumbnailRequest, useThumbnails } from '../../../../hooks';
 import { useTheme } from '../../../../theme/ThemeProvider';
+import { toNormalizedCropRect } from '@tgim/utils/crop';
 
 interface Props {
   graphData: GraphData;
@@ -28,96 +30,6 @@ const clampDevicePixelRatio = () => {
     return 1;
   }
   return Math.min(3, Math.max(1, Math.round(ratio)));
-};
-
-type NormalizedCropRect = {
-  startX: number;
-  startY: number;
-  width: number;
-  height: number;
-};
-
-const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
-
-const isFiniteNumber = (value: unknown): value is number =>
-  typeof value === 'number' && Number.isFinite(value);
-
-const toNormalizedCropRect = (
-  crop: NodeCrop | undefined,
-  fallback?: NormalizedCropRect,
-): NormalizedCropRect | undefined => {
-  if (!crop) return fallback;
-
-  const normalizedFromPayload = (crop as unknown as { normalizedRect?: NormalizedCropRect })
-    .normalizedRect;
-  if (normalizedFromPayload) {
-    const { startX, startY, width, height } = normalizedFromPayload;
-    if ([startX, startY, width, height].every(isFiniteNumber)) {
-      const startXClamped = clamp01(startX);
-      const startYClamped = clamp01(startY);
-      const endXClamped = clamp01(startX + width);
-      const endYClamped = clamp01(startY + height);
-      const normalizedWidth = endXClamped - startXClamped;
-      const normalizedHeight = endYClamped - startYClamped;
-      if (normalizedWidth > 0 && normalizedHeight > 0) {
-        return {
-          startX: startXClamped,
-          startY: startYClamped,
-          width: normalizedWidth,
-          height: normalizedHeight,
-        };
-      }
-    }
-  }
-
-  const values = [crop.startX, crop.startY, crop.width, crop.height];
-  if (!values.every(isFiniteNumber)) {
-    return fallback;
-  }
-
-  let startX = crop.startX;
-  let startY = crop.startY;
-  let width = crop.width;
-  let height = crop.height;
-
-  if (!crop.isRelative) {
-    const referenceWidth = crop.referenceWidth ?? null;
-    const referenceHeight = crop.referenceHeight ?? null;
-    if (
-      isFiniteNumber(referenceWidth) &&
-      referenceWidth > 0 &&
-      isFiniteNumber(referenceHeight) &&
-      referenceHeight > 0
-    ) {
-      startX = startX / referenceWidth;
-      startY = startY / referenceHeight;
-      width = width / referenceWidth;
-      height = height / referenceHeight;
-    } else {
-      const alreadyNormalized = values.every(value => value >= 0 && value <= 1);
-      if (!alreadyNormalized) {
-        return fallback;
-      }
-    }
-  }
-
-  const startXClamped = clamp01(startX);
-  const startYClamped = clamp01(startY);
-  const endXClamped = clamp01(startX + width);
-  const endYClamped = clamp01(startY + height);
-  const normalizedWidth = endXClamped - startXClamped;
-  const normalizedHeight = endYClamped - startYClamped;
-
-  if (normalizedWidth <= 0 || normalizedHeight <= 0) {
-    return fallback;
-  }
-
-  return {
-    startX: startXClamped,
-    startY: startYClamped,
-    width: normalizedWidth,
-    height: normalizedHeight,
-  };
 };
 
 const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) => {
@@ -388,10 +300,10 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
         linkWidth={1.5}
         linkCurvature={0}
         nodeCanvasObject={(node, ctx, globalScale) => {
-          const normalizedCrop = toNormalizedCropRect(
-            node.type === 'crop' ? (node.crop as NodeCrop | undefined) : undefined,
-            node.cropRect as NormalizedCropRect | undefined,
-          );
+          const computedCrop =
+            node.type === 'crop' ? toNormalizedCropRect(node.crop as NodeCrop | null) : null;
+          const fallbackCrop = node.cropRect as NormalizedCropRect | undefined;
+          const normalizedCrop = computedCrop ?? fallbackCrop ?? null;
           if (normalizedCrop) {
             node.cropRect = normalizedCrop;
           }
@@ -404,7 +316,7 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
               label: node.label,
               url: node.url,
               thumbKey: node.thumbKey,
-              cropRect: normalizedCrop,
+              cropRect: normalizedCrop ?? undefined,
             },
             globalScale,
           );

--- a/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/ImageCropView.tsx
@@ -9,6 +9,8 @@ import Button from '@tgim/ui/Button';
 import Modal from '@tgim/ui/Modal';
 import { cn } from '@tgim/utils/index';
 import { toast } from 'react-toastify';
+import { toAbsoluteCropRect } from '@tgim/utils/crop';
+import { CropPreview } from '@tgim/ui';
 
 interface CropEntry {
   nodeId: string;
@@ -84,39 +86,6 @@ const computeSelectionData = (
 
 const approx = (value: number, expected: number, tolerance = FULL_IMAGE_TOLERANCE) =>
   Math.abs(value - expected) <= tolerance;
-
-const resolveCropRect = (crop: NodeCrop, sourceWidth: number, sourceHeight: number) => {
-  if (sourceWidth <= 0 || sourceHeight <= 0) return null;
-
-  const referenceWidth = crop.referenceWidth ?? sourceWidth;
-  const referenceHeight = crop.referenceHeight ?? sourceHeight;
-
-  if (referenceWidth <= 0 || referenceHeight <= 0) {
-    return null;
-  }
-
-  let startX = crop.startX;
-  let startY = crop.startY;
-  let width = crop.width;
-  let height = crop.height;
-
-  if (crop.isRelative) {
-    startX *= referenceWidth;
-    startY *= referenceHeight;
-    width *= referenceWidth;
-    height *= referenceHeight;
-  }
-
-  const scaleX = sourceWidth / referenceWidth;
-  const scaleY = sourceHeight / referenceHeight;
-
-  return {
-    startX: startX * scaleX,
-    startY: startY * scaleY,
-    width: width * scaleX,
-    height: height * scaleY,
-  };
-};
 
 const formatDimensions = (width: number, height: number) =>
   `${Math.round(width)} × ${Math.round(height)}`;
@@ -362,16 +331,9 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
   const renderCropPreview = useCallback(
     (entry: CropEntry) => {
       if (!imageSrc || sourceWidth == null || sourceHeight == null) return null;
-      const rect = resolveCropRect(entry.crop, sourceWidth, sourceHeight);
+      const rect = toAbsoluteCropRect(entry.crop, sourceWidth, sourceHeight);
       if (!rect) return null;
 
-      const maxEdge = Math.max(rect.width, rect.height);
-      const scale = maxEdge > 0 ? Math.min(PREVIEW_MAX_EDGE / maxEdge, 1) : 1;
-      const displayWidth = Math.max(rect.width * scale, 1);
-      const displayHeight = Math.max(rect.height * scale, 1);
-      const backgroundSize = `${sourceWidth * scale}px ${sourceHeight * scale}px`;
-      const backgroundPosition = `${-rect.startX * scale}px ${-rect.startY * scale}px`;
-      console.log(imageSrc);
       return (
         <button
           key={entry.nodeId}
@@ -379,20 +341,14 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
           onClick={() => setActiveCrop(entry)}
           className="flex flex-col gap-2 rounded-lg border border-border bg-surface-muted p-2 text-left shadow-sm transition hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
         >
-          <div
-            className="flex items-center justify-center overflow-hidden rounded-md bg-background"
-            style={{ width: displayWidth, height: displayHeight }}
-          >
-            <div
-              className="h-full w-full"
-              style={{
-                backgroundImage: `url("${imageSrc}")`,
-                backgroundRepeat: 'no-repeat',
-                backgroundSize,
-                backgroundPosition,
-              }}
-            />
-          </div>
+          <CropPreview
+            imageSrc={imageSrc}
+            rect={rect}
+            sourceWidth={sourceWidth}
+            sourceHeight={sourceHeight}
+            maxEdge={PREVIEW_MAX_EDGE}
+            className="flex items-center justify-center"
+          />
           <div className="flex flex-col text-xs text-muted-foreground">
             <span>크기: {formatDimensions(rect.width, rect.height)}</span>
             <span>
@@ -548,34 +504,23 @@ const ImageCropView: React.FC<ImageCropViewProps> = ({ file, moaId, crops, onRef
           <div className="flex flex-col gap-4">
             <h3 className="text-lg font-semibold">크롭 상세 보기</h3>
             {(() => {
-              const rect = resolveCropRect(activeCrop.crop, sourceWidth, sourceHeight);
+              const rect = toAbsoluteCropRect(activeCrop.crop, sourceWidth, sourceHeight);
               if (!rect) {
                 return (
                   <p className="text-sm text-muted-foreground">크롭 정보를 불러올 수 없습니다.</p>
                 );
               }
-              const scale = Math.min(600 / Math.max(rect.width, rect.height), 1);
-              const displayWidth = Math.max(rect.width * scale, 1);
-              const displayHeight = Math.max(rect.height * scale, 1);
-              const backgroundSize = `${sourceWidth * scale}px ${sourceHeight * scale}px`;
-              const backgroundPosition = `${-rect.startX * scale}px ${-rect.startY * scale}px`;
 
               return (
                 <div className="flex flex-col gap-3">
-                  <div
-                    className="self-start overflow-hidden rounded-xl border border-border bg-background shadow"
-                    style={{ width: displayWidth, height: displayHeight }}
-                  >
-                    <div
-                      className="h-full w-full"
-                      style={{
-                        backgroundImage: `url("${imageSrc}")`,
-                        backgroundRepeat: 'no-repeat',
-                        backgroundSize,
-                        backgroundPosition,
-                      }}
-                    />
-                  </div>
+                  <CropPreview
+                    imageSrc={imageSrc}
+                    rect={rect}
+                    sourceWidth={sourceWidth}
+                    sourceHeight={sourceHeight}
+                    maxEdge={600}
+                    className="self-start rounded-xl border border-border bg-background shadow"
+                  />
                   <div className="text-sm text-muted-foreground">
                     <p>크기: {formatDimensions(rect.width, rect.height)}</p>
                     <p>

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -4,3 +4,4 @@ export * from './usePointerSelection';
 export * from './useFileDrop';
 export * from './useElementSize';
 export * from './useDebouncedEffect';
+export * from './useCropRect';

--- a/packages/hooks/src/useCropRect.ts
+++ b/packages/hooks/src/useCropRect.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { AbsoluteCropRect, NormalizedCropRect } from '@tgim/types/crop';
+import { NodeCrop } from '@tgim/types/graph';
+import {
+  CropPreviewStyle,
+  getCropPreviewStyle,
+  toAbsoluteCropRect,
+  toNormalizedCropRect,
+} from '@tgim/utils/crop';
+
+const isNodeCrop = (value: unknown): value is NodeCrop => {
+  if (!value || typeof value !== 'object') return false;
+  return 'isRelative' in value || 'referenceWidth' in value || 'referenceHeight' in value;
+};
+
+export const useNormalizedCropRect = (crop?: NodeCrop | null): NormalizedCropRect | null =>
+  useMemo(() => toNormalizedCropRect(crop), [crop]);
+
+export const useAbsoluteCropRect = (
+  crop?: NodeCrop | null,
+  sourceWidth?: number | null,
+  sourceHeight?: number | null,
+): AbsoluteCropRect | null =>
+  useMemo(() => toAbsoluteCropRect(crop, sourceWidth ?? null, sourceHeight ?? null), [
+    crop,
+    sourceWidth,
+    sourceHeight,
+  ]);
+
+type CropPreviewSource = NodeCrop | AbsoluteCropRect | null | undefined;
+
+type UseCropPreviewOptions = {
+  maxEdge?: number;
+};
+
+export const useCropPreview = (
+  crop: CropPreviewSource,
+  sourceWidth?: number | null,
+  sourceHeight?: number | null,
+  options?: UseCropPreviewOptions,
+): CropPreviewStyle | null => {
+  const maxEdge = options?.maxEdge;
+
+  return useMemo(() => {
+    if (!sourceWidth || !sourceHeight || sourceWidth <= 0 || sourceHeight <= 0) {
+      return null;
+    }
+
+    const rect = isNodeCrop(crop)
+      ? toAbsoluteCropRect(crop, sourceWidth, sourceHeight)
+      : (crop as AbsoluteCropRect | null | undefined);
+
+    return getCropPreviewStyle(rect, sourceWidth, sourceHeight, { maxEdge });
+  }, [crop, maxEdge, sourceHeight, sourceWidth]);
+};

--- a/packages/types/src/crop.ts
+++ b/packages/types/src/crop.ts
@@ -4,3 +4,10 @@ export type NormalizedCropRect = {
   width: number;
   height: number;
 };
+
+export type AbsoluteCropRect = {
+  startX: number;
+  startY: number;
+  width: number;
+  height: number;
+};

--- a/packages/ui/src/CropPreview.tsx
+++ b/packages/ui/src/CropPreview.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { AbsoluteCropRect } from '@tgim/types/crop';
+import { cn, getCropPreviewStyle } from '@tgim/utils/index';
+
+type CropPreviewProps = {
+  imageSrc: string;
+  rect: AbsoluteCropRect;
+  sourceWidth: number;
+  sourceHeight: number;
+  maxEdge?: number;
+  className?: string;
+};
+
+const CropPreview: React.FC<CropPreviewProps> = ({
+  imageSrc,
+  rect,
+  sourceWidth,
+  sourceHeight,
+  maxEdge,
+  className,
+}) => {
+  const preview = useMemo(
+    () => getCropPreviewStyle(rect, sourceWidth, sourceHeight, { maxEdge }),
+    [rect, sourceHeight, sourceWidth, maxEdge],
+  );
+
+  if (!preview) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn('relative overflow-hidden rounded-md bg-background', className)}
+      style={{ width: preview.displayWidth, height: preview.displayHeight }}
+    >
+      <div
+        className="h-full w-full"
+        style={{
+          backgroundImage: `url("${imageSrc}")`,
+          backgroundRepeat: 'no-repeat',
+          backgroundSize: preview.backgroundSize,
+          backgroundPosition: preview.backgroundPosition,
+        }}
+      />
+    </div>
+  );
+};
+
+export default CropPreview;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,3 +10,4 @@ export { default as Modal } from './Modal';
 export { default as Tab } from './Tab';
 export { default as NodeRenderer } from './Node';
 export { getGraphPalette, clearNodeSpriteCaches } from './Node';
+export { default as CropPreview } from './CropPreview';

--- a/packages/utils/src/crop.ts
+++ b/packages/utils/src/crop.ts
@@ -1,11 +1,4 @@
-import {
-  Connection,
-  GraphResponse,
-  Node,
-  NodeCrop,
-  NodeFile,
-  NormalizedCropRect,
-} from '@tgim/types/index';
+import { AbsoluteCropRect, NodeCrop, NormalizedCropRect } from '@tgim/types/index';
 import { clamp01, isFiniteNumber } from './number';
 
 export const toNormalizedCropRect = (crop?: NodeCrop | null): NormalizedCropRect | null => {
@@ -81,5 +74,89 @@ export const toNormalizedCropRect = (crop?: NodeCrop | null): NormalizedCropRect
     startY: startYClamped,
     width: normalizedWidth,
     height: normalizedHeight,
+  };
+};
+
+export const toAbsoluteCropRect = (
+  crop: NodeCrop | null | undefined,
+  sourceWidth: number | null | undefined,
+  sourceHeight: number | null | undefined,
+): AbsoluteCropRect | null => {
+  if (!crop) return null;
+  if (!isFiniteNumber(sourceWidth) || !isFiniteNumber(sourceHeight)) {
+    return null;
+  }
+
+  const normalized = toNormalizedCropRect(crop);
+  if (!normalized) {
+    return null;
+  }
+
+  const width = sourceWidth as number;
+  const height = sourceHeight as number;
+  if (!(width > 0 && height > 0)) {
+    return null;
+  }
+
+  return {
+    startX: normalized.startX * width,
+    startY: normalized.startY * height,
+    width: normalized.width * width,
+    height: normalized.height * height,
+  };
+};
+
+export type CropPreviewStyle = {
+  displayWidth: number;
+  displayHeight: number;
+  backgroundSize: string;
+  backgroundPosition: string;
+  scale: number;
+};
+
+type CropPreviewOptions = {
+  maxEdge?: number;
+};
+
+export const getCropPreviewStyle = (
+  rect: AbsoluteCropRect | null | undefined,
+  sourceWidth: number | null | undefined,
+  sourceHeight: number | null | undefined,
+  options?: CropPreviewOptions,
+): CropPreviewStyle | null => {
+  if (!rect) return null;
+  if (!isFiniteNumber(sourceWidth) || !isFiniteNumber(sourceHeight)) {
+    return null;
+  }
+
+  const width = sourceWidth as number;
+  const height = sourceHeight as number;
+  if (!(width > 0 && height > 0)) {
+    return null;
+  }
+
+  if (!(rect.width > 0 && rect.height > 0)) {
+    return null;
+  }
+
+  const cropMaxEdge = Math.max(rect.width, rect.height);
+  if (!(cropMaxEdge > 0)) {
+    return null;
+  }
+
+  const maxEdge = options?.maxEdge ?? cropMaxEdge;
+  const previewEdge = Math.max(1, maxEdge);
+  const scale = Math.min(previewEdge / cropMaxEdge, 1);
+  const displayWidth = Math.max(rect.width * scale, 1);
+  const displayHeight = Math.max(rect.height * scale, 1);
+  const backgroundSize = `${width * scale}px ${height * scale}px`;
+  const backgroundPosition = `${-rect.startX * scale}px ${-rect.startY * scale}px`;
+
+  return {
+    displayWidth,
+    displayHeight,
+    backgroundSize,
+    backgroundPosition,
+    scale,
   };
 };


### PR DESCRIPTION
## Summary
- add shared crop rectangle types, conversion helpers, and preview style calculator
- expose reusable crop hooks and CropPreview component for consistent image crop rendering
- update panel, graph, viewer, and crop views to rely on shared utilities instead of inline helpers

## Testing
- pnpm lint:check *(fails: missing @eslint/js in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe519d0d4832e8256d3ddf120318a