### PR TITLE
feat: add library workspace filters

### DIFF
--- a/apps/desktop/src-tauri/.sqlx/query-613f9d836593ca57542f42dc961a524ae1982fe9e8ddab06d6f731e50ab44bcf.json
+++ b/apps/desktop/src-tauri/.sqlx/query-613f9d836593ca57542f42dc961a524ae1982fe9e8ddab06d6f731e50ab44bcf.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            WITH requested_asset(id) AS (\n              SELECT CAST(value AS TEXT)\n              FROM json_each(?1)\n            ),\n            asset_record_match AS (\n              SELECT requested.id AS asset_id,\n                     cr.id AS record_id\n              FROM requested_asset requested\n              LEFT JOIN croquis_record cr\n                ON cr.source_asset_id = requested.id\n               AND cr.finished_at IS NOT NULL\n              UNION ALL\n              SELECT requested.id AS asset_id,\n                     cr.id AS record_id\n              FROM requested_asset requested\n              LEFT JOIN croquis_record cr\n                ON cr.result_asset_id = requested.id\n               AND cr.finished_at IS NOT NULL\n               AND (cr.source_asset_id IS NULL OR cr.source_asset_id != requested.id)\n            )\n            SELECT asset_id AS \"asset_id!: String\",\n                   COUNT(record_id) AS \"related_record_count!: i64\"\n            FROM asset_record_match\n            GROUP BY asset_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "asset_id!: String",
+        "ordinal": 0,
+        "type_info": "Null"
+      },
+      {
+        "name": "related_record_count!: i64",
+        "ordinal": 1,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      null,
+      false
+    ]
+  },
+  "hash": "613f9d836593ca57542f42dc961a524ae1982fe9e8ddab06d6f731e50ab44bcf"
+}

