### PR TITLE
Fix crop previews in graph view

### DIFF
--- a/apps/desktop/src/features/main/panel/panels/GraphView.tsx
+++ b/apps/desktop/src/features/main/panel/panels/GraphView.tsx
@@ -173,10 +173,13 @@ const GraphView: React.FC<Props> = ({ graphData, rootNodeId, rootGraphNodeId }) 
 
       const targetSize = node.type === 'crop' ? cropThumbSize : baseThumbSize;
 
+      // Request thumbnails using only the width so the service preserves the
+      // original aspect ratio. Square thumbnails shift the crop coordinates
+      // and make the preview appear offset in the graph.
       const request: ThumbnailRequest = {
         hash,
         width: targetSize,
-        height: targetSize,
+        height: 0,
         dpr: 1 as const,
         mode: ResizeMode.Original,
       };


### PR DESCRIPTION
## Summary
- request graph view thumbnails using only width so the backend preserves the original aspect ratio
- add inline documentation describing why preserving aspect ratio keeps crop previews aligned

## Testing
- pnpm lint:check *(fails: workspace dependencies are not installed in the container)*
- pnpm install *(fails: 403 fetching @tauri-apps/cli from npm registry without credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3b919d30832ea9a735553d2f2070