### PR TITLE
Add eyedropper color picker to FileViewer images

### DIFF
--- a/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
+++ b/apps/desktop/src/features/main/panel/panels/FileViewer.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { MouseEventHandler } from 'react';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { FileType } from '@tgim/types/file';
 import { NodeCrop, NodeFile } from '@tgim/types/graph';
 import { ipc } from '../../../../lib/ipc';
-import { FileText } from 'lucide-react';
+import { FileText, Pipette } from 'lucide-react';
 import { cn } from '@tgim/utils/index';
 import { Split } from '@tgim/ui/Splitter';
 import Button from '@tgim/ui/Button';
@@ -28,6 +29,8 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const imageWrapperRef = useRef<HTMLDivElement | null>(null);
   const imageElementRef = useRef<HTMLImageElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const canvasContextRef = useRef<CanvasRenderingContext2D | null>(null);
   const [imageMetrics, setImageMetrics] = useState<{
     width: number;
     height: number;
@@ -35,6 +38,17 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
     offsetY: number;
   } | null>(null);
   const normalizedCropRect = useNormalizedCropRect(crop);
+  type RgbColor = { r: number; g: number; b: number };
+
+  const [eyedropperActive, setEyedropperActive] = useState(false);
+  const [hoverColor, setHoverColor] = useState<RgbColor | null>(null);
+  const [hoverTooltipPosition, setHoverTooltipPosition] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const [selectedColor, setSelectedColor] = useState<RgbColor | null>(null);
+
+  const formatRgb = (color: RgbColor) =>
+    `rgb(${color.r.toString()}, ${color.g.toString()}, ${color.b.toString()})`;
 
   useEffect(() => {
     if (file.kind !== FileType.Image) {
@@ -79,6 +93,139 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
       setImageMetrics(null);
     }
   }, [status]);
