### PR TITLE
Replace hardcoded Tailwind colors with design tokens

### DIFF
--- a/apps/desktop/src/features/croquis/CroquisWindow.tsx
+++ b/apps/desktop/src/features/croquis/CroquisWindow.tsx
@@ -311,7 +311,7 @@ const CroquisWindow: React.FC = () => {
           <div className="w-full max-w-[720px]">
             <div className="h-1 w-full overflow-hidden rounded-full bg-surface-muted">
               <div
-                className={`h-full ${isCritical ? 'bg-red-500' : 'bg-accent'}`}
+                className={`h-full ${isCritical ? 'bg-status-danger' : 'bg-accent'}`}
                 style={{ width: `${String(Math.min(100, Math.max(0, progress * 100)))}%` }}
               />
             </div>

--- a/apps/desktop/src/features/file/modal/FolderImportProgressModal.tsx
+++ b/apps/desktop/src/features/file/modal/FolderImportProgressModal.tsx
@@ -93,7 +93,7 @@ const FolderImportProgressModal: React.FC<Props> = ({
   }, [progress.state, safeName]);
 
   const dismissible = progress.state === 'completed' || progress.state === 'failed';
-  const barColor = progress.state === 'failed' ? 'bg-[var(--color-status-danger)]' : 'bg-accent';
+  const barColor = progress.state === 'failed' ? 'bg-status-danger' : 'bg-accent';
 
   return (
     <Modal onClose={onClose} className="bg-modal-bg w-[28rem]" dismissible={dismissible}>

--- a/apps/desktop/src/features/file/modal/FolderOptionsModal.tsx
+++ b/apps/desktop/src/features/file/modal/FolderOptionsModal.tsx
@@ -493,12 +493,14 @@ const FolderOptionsModal: React.FC<FolderOptionsModalProps> = ({
                   <span>{formatDate(mount.lastSeenAt)}</span>
                 </div>
                 {mount.errorMsg ? (
-                  <p className="rounded bg-red-500/10 p-2 text-xs text-red-400">{mount.errorMsg}</p>
+                  <p className="rounded bg-status-danger/10 p-2 text-xs text-status-danger">
+                    {mount.errorMsg}
+                  </p>
                 ) : null}
               </div>
             </section>
 
-            {error ? <p className="text-sm text-red-400">{error}</p> : null}
+            {error ? <p className="text-sm text-status-danger">{error}</p> : null}
           </div>
         )}
 

--- a/apps/desktop/src/features/file/modal/NewFolderModal.tsx
+++ b/apps/desktop/src/features/file/modal/NewFolderModal.tsx
@@ -418,7 +418,7 @@ const NewFolderModal: React.FC<Props> = ({ onClose, onSubmit }) => {
             {loadingPreview && (
               <p className="text-sm text-modal-text-secondary">폴더 구조를 불러오는 중입니다...</p>
             )}
-            {previewError && <p className="text-sm text-red-400">{previewError}</p>}
+            {previewError && <p className="text-sm text-status-danger">{previewError}</p>}
             {preview && !loadingPreview && !previewError && (
               <div className="rounded-md bg-modal-input-bg/60 p-3 text-sm">
                 <div>폴더: {preview.summary.totalFolders.toLocaleString()}개</div>

--- a/apps/desktop/src/features/file/modal/ThumbnailStorageModal.tsx
+++ b/apps/desktop/src/features/file/modal/ThumbnailStorageModal.tsx
@@ -93,7 +93,7 @@ const ThumbnailStorageModal: React.FC<ThumbnailStorageModalProps> = ({ open, onC
         </header>
 
         {error ? (
-          <div className="rounded-md border border-red-400/40 bg-red-400/10 p-3 text-sm text-red-200">
+          <div className="rounded-md border border-status-danger/40 bg-status-danger/10 p-3 text-sm text-status-danger/70">
             {error}
           </div>
         ) : null}

--- a/apps/desktop/src/features/main/ProgressWindow.tsx
+++ b/apps/desktop/src/features/main/ProgressWindow.tsx
@@ -9,7 +9,7 @@ const ProgressWindow: React.FC<Props> = ({ progress }) => {
         <div className="w-full h-3 rounded-full bg-surface-muted">
           <div
             className={`h-3 rounded-full ${
-              progress.stage === 'Error' ? 'bg-[var(--color-status-danger)]' : 'bg-accent'
+              progress.stage === 'Error' ? 'bg-status-danger' : 'bg-accent'
             }`}
             style={{ width: `${String(progress.percent)}%` }}
           ></div>

--- a/apps/desktop/src/features/main/panel/panels/FileDetailSidebar.tsx
+++ b/apps/desktop/src/features/main/panel/panels/FileDetailSidebar.tsx
@@ -28,9 +28,9 @@ type ActionState = {
 const PREVIEW_WIDTH = 360;
 
 const statusLabel: Partial<Record<FilePathStatus, { label: string; tone: string }>> = {
-  ok: { label: '정상', tone: 'text-emerald-500 dark:text-emerald-400' },
-  warning: { label: '경고', tone: 'text-amber-500 dark:text-amber-400' },
-  error: { label: '오류', tone: 'text-rose-500 dark:text-rose-400' },
+  ok: { label: '정상', tone: 'text-status-success' },
+  warning: { label: '경고', tone: 'text-status-warning' },
+  error: { label: '오류', tone: 'text-status-danger' },
 };
 
 const extractPath = (value: string | string[] | null): string | null => {
@@ -227,7 +227,7 @@ const FileDetailSidebar: React.FC<Props> = ({ image, onClose }) => {
       </div>
       <div className="flex-1 overflow-auto px-4 py-3 space-y-6">
         {error && (
-          <div className="rounded-md border border-rose-400/60 bg-rose-100/70 px-3 py-2 text-sm text-rose-700 dark:bg-rose-500/10 dark:text-rose-200">
+          <div className="rounded-md border border-status-danger/60 bg-status-danger/10 px-3 py-2 text-sm text-status-danger">
             {error}
           </div>
         )}
@@ -319,17 +319,13 @@ const FileDetailSidebar: React.FC<Props> = ({ image, onClose }) => {
                           </span>
                           {pathInfo.warning && <span>{pathInfo.warning}</span>}
                           {pathInfo.error && (
-                            <span className="text-rose-500 dark:text-rose-300">
-                              {pathInfo.error}
-                            </span>
+                            <span className="text-status-danger">{pathInfo.error}</span>
                           )}
                           {!pathInfo.exists && !pathInfo.error && (
-                            <span className="text-rose-500 dark:text-rose-300">
-                              파일을 찾을 수 없습니다
-                            </span>
+                            <span className="text-status-danger">파일을 찾을 수 없습니다</span>
                           )}
                           {pathInfo.hashMatches === false && (
-                            <span className="text-rose-500 dark:text-rose-300">해시 불일치</span>
+                            <span className="text-status-danger">해시 불일치</span>
                           )}
                           {pathInfo.hashMatches && <span>해시 일치</span>}
                         </div>

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -86,6 +86,11 @@ export default {
           hover: 'var(--color-brand-hover)',
           ring: 'var(--ds-accent-ring)',
         },
+        status: {
+          success: 'var(--color-status-success)',
+          warning: 'var(--color-status-warning)',
+          danger: 'var(--color-status-danger)',
+        },
         overlay: {
           DEFAULT: 'var(--ds-overlay)',
         },

--- a/packages/ui/src/styles/foundations.css
+++ b/packages/ui/src/styles/foundations.css
@@ -28,6 +28,14 @@
   --ds-indigo-500: #6366f1;
   --ds-indigo-600: #4f46e5;
 
+  /* Positive + warning palette */
+  --ds-emerald-400: #34d399;
+  --ds-emerald-500: #10b981;
+  --ds-emerald-600: #059669;
+  --ds-amber-400: #fbbf24;
+  --ds-amber-500: #f59e0b;
+  --ds-amber-600: #d97706;
+
   /* Supporting accents */
   --ds-red-400: #f87171;
   --ds-red-500: #ef4444;

--- a/packages/ui/src/styles/semantic.css
+++ b/packages/ui/src/styles/semantic.css
@@ -50,6 +50,8 @@
   --ds-brand: var(--ds-blue-500);
 
   /* Status tokens */
+  --ds-status-success: var(--ds-emerald-500);
+  --ds-status-warning: var(--ds-amber-500);
   --ds-status-danger: var(--ds-red-600);
 
   /* Stateful layers */
@@ -131,6 +133,8 @@
   --color-border: var(--ds-border-subtle);
   --color-border-hover: var(--ds-border-strong);
 
+  --color-status-success: var(--ds-status-success);
+  --color-status-warning: var(--ds-status-warning);
   --color-status-danger: var(--ds-status-danger);
 
   --color-brand: var(--ds-accent);
@@ -260,6 +264,8 @@
   --ds-accent-ring: color-mix(in srgb, var(--ds-indigo-500) 30%, transparent);
 
   /* Status tokens */
+  --ds-status-success: var(--ds-emerald-400);
+  --ds-status-warning: var(--ds-amber-400);
   --ds-status-danger: var(--ds-red-400);
 
   --ds-overlay: rgba(2, 6, 23, 0.7);


### PR DESCRIPTION
## Summary
- add success and warning status palette entries and expose them via Tailwind tokens
- replace hardcoded Tailwind utility colors in desktop UI with the new status tokens
- normalize progress indicators to use the shared status color token

## Testing
- pnpm lint:check *(fails: missing dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfabc54a8c832ea0e6312a07002bba