--- a/apps/desktop/src-tauri/src/commands/asset.rs
+++ b/apps/desktop/src-tauri/src/commands/asset.rs
@@ -3,7 +3,7 @@ use tauri::State;
 use crate::{
     errors::{CommandResult, IntoCommandResult},
     models::asset::{
-        AssetDetail, AssetListSource, AssetSummary,
+        AssetDetail, AssetListSource, AssetRecordCount, AssetSummary,
         BatchUpdateAssetFoldersPayload, UpdateAssetFoldersPayload,
     },
     services::AssetService,
@@ -15,6 +15,14 @@ pub async fn list_assets(
     asset_service: State<'_, AssetService>,
 ) -> CommandResult<Vec<AssetSummary>> {
     asset_service.list_assets(source).await.into_command()
+}
+
+#[tauri::command]
+pub async fn list_asset_record_counts(
+    source: AssetListSource,
+    asset_service: State<'_, AssetService>,
+) -> CommandResult<Vec<AssetRecordCount>> {
+    asset_service.list_asset_record_counts(source).await.into_command()
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -50,6 +50,7 @@ pub fn run() {
             commands::folder_commands::delete_virtual_folder,
             commands::folder_commands::search_virtual_folders,
             commands::asset_commands::list_assets,
+            commands::asset_commands::list_asset_record_counts,
             commands::asset_commands::get_asset_detail,
             commands::asset_commands::update_asset_folders,
             commands::asset_commands::batch_update_asset_folders,

--- a/apps/desktop/src-tauri/src/models/asset.rs
+++ b/apps/desktop/src-tauri/src/models/asset.rs
@@ -38,6 +38,13 @@ pub struct AssetDetail {
     pub last_croquis_at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetRecordCount {
+    pub asset_id: String,
+    pub related_record_count: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum AssetListSource {

--- a/apps/desktop/src-tauri/src/repositories/asset_repository.rs
+++ b/apps/desktop/src-tauri/src/repositories/asset_repository.rs
@@ -3,7 +3,7 @@ use sqlx::{Sqlite, SqlitePool, Transaction};
 
 use crate::{
     models::{
-        asset::{AssetDetail, AssetListSource, AssetSummary},
+        asset::{AssetDetail, AssetListSource, AssetRecordCount, AssetSummary},
         folder::VirtualFolder,
         record::CroquisRecordSummary,
     },
@@ -216,6 +216,56 @@ impl AssetRepository {
         .await?;
 
         Ok(asset_from_row(row))
+    }
+
+    pub async fn list_record_counts_by_source(
+        &self,
+        source: AssetListSource,
+    ) -> Result<Vec<AssetRecordCount>> {
+        let source_assets = self.list_by_source(source).await?;
+        if source_assets.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let asset_ids = source_assets
+            .iter()
+            .map(|asset| asset.id.clone())
+            .collect::<Vec<_>>();
+        let asset_ids_json = serde_json::to_string(&asset_ids)?;
+        let rows = sqlx::query_as!(
+            AssetRecordCount,
+            r#"
+            WITH requested_asset(id) AS (
+              SELECT CAST(value AS TEXT)
+              FROM json_each(?1)
+            ),
+            asset_record_match AS (
+              SELECT requested.id AS asset_id,
+                     cr.id AS record_id
+              FROM requested_asset requested
+              LEFT JOIN croquis_record cr
+                ON cr.source_asset_id = requested.id
+               AND cr.finished_at IS NOT NULL
+              UNION ALL
+              SELECT requested.id AS asset_id,
+                     cr.id AS record_id
+              FROM requested_asset requested
+              LEFT JOIN croquis_record cr
+                ON cr.result_asset_id = requested.id
+               AND cr.finished_at IS NOT NULL
+               AND (cr.source_asset_id IS NULL OR cr.source_asset_id != requested.id)
+            )
+            SELECT asset_id AS "asset_id!: String",
+                   COUNT(record_id) AS "related_record_count!: i64"
+            FROM asset_record_match
+            GROUP BY asset_id
+            "#,
+            asset_ids_json
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
     }
 
     pub async fn get_detail(&self, asset_id: &str) -> Result<AssetDetail> {

--- a/apps/desktop/src-tauri/src/services/asset_service.rs
+++ b/apps/desktop/src-tauri/src/services/asset_service.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 
 use crate::{
     models::asset::{
-        AssetDetail, AssetListSource, AssetSummary,
+        AssetDetail, AssetListSource, AssetRecordCount, AssetSummary,
         BatchUpdateAssetFoldersMode, BatchUpdateAssetFoldersPayload,
         ImportFailure, ImportPreviewResult, ImportRemoteImagesRequest,
         ImportRequest, ImportResult, UpdateAssetFoldersPayload,
@@ -67,6 +67,13 @@ impl AssetService {
     ) -> Result<Vec<AssetSummary>> {
         let assets = self.asset_repository.list_by_source(source).await?;
         Ok(self.hydrate_asset_summaries(assets).await)
+    }
+
+    pub async fn list_asset_record_counts(
+        &self,
+        source: AssetListSource,
+    ) -> Result<Vec<AssetRecordCount>> {
+        self.asset_repository.list_record_counts_by_source(source).await
     }
 
     pub async fn get_asset(&self, asset_id: &str) -> Result<AssetDetail> {

--- a/apps/desktop/src/features/library-explorer/ExplorerPanel.tsx
+++ b/apps/desktop/src/features/library-explorer/ExplorerPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getErrorMessage } from '../../shared/lib/error';
 import { Button } from '../../shared/ui';
 import { ExplorerTreeGroup } from './ExplorerTreeGroup';
 import { FOLDERS_NODE_ID } from './explorerTree';
@@ -18,18 +19,6 @@ function buildDefaultExpandedState(nodes: ExplorerNode[]): Record<string, boolea
 }
 
 const FOLDER_NODE_ID_PREFIX = 'folder:';
-
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  return fallback;
-}
 
 function getFolderIdFromNodeId(nodeId: string) {
   return nodeId.startsWith(FOLDER_NODE_ID_PREFIX)

--- a/apps/desktop/src/features/library-workspace/common/SelectionToolbar.tsx
+++ b/apps/desktop/src/features/library-workspace/common/SelectionToolbar.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cx } from '../../../shared/lib/cx';
+import { Button, Checkbox } from '../../../shared/ui';
+
+type SelectionToolbarProps = {
+  selectionMode: boolean;
+  selectedCount: number;
+  totalCount: number;
+  selectAllAriaLabel: string;
+  actions?: ReactNode;
+  className?: string;
+  cancelDisabled?: boolean;
+  selectDisabled?: boolean;
+  selectAllDisabled?: boolean;
+  onSelectionModeChange: (selectionMode: boolean) => void;
+  onSelectAllChange: (selected: boolean) => void;
+};
+
+export function SelectionToolbar({
+  selectionMode,
+  selectedCount,
+  totalCount,
+  selectAllAriaLabel,
+  actions = null,
+  className,
+  cancelDisabled = false,
+  selectDisabled = false,
+  selectAllDisabled = totalCount === 0,
+  onSelectionModeChange,
+  onSelectAllChange,
+}: SelectionToolbarProps) {
+  const { t } = useTranslation('common');
+  const allSelected = totalCount > 0 && selectedCount === totalCount;
+  const selectedLabel = t('common.selected_count', {
+    count: selectedCount,
+    formattedCount: selectedCount.toLocaleString(),
+    defaultValue: '{{formattedCount}} selected',
+  });
+  const rootClassName = cx('library-selection-toolbar', className);
+
+  if (!selectionMode) {
+    return (
+      <div className={rootClassName} data-selection="off">
+        <Button
+          size="sm"
+          className="library-selection-toolbar__button"
+          disabled={selectDisabled}
+          onClick={() => {
+            onSelectionModeChange(true);
+          }}
+        >
+          {t('common.select', { defaultValue: 'Select' })}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={rootClassName} data-selection="on">
+      <div className="library-selection-toolbar__left">
+        <Button
+          size="sm"
+          variant="secondary"
+          className="library-selection-toolbar__button"
+          disabled={cancelDisabled}
+          onClick={() => {
+            onSelectionModeChange(false);
+          }}
+        >
+          {t('common.cancel', { defaultValue: 'Cancel' })}
+        </Button>
+        <label className="library-selection-toolbar__select-all">
+          <Checkbox
+            size="sm"
+            checked={allSelected}
+            disabled={selectAllDisabled}
+            aria-label={selectAllAriaLabel}
+            onCheckedChange={onSelectAllChange}
+          />
+          <span>{t('common.select_all', { defaultValue: 'Select all' })}</span>
+        </label>
+        <span className="library-selection-toolbar__divider" aria-hidden />
+        <span className="library-selection-toolbar__count">{selectedLabel}</span>
+      </div>
+
+      {actions ? <div className="library-selection-toolbar__actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/library-workspace/common/library-workspace.css
+++ b/apps/desktop/src/features/library-workspace/common/library-workspace.css
@@ -53,6 +53,186 @@
     transform: translateX(16px);
   }
 
+  .library-explorer-header-shell {
+    display: flex;
+    flex: none;
+    flex-direction: column;
+    min-width: 0;
+    border-bottom: 1px solid var(--semantic-colors-border-secondary);
+    background: var(--semantic-colors-surface-panel);
+  }
+
+  .library-explorer-header {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 48px;
+    padding: 0 24px;
+    background: var(--semantic-colors-surface-panel);
+  }
+
+  .library-explorer-header-shell[data-expanded='true'] .library-explorer-header {
+    border-bottom: 1px solid var(--semantic-colors-border-secondary);
+  }
+
+  .library-explorer-header__leading,
+  .library-explorer-header__actions {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .library-explorer-header__leading {
+    gap: 16px;
+  }
+
+  .library-explorer-header__actions {
+    gap: 8px;
+  }
+
+  .library-explorer-header__filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 24px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--semantic-colors-text-secondary);
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: var(--font-weight-medium);
+    cursor: pointer;
+  }
+
+  .library-explorer-header__filter[data-expanded='true'] {
+    color: var(--semantic-colors-text-primary);
+  }
+
+  .library-explorer-header__filter:hover,
+  .library-explorer-header__filter:focus-visible {
+    color: var(--semantic-colors-text-primary);
+  }
+
+  .library-explorer-header__filter:focus-visible {
+    border-radius: var(--primitives-radius-05);
+    outline: 2px solid var(--semantic-colors-border-focus);
+    outline-offset: 2px;
+  }
+
+  .library-explorer-header__filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 5px;
+    border-radius: var(--primitives-radius-full);
+    background: var(--components-croquis-duration-chip-active-background);
+    color: var(--semantic-colors-brand-primary);
+    font-size: 10px;
+    line-height: 14px;
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .library-explorer-header__sort,
+  .library-explorer-header__count {
+    margin: 0;
+    overflow: hidden;
+    color: var(--semantic-colors-text-tertiary);
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: var(--font-weight-medium);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .library-explorer-header__sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--semantic-colors-text-secondary);
+  }
+
+  .library-explorer-header__divider {
+    width: 1px;
+    height: 16px;
+    background: var(--semantic-colors-border-subtle);
+  }
+
+  .library-explorer-filter-panel {
+    position: relative;
+    display: flex;
+    flex: none;
+    align-items: center;
+    min-width: 0;
+    padding: 17px 24px 16px;
+    border-top: 1px solid var(--semantic-colors-border-soft);
+    background: var(--semantic-colors-surface-panel);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+
+  .library-selection-toolbar {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 0 24px;
+    border-bottom: 1px solid var(--semantic-colors-border-secondary);
+    background: var(--semantic-colors-surface-panel);
+  }
+
+  .library-selection-toolbar__left,
+  .library-selection-toolbar__actions {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .library-selection-toolbar__left {
+    gap: 16px;
+  }
+
+  .library-selection-toolbar__actions {
+    gap: 8px;
+  }
+
+  .library-selection-toolbar .c-button {
+    align-self: center;
+    min-width: 60px;
+  }
+
+  .library-selection-toolbar__select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    color: var(--semantic-colors-text-primary);
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .library-selection-toolbar__divider {
+    width: 1px;
+    height: 16px;
+    background: var(--semantic-colors-border-subtle);
+  }
+
+  .library-selection-toolbar__count {
+    color: var(--semantic-colors-text-tertiary);
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: var(--font-weight-medium);
+    white-space: nowrap;
+  }
+
   .masonry-grid {
     --masonry-item-width: 280px;
     --masonry-gap-x: 16px;

--- a/apps/desktop/src/features/library-workspace/records/RecordExplorerHeader.tsx
+++ b/apps/desktop/src/features/library-workspace/records/RecordExplorerHeader.tsx
@@ -1,24 +1,59 @@
+import { useId } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Icon, IconButton } from '../../../shared/ui';
+import { ChipButton, Icon, IconButton } from '../../../shared/ui';
 import type { LibraryWorkspaceLayout } from '../common/types';
+
+export type RecordExplorerFilterTag = {
+  id: string;
+  name: string;
+};
+
+export type RecordExplorerFilterGroup = {
+  key: string;
+  label: string;
+  tags: readonly RecordExplorerFilterTag[];
+};
+
+export type RecordExplorerSelectedFilters = Readonly<Record<string, readonly string[]>>;
 
 type RecordExplorerHeaderProps = {
   itemCount: number;
   layout: LibraryWorkspaceLayout;
+  filterExpanded?: boolean;
+  filterGroups?: readonly RecordExplorerFilterGroup[];
+  selectedFilters?: RecordExplorerSelectedFilters;
   onLayoutChange: (layout: LibraryWorkspaceLayout) => void;
+  onFilterExpandedChange?: (expanded: boolean) => void;
+  onFilterTagToggle?: (groupKey: string, tagId: string) => void;
 };
+
+function getSelectedFilterCount(selectedFilters: RecordExplorerSelectedFilters) {
+  return Object.values(selectedFilters).reduce((count, tagIds) => count + tagIds.length, 0);
+}
 
 export function RecordExplorerHeader({
   itemCount,
   layout,
+  filterExpanded = false,
+  filterGroups = [],
+  selectedFilters = {},
   onLayoutChange,
+  onFilterExpandedChange,
+  onFilterTagToggle,
 }: RecordExplorerHeaderProps) {
   const { t } = useTranslation('common');
+  const filterPanelId = useId();
+  const selectedFilterCount = getSelectedFilterCount(selectedFilters);
   const recordCountLabel = t('records.count', {
     count: itemCount,
     formattedCount: itemCount.toLocaleString(),
     defaultValue: '{{formattedCount}} Records',
   });
+
+  const handleFilterClick = () => {
+    onFilterExpandedChange?.(!filterExpanded);
+  };
+
   const handleGridViewClick = () => {
     if (layout !== 'grid') {
       onLayoutChange('grid');
@@ -32,40 +67,105 @@ export function RecordExplorerHeader({
   };
 
   return (
-    <header className="record-explorer-header">
-      <div className="record-explorer-header__leading">
-        <button type="button" className="record-explorer-header__filter">
-          <Icon name="filter" size="sm" hierarchy="tertiary" aria-hidden />
-          <span>{t('common.filter', { defaultValue: 'Filter' })}</span>
-        </button>
-        <span className="record-explorer-header__sort">
-          {t('common.sort_newest', { defaultValue: 'Sort: Newest' })}
-        </span>
-        <span className="record-explorer-header__divider" aria-hidden />
-        <p className="record-explorer-header__count">{recordCountLabel}</p>
-      </div>
+    <div
+      className="library-explorer-header-shell record-explorer-header-shell"
+      data-expanded={filterExpanded ? 'true' : 'false'}
+    >
+      <header className="library-explorer-header record-explorer-header">
+        <div className="library-explorer-header__leading record-explorer-header__leading">
+          <button
+            type="button"
+            className="library-explorer-header__filter record-explorer-header__filter"
+            aria-expanded={filterExpanded}
+            aria-controls={filterPanelId}
+            data-expanded={filterExpanded ? 'true' : undefined}
+            onClick={handleFilterClick}
+          >
+            <Icon name="filter" size="sm" hierarchy="tertiary" aria-hidden />
+            <span>{t('common.filter', { defaultValue: 'Filter' })}</span>
+            {selectedFilterCount > 0 ? (
+              <span className="library-explorer-header__filter-count record-explorer-header__filter-count">
+                {selectedFilterCount}
+              </span>
+            ) : null}
+          </button>
+          <span className="library-explorer-header__sort record-explorer-header__sort">
+            <Icon name="sort-desc" size="sm" hierarchy="tertiary" aria-hidden />
+            <span>{t('common.sort_newest', { defaultValue: 'Sort: Newest' })}</span>
+          </span>
+          <span
+            className="library-explorer-header__divider record-explorer-header__divider"
+            aria-hidden
+          />
+          <p className="library-explorer-header__count record-explorer-header__count">
+            {recordCountLabel}
+          </p>
+        </div>
 
-      <div
-        className="record-explorer-header__actions"
-        aria-label={t('library.view_mode', { defaultValue: 'View mode' })}
-      >
-        <IconButton
-          icon="view-grid"
-          size="md"
-          active={layout === 'grid'}
-          aria-label={t('library.grid_view', { defaultValue: 'Grid view' })}
-          aria-pressed={layout === 'grid'}
-          onClick={handleGridViewClick}
-        />
-        <IconButton
-          icon="masonry-item"
-          size="md"
-          active={layout === 'masonry'}
-          aria-label={t('library.masonry_view', { defaultValue: 'Masonry view' })}
-          aria-pressed={layout === 'masonry'}
-          onClick={handleMasonryViewClick}
-        />
-      </div>
-    </header>
+        <div
+          className="library-explorer-header__actions record-explorer-header__actions"
+          aria-label={t('library.view_mode', { defaultValue: 'View mode' })}
+        >
+          <IconButton
+            icon="view-grid"
+            size="md"
+            active={layout === 'grid'}
+            aria-label={t('library.grid_view', { defaultValue: 'Grid view' })}
+            aria-pressed={layout === 'grid'}
+            onClick={handleGridViewClick}
+          />
+          <IconButton
+            icon="masonry-item"
+            size="md"
+            active={layout === 'masonry'}
+            aria-label={t('library.masonry_view', { defaultValue: 'Masonry view' })}
+            aria-pressed={layout === 'masonry'}
+            onClick={handleMasonryViewClick}
+          />
+        </div>
+      </header>
+
+      {filterExpanded ? (
+        <div
+          id={filterPanelId}
+          className="library-explorer-filter-panel record-explorer-filter-panel"
+        >
+          {filterGroups.length > 0 ? (
+            filterGroups.map(group => {
+              const selectedTagIds = selectedFilters[group.key] ?? [];
+
+              return (
+                <div key={group.key} className="record-explorer-filter-panel__row">
+                  <div className="record-explorer-filter-panel__label">{group.label}</div>
+                  <div className="record-explorer-filter-panel__chips">
+                    {group.tags.map(tag => {
+                      const selected = selectedTagIds.includes(tag.id);
+
+                      return (
+                        <ChipButton
+                          key={tag.id}
+                          shape="pill"
+                          variant={selected ? 'selected' : 'outline'}
+                          pressed={selected}
+                          onClick={() => {
+                            onFilterTagToggle?.(group.key, tag.id);
+                          }}
+                        >
+                          {tag.name}
+                        </ChipButton>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <p className="record-explorer-filter-panel__empty">
+              {t('records.filters.empty', { defaultValue: 'No tag groups available.' })}
+            </p>
+          )}
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/desktop/src/features/library-workspace/records/RecordSelectionToolbar.tsx
+++ b/apps/desktop/src/features/library-workspace/records/RecordSelectionToolbar.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { Button, Checkbox } from '../../../shared/ui';
+import { Button } from '../../../shared/ui';
+import { SelectionToolbar } from '../common/SelectionToolbar';
 
 type RecordSelectionToolbarProps = {
   selectionMode: boolean;
@@ -21,76 +22,39 @@ export function RecordSelectionToolbar({
   onDeleteSelected,
 }: RecordSelectionToolbarProps) {
   const { t } = useTranslation('common');
-  const allSelected = totalCount > 0 && selectedCount === totalCount;
-  const selectedLabel = t('common.selected_count', {
-    count: selectedCount,
-    formattedCount: selectedCount.toLocaleString(),
-    defaultValue: '{{formattedCount}} selected',
-  });
   const selectedActionsDisabled = actionBusy || selectedCount === 0;
 
-  if (!selectionMode) {
-    return (
-      <div className="record-selection-toolbar" data-selection="off">
-        <Button
-          size="sm"
-          className="record-selection-toolbar__button"
-          onClick={() => {
-            onSelectionModeChange(true);
-          }}
-        >
-          {t('common.select', { defaultValue: 'Select' })}
-        </Button>
-      </div>
-    );
-  }
-
   return (
-    <div className="record-selection-toolbar" data-selection="on">
-      <div className="record-selection-toolbar__left">
-        <Button
-          size="sm"
-          variant="secondary"
-          className="record-selection-toolbar__button"
-          disabled={actionBusy}
-          onClick={() => {
-            onSelectionModeChange(false);
-          }}
-        >
-          {t('common.cancel', { defaultValue: 'Cancel' })}
-        </Button>
-        <label className="record-selection-toolbar__select-all">
-          <Checkbox
+    <SelectionToolbar
+      className="record-selection-toolbar"
+      selectionMode={selectionMode}
+      selectedCount={selectedCount}
+      totalCount={totalCount}
+      cancelDisabled={actionBusy}
+      selectAllDisabled={actionBusy || totalCount === 0}
+      selectAllAriaLabel={t('records.select_all_records', {
+        defaultValue: 'Select all records',
+      })}
+      onSelectionModeChange={onSelectionModeChange}
+      onSelectAllChange={onSelectAllChange}
+      actions={
+        <>
+          <Button size="sm" variant="secondary" disabled>
+            {t('common.add_tag', { defaultValue: 'Add Tag' })}
+          </Button>
+          <Button
             size="sm"
-            checked={allSelected}
-            disabled={actionBusy || totalCount === 0}
-            aria-label={t('records.select_all_records', {
-              defaultValue: 'Select all records',
-            })}
-            onCheckedChange={onSelectAllChange}
-          />
-          <span>{t('common.select_all', { defaultValue: 'Select all' })}</span>
-        </label>
-        <span className="record-selection-toolbar__divider" aria-hidden />
-        <span className="record-selection-toolbar__count">{selectedLabel}</span>
-      </div>
-
-      <div className="record-selection-toolbar__actions">
-        <Button size="sm" variant="secondary" disabled>
-          {t('common.add_tag', { defaultValue: 'Add Tag' })}
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={selectedActionsDisabled}
-          onClick={onDeleteSelected}
-        >
-          {t('common.delete', { defaultValue: 'Delete' })}
-        </Button>
-        <Button size="sm" disabled>
-          {t('common.export', { defaultValue: 'Export' })}
-        </Button>
-      </div>
-    </div>
+            variant="secondary"
+            disabled={selectedActionsDisabled}
+            onClick={onDeleteSelected}
+          >
+            {t('common.delete', { defaultValue: 'Delete' })}
+          </Button>
+          <Button size="sm" disabled>
+            {t('common.export', { defaultValue: 'Export' })}
+          </Button>
+        </>
+      }
+    />
   );
 }

--- a/apps/desktop/src/features/library-workspace/records/RecordsView.tsx
+++ b/apps/desktop/src/features/library-workspace/records/RecordsView.tsx
@@ -1,11 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getErrorMessage } from '../../../shared/lib/error';
 import { ipc } from '../../../shared/lib/ipc';
-import type { CroquisRecordDetail, CroquisRecordSummary } from '../../../shared/types';
+import type {
+  CroquisRecordDetail,
+  CroquisRecordSummary,
+  Tag,
+  TagGroup,
+  TagIndex,
+} from '../../../shared/types';
 import { Button } from '../../../shared/ui';
 import { LibraryWorkspace } from '../common/LibraryWorkspace';
 import type { LibraryWorkspaceLayout } from '../common/types';
-import { RecordExplorerHeader } from './RecordExplorerHeader';
+import {
+  RecordExplorerHeader,
+  type RecordExplorerFilterGroup,
+  type RecordExplorerSelectedFilters,
+} from './RecordExplorerHeader';
 import { RecordResultPreviewPanel } from './RecordResultPreviewPanel';
 import { RecordResultTile } from './RecordResultTile';
 import { RecordSelectionToolbar } from './RecordSelectionToolbar';
@@ -24,16 +35,117 @@ type RecordGridStateProps = {
   action?: ReactNode;
 };
 
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
+type SelectedRecordFilters = Record<string, string[]>;
+
+const EMPTY_TAG_INDEX: TagIndex = {
+  groups: [],
+  tags: [],
+};
+
+const UNGROUPED_RECORD_FILTER_GROUP_KEY = '__record-filter-group:ungrouped__';
+
+function compareBySortOrderThenName(
+  first: Pick<Tag | TagGroup, 'name' | 'sortOrder'>,
+  second: Pick<Tag | TagGroup, 'name' | 'sortOrder'>,
+) {
+  if (first.sortOrder !== second.sortOrder) {
+    return first.sortOrder - second.sortOrder;
   }
 
-  if (typeof error === 'string') {
-    return error;
+  return first.name.localeCompare(second.name);
+}
+
+function getRecordFilterGroupKey(groupId: string | null) {
+  return groupId ?? UNGROUPED_RECORD_FILTER_GROUP_KEY;
+}
+
+function createRecordFilterGroups(tagIndex: TagIndex): RecordExplorerFilterGroup[] {
+  const tagsByGroupId = new Map<string | null, Tag[]>();
+
+  for (const tag of tagIndex.tags) {
+    const groupId = tag.groupId ?? null;
+    const groupTags = tagsByGroupId.get(groupId) ?? [];
+    groupTags.push(tag);
+    tagsByGroupId.set(groupId, groupTags);
   }
 
-  return fallback;
+  const groups = [...tagIndex.groups]
+    .sort(compareBySortOrderThenName)
+    .map<RecordExplorerFilterGroup>(group => ({
+      key: getRecordFilterGroupKey(group.id),
+      label: group.name,
+      tags: [...(tagsByGroupId.get(group.id) ?? [])].sort(compareBySortOrderThenName).map(tag => ({
+        id: tag.id,
+        name: tag.name,
+      })),
+    }))
+    .filter(group => group.tags.length > 0);
+
+  const ungroupedTags = [...(tagsByGroupId.get(null) ?? [])].sort(compareBySortOrderThenName);
+  if (ungroupedTags.length > 0) {
+    groups.push({
+      key: UNGROUPED_RECORD_FILTER_GROUP_KEY,
+      label: 'Ungrouped',
+      tags: ungroupedTags.map(tag => ({
+        id: tag.id,
+        name: tag.name,
+      })),
+    });
+  }
+
+  return groups;
+}
+
+function hasActiveSelectedRecordFilters(selectedFilters: RecordExplorerSelectedFilters) {
+  return Object.values(selectedFilters).some(tagIds => tagIds.length > 0);
+}
+
+function recordMatchesSelectedFilters(
+  record: RecordResultItem,
+  selectedFilters: RecordExplorerSelectedFilters,
+) {
+  const selectedTagGroups = Object.values(selectedFilters).filter(tagIds => tagIds.length > 0);
+  if (selectedTagGroups.length === 0) {
+    return true;
+  }
+
+  const recordTagIds = new Set(record.tags.map(tag => tag.id));
+
+  return selectedTagGroups.every(tagIds => tagIds.some(tagId => recordTagIds.has(tagId)));
+}
+
+function pruneSelectedRecordFilters(
+  selectedFilters: SelectedRecordFilters,
+  filterGroups: readonly RecordExplorerFilterGroup[],
+) {
+  const validTagsByGroupKey = new Map(
+    filterGroups.map(group => [group.key, new Set(group.tags.map(tag => tag.id))]),
+  );
+  const nextFilters: SelectedRecordFilters = {};
+  let changed = false;
+
+  for (const [groupKey, tagIds] of Object.entries(selectedFilters)) {
+    const validTagIds = validTagsByGroupKey.get(groupKey);
+    if (!validTagIds) {
+      changed = true;
+      continue;
+    }
+
+    const nextTagIds = tagIds.filter(tagId => validTagIds.has(tagId));
+    if (nextTagIds.length !== tagIds.length) {
+      changed = true;
+    }
+
+    if (nextTagIds.length > 0) {
+      nextFilters[groupKey] = nextTagIds;
+    }
+  }
+
+  if (Object.keys(nextFilters).length !== Object.keys(selectedFilters).length) {
+    changed = true;
+  }
+
+  return changed ? nextFilters : selectedFilters;
 }
 
 function RecordGridState({ title, description, action }: RecordGridStateProps) {
@@ -101,6 +213,9 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
   const [isActionBusy, setIsActionBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [filterExpanded, setFilterExpanded] = useState(false);
+  const [selectedRecordFilters, setSelectedRecordFilters] = useState<SelectedRecordFilters>({});
+  const [tagIndex, setTagIndex] = useState<TagIndex>(EMPTY_TAG_INDEX);
   const [tagGroupNamesById, setTagGroupNamesById] = useState(() => new Map<string, string>());
   const loadSequenceRef = useRef(0);
   const selectedRecordIdRef = useRef<string | null>(null);
@@ -168,10 +283,12 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
           return;
         }
 
+        setTagIndex(tagIndex);
         setTagGroupNamesById(new Map(tagIndex.groups.map(group => [group.id, group.name])));
       })
       .catch(() => {
         if (!cancelled) {
+          setTagIndex(EMPTY_TAG_INDEX);
           setTagGroupNamesById(new Map());
         }
       });
@@ -191,6 +308,17 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
     [recordDetailsById, records],
   );
 
+  const recordFilterGroups = useMemo(() => createRecordFilterGroups(tagIndex), [tagIndex]);
+
+  useEffect(() => {
+    setSelectedRecordFilters(current => pruneSelectedRecordFilters(current, recordFilterGroups));
+  }, [recordFilterGroups]);
+
+  const filteredItems = useMemo(
+    () => items.filter(item => recordMatchesSelectedFilters(item, selectedRecordFilters)),
+    [items, selectedRecordFilters],
+  );
+  const hasActiveFilters = hasActiveSelectedRecordFilters(selectedRecordFilters);
   const recordsBySourceAssetId = useMemo(() => createRecordsBySourceAssetId(items), [items]);
 
   const gridEmptyState = isLoading ? (
@@ -205,9 +333,43 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
         </Button>
       }
     />
+  ) : hasActiveFilters ? (
+    <RecordGridState
+      title="No records match these filters"
+      description="Try clearing a tag filter."
+    />
   ) : (
     <RecordGridState title={t('records.empty', { defaultValue: 'No records yet' })} />
   );
+
+  useEffect(() => {
+    const itemIds = new Set(filteredItems.map(item => item.id));
+    setSelectedRecordIds(current => current.filter(recordId => itemIds.has(recordId)));
+  }, [filteredItems]);
+
+  const handleFilterTagToggle = useCallback((groupKey: string, tagId: string) => {
+    setSelectedRecordFilters(current => {
+      const currentTagIds = current[groupKey] ?? [];
+      const nextTagIds = currentTagIds.includes(tagId)
+        ? currentTagIds.filter(currentTagId => currentTagId !== tagId)
+        : [...currentTagIds, tagId];
+
+      if (nextTagIds.length > 0) {
+        return {
+          ...current,
+          [groupKey]: nextTagIds,
+        };
+      }
+
+      const nextFilters: SelectedRecordFilters = {};
+      for (const [currentGroupKey, currentTagIds] of Object.entries(current)) {
+        if (currentGroupKey !== groupKey) {
+          nextFilters[currentGroupKey] = currentTagIds;
+        }
+      }
+      return nextFilters;
+    });
+  }, []);
 
   const handleSelectedRecordChange = (recordId: string) => {
     if (selectionMode) {
@@ -238,19 +400,19 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
           return current;
         }
 
-        return selectedRecordId && records.some(record => record.id === selectedRecordId)
+        return selectedRecordId && filteredItems.some(record => record.id === selectedRecordId)
           ? [selectedRecordId]
           : [];
       });
     },
-    [records, selectedRecordId],
+    [filteredItems, selectedRecordId],
   );
 
   const handleSelectAllChange = useCallback(
     (selected: boolean) => {
-      setSelectedRecordIds(selected ? records.map(record => record.id) : []);
+      setSelectedRecordIds(selected ? filteredItems.map(record => record.id) : []);
     },
-    [records],
+    [filteredItems],
   );
 
   const handleDeleteSelected = useCallback(() => {
@@ -295,7 +457,7 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
     <>
       <LibraryWorkspace
         mode="records"
-        items={items}
+        items={filteredItems}
         layout={layout}
         selectedItemId={selectedRecordId ?? undefined}
         selectedItemIds={selectedRecordIds}
@@ -310,14 +472,19 @@ export function RecordsView({ refreshKey = 0, onExplorerRefresh }: RecordsViewPr
           <RecordExplorerHeader
             itemCount={itemCount}
             layout={currentLayout}
+            filterExpanded={filterExpanded}
+            filterGroups={recordFilterGroups}
+            selectedFilters={selectedRecordFilters}
             onLayoutChange={onLayoutChange}
+            onFilterExpandedChange={setFilterExpanded}
+            onFilterTagToggle={handleFilterTagToggle}
           />
         )}
         renderToolbar={
           <RecordSelectionToolbar
             selectionMode={selectionMode}
             selectedCount={selectedRecordIds.length}
-            totalCount={records.length}
+            totalCount={filteredItems.length}
             actionBusy={isActionBusy}
             onSelectionModeChange={handleSelectionModeChange}
             onSelectAllChange={handleSelectAllChange}

--- a/apps/desktop/src/features/library-workspace/records/record-workspace.css
+++ b/apps/desktop/src/features/library-workspace/records/record-workspace.css
@@ -1,135 +1,48 @@
 @layer app {
-  .record-explorer-header {
-    display: flex;
-    flex: none;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 48px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--semantic-colors-border-secondary);
-    background: var(--semantic-colors-surface-panel);
-  }
-
-  .record-explorer-header__leading,
-  .record-explorer-header__actions {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    min-width: 0;
-  }
-
-  .record-explorer-header__leading {
+  .record-explorer-filter-panel {
+    flex-direction: column;
+    align-items: stretch;
     gap: 16px;
   }
 
-  .record-explorer-header__actions {
-    gap: 8px;
-  }
-
-  .record-explorer-header__filter {
-    display: inline-flex;
+  .record-explorer-filter-panel__row {
+    display: flex;
     align-items: center;
-    gap: 4px;
-    min-height: 24px;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(--semantic-colors-text-secondary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    cursor: pointer;
+    gap: 24px;
+    min-width: 0;
   }
 
-  .record-explorer-header__filter:hover,
-  .record-explorer-header__filter:focus-visible {
-    color: var(--semantic-colors-text-primary);
-  }
-
-  .record-explorer-header__filter:focus-visible {
-    border-radius: var(--primitives-radius-05);
-    outline: 2px solid var(--semantic-colors-border-focus);
-    outline-offset: 2px;
-  }
-
-  .record-explorer-header__sort,
-  .record-explorer-header__count {
+  .record-explorer-filter-panel__label {
+    display: flex;
+    flex: 0 0 48px;
+    align-items: center;
+    min-width: 0;
     overflow: hidden;
     color: var(--semantic-colors-text-tertiary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
+    font-size: 10px;
+    line-height: 15px;
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 1px;
     text-overflow: ellipsis;
+    text-transform: uppercase;
     white-space: nowrap;
   }
 
-  .record-explorer-header__sort {
-    color: var(--semantic-colors-text-secondary);
-  }
-
-  .record-explorer-header__divider {
-    width: 1px;
-    height: 16px;
-    background: var(--semantic-colors-border-subtle);
-  }
-
-  .record-selection-toolbar {
+  .record-explorer-filter-panel__chips {
     display: flex;
-    flex: none;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 44px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--semantic-colors-border-secondary);
-    background: var(--semantic-colors-surface-panel);
-  }
-
-  .record-selection-toolbar__left,
-  .record-selection-toolbar__actions {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    min-width: 0;
-  }
-
-  .record-selection-toolbar__left {
-    gap: 16px;
-  }
-
-  .record-selection-toolbar__actions {
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    align-items: flex-start;
     gap: 8px;
-  }
-
-  .record-selection-toolbar .record-selection-toolbar__button {
-    align-self: center;
-    min-width: 60px;
-  }
-
-  .record-selection-toolbar__select-all {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
     min-width: 0;
-    color: var(--semantic-colors-text-primary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    white-space: nowrap;
-    cursor: pointer;
   }
 
-  .record-selection-toolbar__divider {
-    width: 1px;
-    height: 16px;
-    background: var(--semantic-colors-border-subtle);
-  }
-
-  .record-selection-toolbar__count {
+  .record-explorer-filter-panel__empty {
+    margin: 0;
     color: var(--semantic-colors-text-tertiary);
     font-size: 12px;
     line-height: 16px;
     font-weight: var(--font-weight-medium);
-    white-space: nowrap;
   }
 
   .record-result-tile {

--- a/apps/desktop/src/features/library-workspace/references/ReferenceExplorerHeader.tsx
+++ b/apps/desktop/src/features/library-workspace/references/ReferenceExplorerHeader.tsx
@@ -1,27 +1,61 @@
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Icon } from '../../../shared/ui/icon/Icon';
-import { IconButton } from '../../../shared/ui/icon-button/IconButton';
+import { CheckboxRow, Icon, IconButton } from '../../../shared/ui';
 import type { LibraryWorkspaceLayout, LibraryWorkspaceMode } from '../common/types';
 
 type ReferenceExplorerHeaderProps = {
   mode: LibraryWorkspaceMode;
   itemCount: number;
   layout: LibraryWorkspaceLayout;
+  filterExpanded?: boolean;
+  noRecordFilterSelected?: boolean;
   onLayoutChange: (layout: LibraryWorkspaceLayout) => void;
+  onFilterExpandedChange?: (expanded: boolean) => void;
+  onNoRecordFilterChange?: (selected: boolean) => void;
 };
 
 export function ReferenceExplorerHeader({
   mode,
   itemCount,
   layout,
+  filterExpanded,
+  noRecordFilterSelected,
   onLayoutChange,
+  onFilterExpandedChange,
+  onNoRecordFilterChange,
 }: ReferenceExplorerHeaderProps) {
   const { t } = useTranslation('common');
+  const filterPanelId = useId();
+  const [internalFilterExpanded, setInternalFilterExpanded] = useState(false);
+  const [internalNoRecordFilterSelected, setInternalNoRecordFilterSelected] = useState(false);
+  const resolvedFilterExpanded = filterExpanded ?? internalFilterExpanded;
+  const resolvedNoRecordFilterSelected = noRecordFilterSelected ?? internalNoRecordFilterSelected;
+  const selectedFilterCount = resolvedNoRecordFilterSelected ? 1 : 0;
   const itemCountLabel = t('references.count', {
     count: itemCount,
     formattedCount: itemCount.toLocaleString(),
     defaultValue: '{{formattedCount}} Items',
   });
+
+  const handleFilterClick = () => {
+    const nextExpanded = !resolvedFilterExpanded;
+    if (onFilterExpandedChange) {
+      onFilterExpandedChange(nextExpanded);
+      return;
+    }
+
+    setInternalFilterExpanded(nextExpanded);
+  };
+
+  const handleNoRecordFilterChange = (selected: boolean) => {
+    if (onNoRecordFilterChange) {
+      onNoRecordFilterChange(selected);
+      return;
+    }
+
+    setInternalNoRecordFilterSelected(selected);
+  };
+
   const handleGridViewClick = () => {
     if (layout !== 'grid') {
       onLayoutChange('grid');
@@ -35,38 +69,75 @@ export function ReferenceExplorerHeader({
   };
 
   return (
-    <header className="reference-explorer-header" data-mode={mode}>
-      <div className="reference-explorer-header__leading">
-        <button type="button" className="reference-explorer-header__filter">
-          <Icon name="filter" size="sm" hierarchy="tertiary" aria-hidden />
-          <span>{t('common.filter', { defaultValue: 'Filter' })}</span>
-        </button>
-        <span className="reference-explorer-header__divider" aria-hidden />
-      </div>
+    <div
+      className="library-explorer-header-shell reference-explorer-header-shell"
+      data-expanded={resolvedFilterExpanded ? 'true' : 'false'}
+    >
+      <header className="library-explorer-header reference-explorer-header" data-mode={mode}>
+        <div className="library-explorer-header__leading reference-explorer-header__leading">
+          <button
+            type="button"
+            className="library-explorer-header__filter reference-explorer-header__filter"
+            aria-expanded={resolvedFilterExpanded}
+            aria-controls={filterPanelId}
+            data-expanded={resolvedFilterExpanded ? 'true' : undefined}
+            onClick={handleFilterClick}
+          >
+            <Icon name="filter" size="sm" hierarchy="tertiary" aria-hidden />
+            <span>{t('common.filter', { defaultValue: 'Filter' })}</span>
+            {selectedFilterCount > 0 ? (
+              <span className="library-explorer-header__filter-count reference-explorer-header__filter-count">
+                {selectedFilterCount}
+              </span>
+            ) : null}
+          </button>
+          <span
+            className="library-explorer-header__divider reference-explorer-header__divider"
+            aria-hidden
+          />
+        </div>
 
-      <p className="reference-explorer-header__count">{itemCountLabel}</p>
+        <p className="library-explorer-header__count reference-explorer-header__count">
+          {itemCountLabel}
+        </p>
 
-      <div
-        className="reference-explorer-header__actions"
-        aria-label={t('library.view_mode', { defaultValue: 'View mode' })}
-      >
-        <IconButton
-          icon="view-grid"
-          size="md"
-          active={layout === 'grid'}
-          aria-label={t('library.grid_view', { defaultValue: 'Grid view' })}
-          aria-pressed={layout === 'grid'}
-          onClick={handleGridViewClick}
-        />
-        <IconButton
-          icon="masonry-item"
-          size="md"
-          active={layout === 'masonry'}
-          aria-label={t('library.masonry_view', { defaultValue: 'Masonry view' })}
-          aria-pressed={layout === 'masonry'}
-          onClick={handleMasonryViewClick}
-        />
-      </div>
-    </header>
+        <div
+          className="library-explorer-header__actions reference-explorer-header__actions"
+          aria-label={t('library.view_mode', { defaultValue: 'View mode' })}
+        >
+          <IconButton
+            icon="view-grid"
+            size="md"
+            active={layout === 'grid'}
+            aria-label={t('library.grid_view', { defaultValue: 'Grid view' })}
+            aria-pressed={layout === 'grid'}
+            onClick={handleGridViewClick}
+          />
+          <IconButton
+            icon="masonry-item"
+            size="md"
+            active={layout === 'masonry'}
+            aria-label={t('library.masonry_view', { defaultValue: 'Masonry view' })}
+            aria-pressed={layout === 'masonry'}
+            onClick={handleMasonryViewClick}
+          />
+        </div>
+      </header>
+
+      {resolvedFilterExpanded ? (
+        <div
+          id={filterPanelId}
+          className="library-explorer-filter-panel reference-explorer-filter-panel"
+        >
+          <CheckboxRow
+            size="sm"
+            label={t('references.filters.no_record', { defaultValue: 'no record' })}
+            checked={resolvedNoRecordFilterSelected}
+            onCheckedChange={handleNoRecordFilterChange}
+            className="reference-explorer-filter-panel__checkbox"
+          />
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/desktop/src/features/library-workspace/references/ReferenceSelectionToolbar.tsx
+++ b/apps/desktop/src/features/library-workspace/references/ReferenceSelectionToolbar.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { Button, Checkbox } from '../../../shared/ui';
+import { Button } from '../../../shared/ui';
+import { SelectionToolbar } from '../common/SelectionToolbar';
 
 type ReferenceSelectionToolbarProps = {
   selectionMode: boolean;
@@ -27,88 +28,49 @@ export function ReferenceSelectionToolbar({
   onStartCroquis,
 }: ReferenceSelectionToolbarProps) {
   const { t } = useTranslation('common');
-  const allSelected = totalCount > 0 && selectedCount === totalCount;
-  const selectedLabel = t('common.selected_count', {
-    count: selectedCount,
-    formattedCount: selectedCount.toLocaleString(),
-    defaultValue: '{{formattedCount}} selected',
-  });
   const selectionActionsDisabled = folderActionsDisabled || selectedCount === 0;
 
-  if (!selectionMode) {
-    return (
-      <div className="reference-selection-toolbar" data-selection="off">
-        <Button
-          size="sm"
-          className="reference-selection-toolbar__button"
-          onClick={() => {
-            onSelectionModeChange(true);
-          }}
-        >
-          {t('common.select', { defaultValue: 'Select' })}
-        </Button>
-      </div>
-    );
-  }
-
   return (
-    <div className="reference-selection-toolbar" data-selection="on">
-      <div className="reference-selection-toolbar__left">
-        <Button
-          size="sm"
-          variant="secondary"
-          className="reference-selection-toolbar__button"
-          onClick={() => {
-            onSelectionModeChange(false);
-          }}
-        >
-          {t('common.cancel', { defaultValue: 'Cancel' })}
-        </Button>
-        <label className="reference-selection-toolbar__select-all">
-          <Checkbox
+    <SelectionToolbar
+      className="reference-selection-toolbar"
+      selectionMode={selectionMode}
+      selectedCount={selectedCount}
+      totalCount={totalCount}
+      selectAllAriaLabel={t('references.select_all_assets', {
+        defaultValue: 'Select all reference assets',
+      })}
+      onSelectionModeChange={onSelectionModeChange}
+      onSelectAllChange={onSelectAllChange}
+      actions={
+        <>
+          <Button
             size="sm"
-            checked={allSelected}
-            disabled={totalCount === 0}
-            aria-label={t('references.select_all_assets', {
-              defaultValue: 'Select all reference assets',
-            })}
-            onCheckedChange={onSelectAllChange}
-          />
-          <span>{t('common.select_all', { defaultValue: 'Select all' })}</span>
-        </label>
-        <span className="reference-selection-toolbar__divider" aria-hidden />
-        <span className="reference-selection-toolbar__count">{selectedLabel}</span>
-      </div>
-
-      <div className="reference-selection-toolbar__actions">
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={selectionActionsDisabled}
-          onClick={onAddToFolder}
-        >
-          {t('references.add_to_folder', { defaultValue: 'Add to Folder' })}
-        </Button>
-        <Button
-          size="sm"
-          variant="secondary"
-          disabled={selectionActionsDisabled}
-          onClick={onMoveToFolder}
-        >
-          {t('common.move', { defaultValue: 'Move' })}
-        </Button>
-        <Button size="sm" variant="secondary" disabled>
-          {t('common.delete', { defaultValue: 'Delete' })}
-        </Button>
-        <Button
-          size="sm"
-          className="reference-selection-toolbar__button"
-          disabled={croquisDisabled || selectedCount === 0}
-          onClick={onStartCroquis}
-        >
-          {t('common.croquis', { defaultValue: 'Croquis' })}
-        </Button>
-      </div>
-    </div>
+            variant="secondary"
+            disabled={selectionActionsDisabled}
+            onClick={onAddToFolder}
+          >
+            {t('references.add_to_folder', { defaultValue: 'Add to Folder' })}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={selectionActionsDisabled}
+            onClick={onMoveToFolder}
+          >
+            {t('common.move', { defaultValue: 'Move' })}
+          </Button>
+          <Button size="sm" variant="secondary" disabled>
+            {t('common.delete', { defaultValue: 'Delete' })}
+          </Button>
+          <Button
+            size="sm"
+            disabled={croquisDisabled || selectedCount === 0}
+            onClick={onStartCroquis}
+          >
+            {t('common.croquis', { defaultValue: 'Croquis' })}
+          </Button>
+        </>
+      }
+    />
   );
 }

--- a/apps/desktop/src/features/library-workspace/references/ReferencesView.tsx
+++ b/apps/desktop/src/features/library-workspace/references/ReferencesView.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CroquisStartModal } from '../../croquis/ui/CroquisStartModal';
+import { getErrorMessage } from '../../../shared/lib/error';
 import { ipc } from '../../../shared/lib/ipc';
 import type {
   AssetDetail,
   AssetListSource,
+  AssetRecordCount,
   AssetSummary,
   BatchUpdateAssetFoldersMode,
   CroquisRecordDetail,
@@ -45,18 +47,6 @@ type FolderAction = {
   mode: BatchUpdateAssetFoldersMode;
 };
 
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  return fallback;
-}
-
 function getSelectableFolders(snapshot: ExplorerSnapshot) {
   const statsByFolderId = new Map(snapshot.folderStats.map(stats => [stats.folderId, stats]));
 
@@ -81,6 +71,64 @@ function createRelatedRecordDetailMap(
   return detailsById;
 }
 
+function createAssetRecordCountMap(
+  assets: readonly AssetSummary[],
+  recordCounts: readonly AssetRecordCount[],
+) {
+  const assetIds = new Set(assets.map(asset => asset.id));
+  const recordCountsById = new Map(assets.map(asset => [asset.id, 0]));
+
+  for (const recordCount of recordCounts) {
+    if (assetIds.has(recordCount.assetId)) {
+      recordCountsById.set(recordCount.assetId, recordCount.relatedRecordCount);
+    }
+  }
+
+  return recordCountsById;
+}
+
+function mergeCachedAssetDetails(
+  current: Map<string, AssetDetail>,
+  updatedDetails: readonly AssetDetail[],
+) {
+  if (updatedDetails.length === 0 || current.size === 0) {
+    return current;
+  }
+
+  let changed = false;
+  const nextDetailsById = new Map(current);
+
+  for (const detail of updatedDetails) {
+    if (nextDetailsById.has(detail.id)) {
+      nextDetailsById.set(detail.id, detail);
+      changed = true;
+    }
+  }
+
+  return changed ? nextDetailsById : current;
+}
+
+function mergeCachedAssetRecordCounts(
+  current: Map<string, number>,
+  updatedDetails: readonly AssetDetail[],
+) {
+  if (updatedDetails.length === 0 || current.size === 0) {
+    return current;
+  }
+
+  let changed = false;
+  const nextRecordCountsById = new Map(current);
+
+  for (const detail of updatedDetails) {
+    if (nextRecordCountsById.has(detail.id)) {
+      nextRecordCountsById.set(detail.id, detail.relatedRecords.length);
+      changed = true;
+    }
+  }
+
+  return changed ? nextRecordCountsById : current;
+}
+
 function ReferenceGridState({ title, description, action }: ReferenceGridStateProps) {
   return (
     <div className="masonry-grid__empty">
@@ -101,12 +149,21 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedAssetIds, setSelectedAssetIds] = useState<string[]>([]);
   const [selectedAssetDetail, setSelectedAssetDetail] = useState<AssetDetail | null>(null);
+  const [assetDetailsById, setAssetDetailsById] = useState(() => new Map<string, AssetDetail>());
+  const [assetRecordCountsById, setAssetRecordCountsById] = useState(
+    () => new Map<string, number>(),
+  );
   const [relatedRecordDetailsById, setRelatedRecordDetailsById] = useState(
     () => new Map<string, CroquisRecordDetail>(),
   );
   const [previewOpen, setPreviewOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [filterExpanded, setFilterExpanded] = useState(false);
+  const [noRecordFilterSelected, setNoRecordFilterSelected] = useState(false);
+  const [noRecordFilterLoading, setNoRecordFilterLoading] = useState(false);
+  const [noRecordFilterError, setNoRecordFilterError] = useState<string | null>(null);
+  const [noRecordFilterRefreshKey, setNoRecordFilterRefreshKey] = useState(0);
   const [croquisModalOpen, setCroquisModalOpen] = useState(false);
   const [croquisAssetIds, setCroquisAssetIds] = useState<string[]>([]);
   const [sessionPresets, setSessionPresets] = useState<SessionPreset[]>([]);
@@ -125,6 +182,7 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
   const [assetActionError, setAssetActionError] = useState<string | null>(null);
   const loadSequenceRef = useRef(0);
   const selectedAssetDetailLoadSequenceRef = useRef(0);
+  const noRecordFilterLoadSequenceRef = useRef(0);
   const croquisConfigLoadSequenceRef = useRef(0);
   const folderActionLoadSequenceRef = useRef(0);
 
@@ -176,6 +234,34 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
   useEffect(() => {
     const assetIds = new Set(assets.map(asset => asset.id));
     setSelectedAssetIds(current => current.filter(assetId => assetIds.has(assetId)));
+    setAssetDetailsById(current => {
+      let changed = false;
+      const nextDetailsById = new Map<string, AssetDetail>();
+
+      for (const [assetId, detail] of current.entries()) {
+        if (assetIds.has(assetId)) {
+          nextDetailsById.set(assetId, detail);
+        } else {
+          changed = true;
+        }
+      }
+
+      return changed || nextDetailsById.size !== current.size ? nextDetailsById : current;
+    });
+    setAssetRecordCountsById(current => {
+      let changed = false;
+      const nextRecordCountsById = new Map<string, number>();
+
+      for (const [assetId, recordCount] of current.entries()) {
+        if (assetIds.has(assetId)) {
+          nextRecordCountsById.set(assetId, recordCount);
+        } else {
+          changed = true;
+        }
+      }
+
+      return changed || nextRecordCountsById.size !== current.size ? nextRecordCountsById : current;
+    });
   }, [assets]);
 
   const {
@@ -211,6 +297,14 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
         }
 
         setSelectedAssetDetail(detail);
+        setAssetDetailsById(current => new Map(current).set(detail.id, detail));
+        setAssetRecordCountsById(current => {
+          if (!current.has(detail.id)) {
+            return current;
+          }
+
+          return new Map(current).set(detail.id, detail.relatedRecords.length);
+        });
         setRelatedRecordDetailsById(new Map());
 
         const detailResults = await Promise.allSettled(
@@ -241,17 +335,90 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
 
   const items = useMemo(
     () =>
-      assets.map(asset =>
-        createReferenceAsset(
+      assets.map(asset => {
+        const detail =
+          assetDetailsById.get(asset.id) ??
+          (selectedAssetDetail?.id === asset.id ? selectedAssetDetail : undefined);
+
+        return createReferenceAsset(
           asset,
-          selectedAssetDetail?.id === asset.id ? selectedAssetDetail : undefined,
+          detail,
           selectedAssetDetail?.id === asset.id ? relatedRecordDetailsById : undefined,
           t,
           i18n.resolvedLanguage,
-        ),
-      ),
-    [assets, i18n.resolvedLanguage, relatedRecordDetailsById, selectedAssetDetail, t],
+        );
+      }),
+    [
+      assetDetailsById,
+      assets,
+      i18n.resolvedLanguage,
+      relatedRecordDetailsById,
+      selectedAssetDetail,
+      t,
+    ],
   );
+
+  useEffect(() => {
+    if (!noRecordFilterSelected) {
+      noRecordFilterLoadSequenceRef.current += 1;
+      setNoRecordFilterLoading(false);
+      setNoRecordFilterError(null);
+      return;
+    }
+
+    if (assets.length === 0) {
+      setAssetRecordCountsById(new Map());
+      setNoRecordFilterLoading(false);
+      setNoRecordFilterError(null);
+      return;
+    }
+
+    const loadSequence = noRecordFilterLoadSequenceRef.current + 1;
+    noRecordFilterLoadSequenceRef.current = loadSequence;
+    setNoRecordFilterLoading(true);
+    setNoRecordFilterError(null);
+
+    void ipc.asset
+      .listRecordCounts(source)
+      .then(recordCounts => {
+        if (noRecordFilterLoadSequenceRef.current !== loadSequence) {
+          return;
+        }
+
+        setAssetRecordCountsById(createAssetRecordCountMap(assets, recordCounts));
+      })
+      .catch((nextError: unknown) => {
+        if (noRecordFilterLoadSequenceRef.current !== loadSequence) {
+          return;
+        }
+
+        setAssetRecordCountsById(new Map());
+        setNoRecordFilterError(getErrorMessage(nextError, 'Failed to load reference filter data.'));
+      })
+      .finally(() => {
+        if (noRecordFilterLoadSequenceRef.current === loadSequence) {
+          setNoRecordFilterLoading(false);
+        }
+      });
+  }, [assets, noRecordFilterRefreshKey, noRecordFilterSelected, source]);
+
+  const filteredItems = useMemo(() => {
+    if (!noRecordFilterSelected) {
+      return items;
+    }
+
+    if (noRecordFilterLoading || noRecordFilterError) {
+      return [];
+    }
+
+    return items.filter(item => assetRecordCountsById.get(item.id) === 0);
+  }, [
+    assetRecordCountsById,
+    items,
+    noRecordFilterError,
+    noRecordFilterLoading,
+    noRecordFilterSelected,
+  ]);
 
   const gridEmptyState = isLoading ? (
     <ReferenceGridState
@@ -267,9 +434,52 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
         </Button>
       }
     />
+  ) : noRecordFilterLoading ? (
+    <ReferenceGridState title="Loading filter data..." />
+  ) : noRecordFilterError ? (
+    <ReferenceGridState
+      title="Failed to load filter data"
+      description={noRecordFilterError}
+      action={
+        <Button
+          size="sm"
+          onClick={() => {
+            setNoRecordFilterLoading(true);
+            setNoRecordFilterError(null);
+            setNoRecordFilterRefreshKey(current => current + 1);
+          }}
+        >
+          Retry
+        </Button>
+      }
+    />
+  ) : noRecordFilterSelected ? (
+    <ReferenceGridState title="No references without records" />
   ) : (
     <ReferenceGridState title={t('references.empty', { defaultValue: 'No assets in this view' })} />
   );
+
+  useEffect(() => {
+    const itemIds = new Set(filteredItems.map(item => item.id));
+    setSelectedAssetIds(current => current.filter(assetId => itemIds.has(assetId)));
+    if (selectedAssetId && noRecordFilterSelected && !noRecordFilterLoading) {
+      if (!itemIds.has(selectedAssetId)) {
+        setSelectedAssetId(null);
+        setPreviewOpen(false);
+      }
+    }
+  }, [filteredItems, noRecordFilterLoading, noRecordFilterSelected, selectedAssetId]);
+
+  const handleNoRecordFilterChange = useCallback((selected: boolean) => {
+    setNoRecordFilterSelected(selected);
+    if (!selected) {
+      setNoRecordFilterError(null);
+      return;
+    }
+
+    setNoRecordFilterLoading(true);
+    setNoRecordFilterRefreshKey(current => current + 1);
+  }, []);
 
   const handleSelectedAssetChange = (assetId: string) => {
     if (selectionMode) {
@@ -347,19 +557,19 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
           return current;
         }
 
-        return selectedAssetId && assets.some(asset => asset.id === selectedAssetId)
+        return selectedAssetId && filteredItems.some(asset => asset.id === selectedAssetId)
           ? [selectedAssetId]
           : [];
       });
     },
-    [assets, selectedAssetId],
+    [filteredItems, selectedAssetId],
   );
 
   const handleSelectAllChange = useCallback(
     (selected: boolean) => {
-      setSelectedAssetIds(selected ? assets.map(asset => asset.id) : []);
+      setSelectedAssetIds(selected ? filteredItems.map(asset => asset.id) : []);
     },
-    [assets],
+    [filteredItems],
   );
 
   const applyAssetFolderUpdate = useCallback(
@@ -373,6 +583,7 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
           virtualFolderIds,
           mode,
         });
+        const updatedDetailsById = new Map(updatedDetails.map(detail => [detail.id, detail]));
 
         setSelectedAssetDetail(current => {
           if (!selectedAssetId && !current) {
@@ -380,9 +591,11 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
           }
 
           const targetId = current?.id ?? selectedAssetId;
-          const updatedDetail = updatedDetails.find(detail => detail.id === targetId);
+          const updatedDetail = targetId ? updatedDetailsById.get(targetId) : undefined;
           return updatedDetail ?? current;
         });
+        setAssetDetailsById(current => mergeCachedAssetDetails(current, updatedDetails));
+        setAssetRecordCountsById(current => mergeCachedAssetRecordCounts(current, updatedDetails));
         await loadAssets();
         try {
           await onExplorerRefresh?.();
@@ -572,23 +785,31 @@ export function ReferencesView({ source, refreshKey = 0, onExplorerRefresh }: Re
       <div className="references-view-drop-shell" {...dropShellProps}>
         <LibraryWorkspace
           mode="references"
-          items={items}
+          items={filteredItems}
           layout={layout}
           selectedItemId={selectedAssetId ?? undefined}
           selectedItemIds={selectedAssetIds}
           selectionMode={selectionMode}
           gridAriaLabel={t('references.title', { defaultValue: 'References' })}
           previewOpen={previewOpen}
-          gridBusy={isLoading}
+          gridBusy={isLoading || noRecordFilterLoading}
           gridEmptyState={gridEmptyState}
           onLayoutChange={setLayout}
           onSelectedItemChange={handleSelectedAssetChange}
-          renderHeader={headerProps => <ReferenceExplorerHeader {...headerProps} />}
+          renderHeader={headerProps => (
+            <ReferenceExplorerHeader
+              {...headerProps}
+              filterExpanded={filterExpanded}
+              noRecordFilterSelected={noRecordFilterSelected}
+              onFilterExpandedChange={setFilterExpanded}
+              onNoRecordFilterChange={handleNoRecordFilterChange}
+            />
+          )}
           renderToolbar={
             <ReferenceSelectionToolbar
               selectionMode={selectionMode}
               selectedCount={selectedAssetIds.length}
-              totalCount={assets.length}
+              totalCount={filteredItems.length}
               croquisDisabled={isCroquisConfigLoading}
               folderActionsDisabled={assetActionBusy || folderActionModalBusy}
               onSelectionModeChange={handleSelectionModeChange}

--- a/apps/desktop/src/features/library-workspace/references/lib/useReferenceDropImport.ts
+++ b/apps/desktop/src/features/library-workspace/references/lib/useReferenceDropImport.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getErrorMessage } from '../../../../shared/lib/error';
 import { ipc } from '../../../../shared/lib/ipc';
 import type { AssetListSource, ImportFailure, ImportResult } from '../../../../shared/types';
 import {
@@ -29,18 +30,6 @@ const REMOTE_DROP_TYPES = [
   'public.text',
   'public.url',
 ];
-
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  return fallback;
-}
 
 function getImportTargetFolderIds(source: AssetListSource) {
   if (source.kind === 'folder' || source.kind === 'folderDescendants') {

--- a/apps/desktop/src/features/library-workspace/references/reference-workspace.css
+++ b/apps/desktop/src/features/library-workspace/references/reference-workspace.css
@@ -51,135 +51,14 @@
     font-weight: var(--font-weight-regular);
   }
 
-  .reference-explorer-header {
-    display: flex;
-    flex: none;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 48px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--semantic-colors-border-secondary);
-    background: var(--semantic-colors-surface-panel);
-  }
-
-  .reference-explorer-header__leading {
-    display: flex;
-    flex: none;
-    align-items: center;
-    gap: 16px;
-    min-width: 0;
-  }
-
-  .reference-explorer-header__filter {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    min-height: 24px;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    color: var(--semantic-colors-text-secondary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    cursor: pointer;
-  }
-
-  .reference-explorer-header__filter:hover,
-  .reference-explorer-header__filter:focus-visible {
-    color: var(--semantic-colors-text-primary);
-  }
-
-  .reference-explorer-header__filter:focus-visible {
-    border-radius: var(--primitives-radius-05);
-    outline: 2px solid var(--semantic-colors-border-focus);
-    outline-offset: 2px;
-  }
-
-  .reference-explorer-header__divider {
-    width: 1px;
-    height: 16px;
-    background: var(--semantic-colors-border-subtle);
-  }
-
   .reference-explorer-header__count {
     flex: 1 1 auto;
     min-width: 0;
-    margin: 0;
     padding-left: 16px;
-    overflow: hidden;
-    color: var(--semantic-colors-text-tertiary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
-  .reference-explorer-header__actions {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .reference-selection-toolbar {
-    display: flex;
-    flex: none;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 44px;
-    padding: 0 24px;
-    border-bottom: 1px solid var(--semantic-colors-border-secondary);
-    background: var(--semantic-colors-surface-panel);
-  }
-
-  .reference-selection-toolbar__left,
-  .reference-selection-toolbar__actions {
-    display: inline-flex;
-    flex: none;
-    align-items: center;
-    min-width: 0;
-  }
-
-  .reference-selection-toolbar__left {
-    gap: 16px;
-  }
-
-  .reference-selection-toolbar__actions {
-    gap: 8px;
-  }
-
-  .reference-selection-toolbar .reference-selection-toolbar__button {
-    align-self: center;
-    min-width: 60px;
-  }
-
-  .reference-selection-toolbar__select-all {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    min-width: 0;
+  .reference-explorer-filter-panel__checkbox {
     color: var(--semantic-colors-text-primary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    white-space: nowrap;
-    cursor: pointer;
-  }
-
-  .reference-selection-toolbar__divider {
-    width: 1px;
-    height: 16px;
-    background: var(--semantic-colors-border-subtle);
-  }
-
-  .reference-selection-toolbar__count {
-    color: var(--semantic-colors-text-tertiary);
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: var(--font-weight-medium);
-    white-space: nowrap;
   }
 
   .reference-masonry-tile {

--- a/apps/desktop/src/features/library-workspace/session-presets/SessionPresetSettingsView.tsx
+++ b/apps/desktop/src/features/library-workspace/session-presets/SessionPresetSettingsView.tsx
@@ -9,6 +9,7 @@ import {
   Select,
   type SelectOption,
 } from '../../../shared/ui';
+import { getErrorMessage } from '../../../shared/lib/error';
 import { ipc } from '../../../shared/lib/ipc';
 import type { SessionPreset, Tag, TagGroup, TimeStepPreset } from '../../../shared/types';
 import { findFallbackPreset, setStoredActiveSessionPresetId } from '../../croquis/lib/startModal';
@@ -37,18 +38,6 @@ const NEW_TIME_STEP_PRESET_NAME = 'Untitled Time Step';
 type EditorMode = 'session' | 'time-step';
 type NamedPreset = { id: string; name: string };
 type Translate = (key: string, options?: Record<string, unknown>) => string;
-
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  return fallback;
-}
 
 function formatStepCount(stepCount: number, t: Translate) {
   return t('presets.step_count', {

--- a/apps/desktop/src/pages/library/index.tsx
+++ b/apps/desktop/src/pages/library/index.tsx
@@ -11,6 +11,7 @@ import { open } from '@tauri-apps/plugin-dialog';
 import { useTranslation } from 'react-i18next';
 import { formatBytes } from '../../lib/format';
 import { cx } from '../../shared/lib/cx';
+import { getErrorMessage } from '../../shared/lib/error';
 import { ipc } from '../../shared/lib/ipc';
 import type {
   AssetListSource,
@@ -73,18 +74,6 @@ type ImportProgressState = {
   completed: number;
   total: number;
 };
-
-function getErrorMessage(error: unknown, fallback: string) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'string') {
-    return error;
-  }
-
-  return fallback;
-}
 
 function getSidebarMaxWidth() {
   if (typeof window === 'undefined') {

--- a/apps/desktop/src/shared/lib/error.ts
+++ b/apps/desktop/src/shared/lib/error.ts
@@ -1,0 +1,11 @@
+export function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return fallback;
+}

--- a/apps/desktop/src/shared/lib/ipc/asset.ts
+++ b/apps/desktop/src/shared/lib/ipc/asset.ts
@@ -1,6 +1,7 @@
 import type {
   AssetDetail,
   AssetListSource,
+  AssetRecordCount,
   AssetSummary,
   BatchUpdateAssetFoldersPayload,
   UpdateAssetFoldersPayload,
@@ -10,6 +11,8 @@ import { invokeCamel, invokeRaw } from './core';
 export const assetIpc = {
   list: (source: AssetListSource): Promise<AssetSummary[]> =>
     invokeCamel('list_assets', { source }),
+  listRecordCounts: (source: AssetListSource): Promise<AssetRecordCount[]> =>
+    invokeCamel('list_asset_record_counts', { source }),
   getDetail: (assetId: string): Promise<AssetDetail> =>
     invokeCamel('get_asset_detail', { assetId }),
   updateFolders: (payload: UpdateAssetFoldersPayload) =>

--- a/apps/desktop/src/shared/lib/ipc/core.ts
+++ b/apps/desktop/src/shared/lib/ipc/core.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type {
   AssetDetail,
   AssetListSource,
+  AssetRecordCount,
   AssetSummary,
   BatchUpdateAssetFoldersPayload,
   CaptureContext,
@@ -58,6 +59,7 @@ export type IpcCommandContract = {
   search_virtual_folders: CommandContract<{ query: string }, VirtualFolder[]>;
 
   list_assets: CommandContract<{ source: AssetListSource }, AssetSummary[]>;
+  list_asset_record_counts: CommandContract<{ source: AssetListSource }, AssetRecordCount[]>;
   get_asset_detail: CommandContract<{ assetId: string }, AssetDetail>;
   update_asset_folders: CommandContract<{ payload: UpdateAssetFoldersPayload }, AssetDetail>;
   batch_update_asset_folders: CommandContract<

--- a/apps/desktop/src/shared/types/index.ts
+++ b/apps/desktop/src/shared/types/index.ts
@@ -16,6 +16,7 @@ export type {
 export type {
   AssetDetail,
   AssetListSource,
+  AssetRecordCount,
   AssetSummary,
   BatchUpdateAssetFoldersMode,
   BatchUpdateAssetFoldersPayload,

--- a/apps/desktop/src/shared/types/library.ts
+++ b/apps/desktop/src/shared/types/library.ts
@@ -57,6 +57,11 @@ export interface AssetSummary {
   updatedAt: string;
 }
 
+export interface AssetRecordCount {
+  assetId: string;
+  relatedRecordCount: number;
+}
+
 export interface CroquisRecordSummary {
   id: string;
   title: string;

--- a/apps/desktop/src/shared/ui/icon/iconGlyphs.tsx
+++ b/apps/desktop/src/shared/ui/icon/iconGlyphs.tsx
@@ -33,6 +33,7 @@ export const ICON_NAMES = [
   'setting',
   'skip-back',
   'skip-forward',
+  'sort-desc',
   'star',
   'tree',
   'user',
@@ -99,6 +100,16 @@ const reloadGlyph = (
   <>
     <path d="M3 12a9 9 0 1 0 2.64-6.36" />
     <path d="M3 4v5h5" />
+  </>
+);
+
+const sortDescGlyph = (
+  <>
+    <path d="M7 4v14" />
+    <path d="m4 15 3 3 3-3" />
+    <path d="M14 6h6" />
+    <path d="M14 12h4" />
+    <path d="M14 18h2" />
   </>
 );
 
@@ -250,6 +261,7 @@ export const ICON_GLYPHS = {
       <path d="m5 4 10 8-10 8z" />
     </>
   ),
+  'sort-desc': sortDescGlyph,
   star: (
     <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" />
   ),


### PR DESCRIPTION
Add tag-based record filters and a reference no-record filter backed by asset record counts. Extract shared workspace selection toolbar, header/filter styles, and error message handling.

## Summary of Changes

- List key updates one bullet per line.
- Briefly describe user impact and the technical intent.

## Test Results

> Required commands: `pnpm lint:check`, `pnpm format:write`, `pnpm --filter @grim/desktop build`, `cargo fmt --all` (when Tauri backend changes are included), `cargo clippy --all-targets -- -D warnings` (when Tauri backend changes are included)

- [ ] I ran the required commands and recorded the results below.
- Commands executed and outcome:
  - `Describe each command you ran and summarize the result`

## Translation Impact

- [ ] Translations were added or updated. (`scripts/translations.xlsx`, `apps/desktop/public/locales/*/*.json`, etc.)
- [ ] No translation impact.

## Additional Notes

- Capture any follow-up tasks, documentation updates, or migrations here.
- Reviewers: see the [review checklist](../docs/review-checklist.md).