+
+  useEffect(() => {
+    if (status !== 'ready') {
+      canvasRef.current = null;
+      canvasContextRef.current = null;
+      return;
+    }
+
+    const img = imageElementRef.current;
+    if (!img) return;
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    const drawImage = () => {
+      if (!img.naturalWidth || !img.naturalHeight) return;
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      context.drawImage(img, 0, 0, canvas.width, canvas.height);
+      canvasRef.current = canvas;
+      canvasContextRef.current = context;
+    };
+
+    let cleanup: (() => void) | undefined;
+    if (img.complete && img.naturalWidth && img.naturalHeight) {
+      drawImage();
+    } else {
+      const handleLoad = () => {
+        drawImage();
+      };
+      img.addEventListener('load', handleLoad, { once: true });
+      cleanup = () => {
+        img.removeEventListener('load', handleLoad);
+      };
+    }
+
+    return () => {
+      cleanup?.();
+      canvasRef.current = null;
+      canvasContextRef.current = null;
+    };
+  }, [status, imageSrc]);
+
+  useEffect(() => {
+    setSelectedColor(null);
+    setEyedropperActive(false);
+    setHoverColor(null);
+    setHoverTooltipPosition(null);
+  }, [file.xxh364]);
+
+  const handleToggleEyedropper = () => {
+    setEyedropperActive(prev => {
+      const next = !prev;
+      if (!next) {
+        setHoverColor(null);
+        setHoverTooltipPosition(null);
+      }
+      return next;
+    });
+  };
+
+  const handlePointerMove: MouseEventHandler<HTMLDivElement> = event => {
+    if (!eyedropperActive) return;
+    const wrapper = imageWrapperRef.current;
+    const img = imageElementRef.current;
+    const metrics = imageMetrics;
+    const context = canvasContextRef.current;
+    if (!wrapper || !img || !metrics || !context) return;
+
+    const rect = wrapper.getBoundingClientRect();
+    const relativeX = event.clientX - rect.left;
+    const relativeY = event.clientY - rect.top;
+
+    const imageX = relativeX - metrics.offsetX;
+    const imageY = relativeY - metrics.offsetY;
+
+    if (imageX < 0 || imageY < 0 || imageX > metrics.width || imageY > metrics.height) {
+      setHoverColor(null);
+      setHoverTooltipPosition(null);
+      return;
+    }
+
+    const naturalX = Math.floor((imageX / Math.max(metrics.width, 1e-6)) * img.naturalWidth);
+    const naturalY = Math.floor((imageY / Math.max(metrics.height, 1e-6)) * img.naturalHeight);
+
+    if (
+      naturalX < 0 ||
+      naturalY < 0 ||
+      naturalX >= img.naturalWidth ||
+      naturalY >= img.naturalHeight
+    ) {
+      setHoverColor(null);
+      setHoverTooltipPosition(null);
+      return;
+    }
+
+    try {
+      const pixel = context.getImageData(naturalX, naturalY, 1, 1).data;
+      const color = { r: pixel[0], g: pixel[1], b: pixel[2] };
+      setHoverColor(color);
+
+      const tooltipPadding = 16;
+      const tooltipWidth = 120;
+      const tooltipHeight = 48;
+      const clampedX = Math.min(
+        Math.max(relativeX + tooltipPadding, 0),
+        Math.max(rect.width - tooltipWidth, 0),
+      );
+      const clampedY = Math.min(
+        Math.max(relativeY + tooltipPadding, 0),
+        Math.max(rect.height - tooltipHeight, 0),
+      );
+      setHoverTooltipPosition({ x: clampedX, y: clampedY });
+    } catch (error) {
+      console.error('[FileViewer] Failed to read pixel data', error);
+    }
+  };
+
+  const handleMouseLeave: MouseEventHandler<HTMLDivElement> = () => {
+    setHoverColor(null);
+    setHoverTooltipPosition(null);
+  };
+
+  const handleImageClick: MouseEventHandler<HTMLDivElement> = event => {
+    if (!eyedropperActive) return;
+    event.preventDefault();
+    if (!hoverColor) return;
+    setSelectedColor(hoverColor);
+    setEyedropperActive(false);
+    setHoverColor(null);
+    setHoverTooltipPosition(null);
+  };
 
   useEffect(() => {
     if (!normalizedCropRect) {
@@ -191,21 +338,51 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
               <div className="flex h-full min-h-0 w-full flex-col gap-3 relative">
                 {/* Toggle button pinned to the top-right over the viewer */}
                 {
-                  <Button
-                    type="button"
-                    variant="icon"
-                    aria-label={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
-                    title={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
-                    onClick={() => {
-                      setViewerSidebarVisible(prev => !prev);
-                    }}
-                    className="absolute right-0 top-0 h-8 w-8"
-                    aria-controls="viewer-sidebar"
-                    aria-expanded={viewerSidebarVisible}
-                  >
-                    {/* Keep it simple — use chevrons as text fallback */}
-                    {viewerSidebarVisible ? '>' : '<'}
-                  </Button>
+                  <div className="absolute right-0 top-0 flex flex-col items-end gap-2">
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="icon"
+                        aria-label={eyedropperActive ? '스포이드 비활성화' : '스포이드 활성화'}
+                        title={eyedropperActive ? '스포이드 비활성화' : '스포이드 활성화'}
+                        onClick={handleToggleEyedropper}
+                        className={cn(
+                          'h-8 w-8',
+                          eyedropperActive &&
+                            'bg-primary text-primary-foreground hover:bg-primary/90',
+                        )}
+                      >
+                        <Pipette className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="icon"
+                        aria-label={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
+                        title={viewerSidebarVisible ? '사이드바 닫기' : '사이드바 열기'}
+                        onClick={() => {
+                          setViewerSidebarVisible(prev => !prev);
+                        }}
+                        className="h-8 w-8"
+                        aria-controls="viewer-sidebar"
+                        aria-expanded={viewerSidebarVisible}
+                      >
+                        {/* Keep it simple — use chevrons as text fallback */}
+                        {viewerSidebarVisible ? '>' : '<'}
+                      </Button>
+                    </div>
+                    {selectedColor ? (
+                      <div className="flex items-center gap-2 rounded-md border border-border bg-background/90 px-2 py-1 text-xs font-mono shadow">
+                        <span
+                          className="h-3 w-3 rounded-sm border border-border"
+                          style={{
+                            backgroundColor: formatRgb(selectedColor),
+                          }}
+                          aria-hidden
+                        />
+                        <span>{formatRgb(selectedColor)}</span>
+                      </div>
+                    ) : null}
+                  </div>
                 }
 
                 {/* Header (non-scrolling) */}
@@ -220,7 +397,13 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
                   {file.kind === FileType.Image ? (
                     <div
                       ref={imageWrapperRef}
-                      className="relative flex h-full items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted"
+                      className={cn(
+                        'relative flex h-full items-center justify-center overflow-hidden rounded-lg border border-border bg-surface-muted',
+                        eyedropperActive && 'cursor-crosshair',
+                      )}
+                      onMouseMove={handlePointerMove}
+                      onMouseLeave={handleMouseLeave}
+                      onClick={handleImageClick}
                     >
                       {status === 'ready' && imageSrc ? (
                         <>
@@ -230,6 +413,25 @@ const FileViewer: React.FC<FileViewerProps> = ({ file, moaId, className, crop })
                             alt={file.fileName}
                             className="h-full w-full max-h-full max-w-full object-contain"
                           />
+                          {eyedropperActive && hoverColor && hoverTooltipPosition ? (
+                            <div
+                              className="pointer-events-none absolute z-10 flex flex-col items-center gap-1"
+                              style={{
+                                left: hoverTooltipPosition.x,
+                                top: hoverTooltipPosition.y,
+                              }}
+                            >
+                              <div className="rounded-md border border-border bg-background/90 px-2 py-1 text-xs font-mono shadow">
+                                {formatRgb(hoverColor)}
+                              </div>
+                              <div
+                                className="h-4 w-4 rounded-sm border border-border"
+                                style={{
+                                  backgroundColor: formatRgb(hoverColor),
+                                }}
+                              />
+                            </div>
+                          ) : null}
                           {normalizedCropRect && imageMetrics ? (
                             <div
                               className="pointer-events-none absolute rounded-md border-2 border-primary/80 bg-primary/15 shadow-[0_0_0_1px_rgba(15,23,42,0.15)]"


### PR DESCRIPTION
## Summary
- add a pipette toggle to the FileViewer image panel and capture pixel colors from the loaded bitmap
- show a live RGB tooltip while hovering and pin the picked color beneath the pipette control

## Testing
- pnpm lint:ts
- pnpm lint *(fails: cargo clippy cannot download crates index in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e69e3fba40832e98af4be0d4af71a1