### PR TITLE
Replace xlsx dependency with ExcelJS in translation tooling

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "fs-extra": "^11.3.0",
     "path": "^0.12.7",
-    "xlsx": "^0.18.5"
+    "exceljs": "^4.4.0"
   },
   "devDependencies": {}
 }

--- a/scripts/translator.mjs
+++ b/scripts/translator.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
-import xlsx from 'xlsx';
 import path from 'path';
+import ExcelJS from 'exceljs';
 
 const args = process.argv.slice(2);
 const excelPath = args[0] || 'translations.xlsx';
@@ -9,15 +9,62 @@ if (!fs.existsSync(excelPath)) {
   console.error(`❌ Excel file not found: ${excelPath}`);
   process.exit(1);
 }
-const workbook = xlsx.readFile(excelPath);
 
-workbook.SheetNames.forEach(namespace => {
-  const sheet = workbook.Sheets[namespace];
-  const jsonData = xlsx.utils.sheet_to_json(sheet);
+const workbook = new ExcelJS.Workbook();
+
+/**
+ * ExcelJS is MIT-licensed and provides workbook parsing compatible with the
+ * previous xlsx.readFile/sheet_to_json pipeline while keeping us GPL friendly.
+ */
+try {
+  await workbook.xlsx.readFile(excelPath);
+} catch (error) {
+  console.error('❌ Failed to read Excel workbook with ExcelJS:', error);
+  process.exit(1);
+}
+
+workbook.worksheets.forEach(worksheet => {
+  const namespace = worksheet.name;
+
+  const headerByColumn = [];
+  worksheet.getRow(1).eachCell({ includeEmpty: true }, (cell, colNumber) => {
+    const header = cell?.text ?? '';
+    if (header) {
+      headerByColumn[colNumber] = header;
+    }
+  });
+
+  if (headerByColumn.length === 0) {
+    return;
+  }
+
+  const jsonData = [];
+  worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+    if (rowNumber === 1) return;
+
+    const rowData = {};
+    let hasContent = false;
+
+    headerByColumn.forEach((header, colNumber) => {
+      if (!header) return;
+
+      const cellText = row.getCell(colNumber).text ?? '';
+      if (cellText !== '') {
+        hasContent = true;
+      }
+      rowData[header] = cellText;
+    });
+
+    if (hasContent) {
+      jsonData.push(rowData);
+    }
+  });
 
   if (jsonData.length === 0) return;
 
-  const languages = Object.keys(jsonData[0]).filter(col => col !== 'key');
+  const languages = [...new Set(headerByColumn.filter(header => header && header !== 'key'))];
+
+  if (languages.length === 0) return;
 
   languages.forEach(lang => {
     const langDir = path.join(outputDir, lang);
@@ -25,8 +72,11 @@ workbook.SheetNames.forEach(namespace => {
 
     const translations = {};
     jsonData.forEach(row => {
+      if (!row.key) return;
       translations[row.key] = row[lang] || '';
     });
+
+    if (Object.keys(translations).length === 0) return;
 
     const jsonPath = path.join(langDir, `${namespace}.json`);
     fs.writeJsonSync(jsonPath, translations, { spaces: 2, encoding: 'utf-8' });


### PR DESCRIPTION
## Summary
- replace the non-MIT xlsx dependency in @grim/scripts with the MIT-licensed ExcelJS parser
- rewrite translator.mjs to load workbooks via ExcelJS and reproduce the JSON generation pipeline
- add defensive handling around workbook parsing and skip empty namespaces/languages when emitting files

## Testing
- pnpm install *(fails: registry.npmjs.org returned 403 Forbidden in this environment)*
- pnpm translate *(fails: workspace dependencies such as fs-extra are unavailable without a successful install)*

------
https://chatgpt.com/codex/tasks/task_e_68de13643e40832e81aca2210c1e0462