### PR TITLE
Add Windows CI workflow and fix Windows build support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,3 +103,54 @@ jobs:
 
       - name: Build (cargo build)
         run: cargo build --manifest-path apps/desktop/src-tauri/Cargo.toml --release
+
+  windows:
+    name: Windows Checks
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1.88.0
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Format check (cargo fmt)
+        run: cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
+
+      - name: Lint (cargo clippy)
+        run: cargo clippy --manifest-path apps/desktop/src-tauri/Cargo.toml --all-targets -- -D warnings
+
+      - name: Build (cargo build)
+        run: cargo build --manifest-path apps/desktop/src-tauri/Cargo.toml --release
+
+      - name: Build frontend
+        run: pnpm --filter @grim/desktop build

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ uuid = { version = "1.17.0", features = ["v4"] }
 tokio = "1.47.1"
 once_cell = "1.21.3"
 tauri-plugin-os = "2"
-tauri-plugin-decorum = "1.1.1"
 dunce = "1.0.5"
 mountpoints = "0.2.1"
 dirs-next = "2.0.0"
@@ -56,6 +55,7 @@ tauri-plugin-http = "2.5.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.7.4"
+tauri-plugin-decorum = "1.1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.3", features = ["Win32_Storage_FileSystem"] }

--- a/apps/desktop/src-tauri/src/models/file.rs
+++ b/apps/desktop/src-tauri/src/models/file.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use sqlx::{FromRow, Type};
 
-#[cfg(not(target_os = "windows"))]
 use std::{
     convert::From,
     fs::{self, Metadata},


### PR DESCRIPTION
## Summary
- add a Windows runner to the CI pipeline to exercise the desktop frontend and backend on windows-latest
- gate the tauri decorum plugin to mac builds and fix missing std imports so the Rust backend compiles on Windows

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68e6ad0861d0832e9f0505157b37413c